### PR TITLE
ci: redesign workflow with PR triggers, focused jobs, and golden build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,88 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  build:
-    name: Build ${{ matrix.target }}
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  doc:
+    name: Documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo doc --workspace --no-deps
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --workspace
+      - run: cargo test --doc --workspace
+
+  golden-build:
+    name: Golden Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+      - run: npm install -g typescript
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+      - run: just golden::build-all
+
+  basics:
+    name: Basics
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy, doc, test, golden-build]
+    steps:
+      - run: exit 0
+
+  release:
+    name: Release ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    needs: [basics]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -28,37 +103,18 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_name: openapi-nexus-macos-aarch64
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Run clippy
-        uses: houseabsolute/actions-rust-cross@v1
-        with:
-          command: clippy
-          target: ${{ matrix.target }}
-          toolchain: 1.90
-          args: "--all-targets -- -D warnings"
-
-      - name: Run tests
-        uses: houseabsolute/actions-rust-cross@v1
-        with:
-          command: test
-          target: ${{ matrix.target }}
-          toolchain: 1.90
-          args: "--workspace"
+      - uses: actions/checkout@v6
 
       - name: Build release binary
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: build
           target: ${{ matrix.target }}
-          toolchain: 1.90
+          toolchain: "1.90"
           args: "--release --bin openapi-nexus"
 
       - name: Prepare artifact
-        shell: bash
         run: |
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             chmod +x target/${{ matrix.target }}/release/openapi-nexus
@@ -66,8 +122,7 @@ jobs:
           mkdir -p artifacts
           cp target/${{ matrix.target }}/release/openapi-nexus artifacts/${{ matrix.artifact_name }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: artifacts/${{ matrix.artifact_name }}

--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -15,7 +15,7 @@
 //! - D-stage 4: delete `api/operation.j2`, all snippets, and `ApiOperationGenerator` ⧖
 //!
 //! Not wired into [`crate::codegen::TypeScriptFetchCodeGenerator`] yet — the
-//! minijinja path in [`crate::generator::api_operation_generator`] is still
+//! minijinja path in `crate::generator::api_operation_generator` is still
 //! authoritative.
 //!
 //! # Import tracking

--- a/crates/openapi-nexus-config/src/cli.rs
+++ b/crates/openapi-nexus-config/src/cli.rs
@@ -40,8 +40,10 @@ pub enum Commands {
         global: GlobalConfig,
 
         /// Override generator-specific config values
-        /// Format: <generator>.<key>=<value>
-        /// Example: --generator-config typescript-fetch.file_naming_convention=PascalCase
+        ///
+        /// Format: `<generator>.<key>=<value>`
+        ///
+        /// Example: `--generator-config typescript-fetch.file_naming_convention=PascalCase`
         #[arg(long = "generator-config", value_name = "GENERATOR.KEY=VALUE")]
         generator_config: Vec<String>,
     },


### PR DESCRIPTION
- Trigger on pull_request (previously push-only to master)
- Add concurrency with cancel-in-progress
- Split into fmt / clippy / doc / test / golden-build jobs
- Use actions-rust-lang/setup-rust-toolchain (respects rust-toolchain.toml, caches via Swatinem automatically)
- Use nextest for faster tests
- Run just golden::build-all to verify generated TS + Go code compiles
- Gate cross-compile release matrix on quality-gate pass, master only
- Bump all actions to latest majors (checkout v6, setup-node v6, setup-go v6, upload-artifact v7, setup-just v4)