### PR TITLE
docs: post-cleanup RFD refresh and core dep prune

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,10 +1055,8 @@ dependencies = [
 name = "openapi-nexus-core"
 version = "0.0.5"
 dependencies = [
- "heck",
  "openapi-nexus-spec",
  "serde",
- "serde_json",
  "serde_plain",
 ]
 

--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -1,4 +1,4 @@
-//! Phase 3 / Slice D: sigil-stitch emit for TypeScript API class files.
+//! Sigil-stitch emit for TypeScript API class files.
 //!
 //! Produces one `FileSpec<TypeScript>` per tag containing:
 //! - request interfaces (one per operation that has parameters)
@@ -6,17 +6,6 @@
 //!   `CodeBlock` so `%T` slots can carry import tracking for every type ref)
 //! - `{Tag}Api` class extending `BaseAPI` with constructor + real Raw +
 //!   convenience methods
-//!
-//! # Status
-//!
-//! - D-stage 1 (scaffold structure) ✅
-//! - D-stage 2 (real bodies + import tracking) ✅ (this stage)
-//! - D-stage 3: cut over `TypeScriptFetchCodeGenerator` to call this path ⧖
-//! - D-stage 4: delete `api/operation.j2`, all snippets, and `ApiOperationGenerator` ⧖
-//!
-//! Not wired into [`crate::codegen::TypeScriptFetchCodeGenerator`] yet — the
-//! minijinja path in `crate::generator::api_operation_generator` is still
-//! authoritative.
 //!
 //! # Import tracking
 //!

--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -265,7 +265,7 @@ fn build_constructor() -> FunSpec<TypeScript> {
 }
 
 // ============================================================================
-// Raw method — full body matching the minijinja snippets
+// Raw method — full request body with parameter handling and response dispatch
 // ============================================================================
 
 fn build_raw_method(op: &IrOperation) -> Result<FunSpec<TypeScript>, String> {

--- a/crates/openapi-nexus-core/Cargo.toml
+++ b/crates/openapi-nexus-core/Cargo.toml
@@ -10,9 +10,7 @@ license.workspace = true
 publish = true
 
 [dependencies]
-heck.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 serde_plain.workspace = true
 
 openapi-nexus-spec.workspace = true

--- a/rfd/0001-architecture-overview.md
+++ b/rfd/0001-architecture-overview.md
@@ -83,16 +83,15 @@ graph TD
   - Handle references and external documents
   - Provide error reporting with source locations
 
-### 2. Transform Stage
+### 2. Lower to IR Stage
 
 - **Input**: utoipa `OpenApi` structure
-- **Output**: Transformed `OpenApi` structure
-- **Component**: `openapi-nexus-transforms`
+- **Output**: Language-agnostic intermediate representation
+- **Component**: `openapi-nexus-ir` (see `lower/v31.rs`)
 - **Responsibilities**:
-  - Apply normalization passes
   - Resolve references and dependencies
-  - Apply semantic analysis
-  - Optimize for code generation
+  - Normalize schemas and classify tagged-enum patterns
+  - Produce an IR ready for language-specific generation
 
 ### 3. Generate AST Stage
 
@@ -120,10 +119,10 @@ graph TD
 
 ### Core Crates
 
-- **`openapi-nexus-core`**: Common types, configuration, and error handling
+- **`openapi-nexus-core`**: Shared traits (`CodeGenerator`, `FileWriter`), common enums (`Language`, `GeneratorType`, `NamingConvention`)
+- **`openapi-nexus-spec`**: OpenAPI specification types (OAS 3.0 / 3.1 / 3.2)
 - **`openapi-nexus-parser`**: OpenAPI specification parsing using utoipa
-- **`openapi-nexus-ir`**: Intermediate representation utilities and helpers
-- **`openapi-nexus-transforms`**: Transformation pass framework and built-in passes
+- **`openapi-nexus-ir`**: Intermediate representation, lowering, tagged-enum pattern classification
 
 ### Language-Specific Crates
 
@@ -271,13 +270,6 @@ Each language generator can define its own configuration options:
 4. Implement type mapping from OpenAPI to language types
 5. Create pretty printer for the language
 6. Register with plugin system
-
-### Adding New Transform Passes
-
-1. Implement `TransformPass` trait
-2. Define pass-specific configuration
-3. Add to built-in passes or create plugin
-4. Register with transform pipeline
 
 ### Custom Type Mappings
 

--- a/rfd/0002-openapi-parsing.md
+++ b/rfd/0002-openapi-parsing.md
@@ -221,39 +221,6 @@ pub struct ParserConfig {
 }
 ```
 
-## Integration with Transform Pipeline
-
-### Parser as Transform Input
-
-The parser produces a `ParseResult` that can be fed into the transform pipeline:
-
-```rust
-// openapi-nexus-transforms/src/pipeline.rs
-impl TransformPipeline {
-    pub fn process_parse_result(&self, result: ParseResult) -> Result<OpenApi, TransformError> {
-        if !result.errors.is_empty() {
-            return Err(TransformError::ParseErrors(result.errors));
-        }
-        
-        let mut openapi = result.openapi;
-        self.transform(&mut openapi)?;
-        Ok(openapi)
-    }
-}
-```
-
-### Error Propagation
-
-Parse errors are propagated through the pipeline:
-
-```rust
-pub enum TransformError {
-    ParseErrors(Vec<ParseError>),
-    TransformFailed { pass: String, error: String },
-    // ... other error types
-}
-```
-
 ## Performance Considerations
 
 ### Lazy Loading

--- a/rfd/0004-transformation-passes.md
+++ b/rfd/0004-transformation-passes.md
@@ -1,5 +1,14 @@
 # RFD 0004: Multi-Level Transformation Passes
 
+> **Status: Superseded.** This RFD described a standalone `openapi-nexus-transforms`
+> crate with `OpenApiTransformPass` / `IrTransformPass` / `AstTransformPass` traits
+> and a `TransformPipeline`. That crate and those traits no longer exist — the
+> transform pipeline was replaced by direct lowering from the parsed OpenAPI spec
+> into an IR (see `openapi-nexus-ir::lower`). Schema analysis, reference resolution,
+> and tagged-enum classification are now IR-internal operations rather than
+> independently-registered passes. This document is retained for historical context
+> only. A future RFD should formalize the current IR-based pipeline.
+
 ## Summary
 
 This RFD defines the multi-level transformation pass architecture that operates on OpenAPI specifications, intermediate representations, and language-specific ASTs. The system enables powerful code generation optimizations and customizations through a composable pipeline of transformation passes.


### PR DESCRIPTION
## Summary

Follow-up cleanup after the workspace slim-down (`264576f`):

- **RFDs:** purge references to the deleted `openapi-nexus-transforms` crate and the dismantled `TransformPipeline`/`TransformPass` traits. RFD 0004 marked as superseded (the whole multi-level pass architecture was replaced by direct IR lowering). RFDs 0008/0010 also carry stale refs — deferred to a future RFD-wide refresh.
- **Core deps:** drop unused `heck` and `serde_json` from `openapi-nexus-core`. Both were residuals from the deleted `data/` module and `tagged_enum_pattern` (now in `openapi-nexus-ir`).
- **Source docs:** the TypeScript generator's "D-stage 3/4 pending" checklist was pointing at a minijinja path that no longer exists — migration to IR + sigil-stitch completed in `77f025d` and `ff17cf2`. Cleaned up the stale status block and one lingering banner comment.

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- [x] `cargo check -p openapi-nexus-core` (verifies dep removal is safe)