### PR TITLE
refactor(typescript-fetch): drop dead scaffolding in generated clients

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/project_files/runtime.ts.txt
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/project_files/runtime.ts.txt
@@ -263,13 +263,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -286,7 +286,7 @@ fn build_raw_method(op: &IrOperation) -> Result<FunSpec<TypeScript>, String> {
     emit_query_params(&mut body, op);
     emit_headers(&mut body, op);
     emit_request_body(&mut body, op);
-    emit_make_request(&mut body, op);
+    emit_make_request(&mut body, op, op.request_body.is_some());
     emit_response_handler(&mut body, op);
 
     fb.body(body.build().map_err(|e| format!("body build: {e}"))?);
@@ -385,7 +385,6 @@ fn emit_headers(cb: &mut sigil_stitch::code_block::CodeBlockBuilder<TypeScript>,
     }
     cb.add("  ...this.configuration?.headers,\n", vec![]);
     cb.add("};\n\n", vec![]);
-    cb.add("// Add header parameters\n", vec![]);
     let names = resolve_param_names(op);
     for p in op
         .parameters
@@ -407,29 +406,29 @@ fn emit_request_body(
     cb: &mut sigil_stitch::code_block::CodeBlockBuilder<TypeScript>,
     op: &IrOperation,
 ) {
-    cb.add("// Prepare request body\n", vec![]);
     if op.request_body.is_some() {
+        cb.add("// Prepare request body\n", vec![]);
         let names = resolve_param_names(op);
         let body_name = resolved_body(&names);
         cb.add(
             &format!("const requestBody = requestParameters['{}'];\n", body_name),
             vec![],
         );
-    } else {
-        cb.add("const requestBody = undefined;\n", vec![]);
     }
 }
 
 fn emit_make_request(
     cb: &mut sigil_stitch::code_block::CodeBlockBuilder<TypeScript>,
     op: &IrOperation,
+    has_body: bool,
 ) {
     let method = op.method.to_uppercase();
+    let body_expr = if has_body { "requestBody" } else { "undefined" };
     cb.add("// Make request\n", vec![]);
     cb.add(
         &format!(
-            "const response = await this.request({{\n    path: urlPath,\n    method: '{}',\n    headers: headerParameters,\n    query: queryParameters,\n    body: requestBody,\n}}, initOverrides);\n\n",
-            method
+            "const response = await this.request({{\n    path: urlPath,\n    method: '{}',\n    headers: headerParameters,\n    query: queryParameters,\n    body: {},\n}}, initOverrides);\n\n",
+            method, body_expr
         ),
         vec![],
     );

--- a/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
@@ -73,7 +73,6 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -123,7 +122,6 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -173,7 +171,6 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
@@ -66,7 +66,6 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -116,16 +115,13 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'DELETE',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
@@ -70,7 +70,6 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['bodyBody'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
@@ -68,19 +68,16 @@ export class UsersApi extends BaseAPI implements UsersApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     if (requestParameters['headerId'] !== undefined) {
       headerParameters['id'] = String(requestParameters['headerId']);
     }
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
@@ -99,7 +99,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -151,7 +150,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -203,7 +201,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -253,7 +250,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -303,7 +299,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
@@ -35,16 +35,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
@@ -273,13 +273,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
@@ -59,7 +59,6 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -106,7 +105,6 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
@@ -102,16 +102,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -150,7 +147,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
@@ -164,7 +164,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -221,7 +220,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -278,16 +276,13 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -330,16 +325,13 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -381,16 +373,13 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -442,16 +431,13 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'POST',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -492,16 +478,13 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'DELETE',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -545,16 +528,13 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'POST',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
@@ -83,16 +83,13 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -130,7 +127,6 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -181,16 +177,13 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -235,16 +228,13 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'DELETE',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
@@ -128,7 +128,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -176,7 +175,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -222,16 +220,13 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -266,16 +261,13 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -313,16 +305,13 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -374,7 +363,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -428,16 +416,13 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'DELETE',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
@@ -50,16 +50,13 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
@@ -36,16 +36,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
@@ -37,16 +37,13 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
@@ -273,13 +273,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
@@ -47,16 +47,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -92,16 +89,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
@@ -273,13 +273,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
@@ -48,16 +48,13 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
@@ -273,13 +273,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
@@ -61,7 +61,6 @@ export class FooApi extends BaseAPI implements FooApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
@@ -273,13 +273,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
@@ -54,16 +54,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses
@@ -101,16 +98,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
@@ -48,7 +48,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
@@ -56,7 +56,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
@@ -285,13 +285,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
@@ -49,7 +49,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
@@ -278,13 +278,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
@@ -60,7 +60,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -107,7 +106,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
@@ -279,13 +279,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
@@ -48,7 +48,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
@@ -277,13 +277,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
@@ -48,7 +48,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
@@ -56,7 +56,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request
@@ -103,16 +102,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
-    // Prepare request body
-    const requestBody = undefined;
     // Make request
     const response = await this.request({
         path: urlPath,
         method: 'GET',
         headers: headerParameters,
         query: queryParameters,
-        body: requestBody,
+        body: undefined,
     }, initOverrides);
 
     // Handle responses

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
@@ -47,7 +47,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
@@ -47,7 +47,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
@@ -47,7 +47,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
@@ -48,7 +48,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
@@ -48,7 +48,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
@@ -47,7 +47,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
@@ -48,7 +48,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       ...this.configuration?.headers,
     };
 
-    // Add header parameters
     // Prepare request body
     const requestBody = requestParameters['body'];
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
@@ -275,13 +275,6 @@ export class RequiredError extends Error {
     }
 }
 
-export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
-};
-
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
 export type Json = any;


### PR DESCRIPTION
## Summary

Three sources of generator noise removed from generated TypeScript clients:

- **`COLLECTION_FORMATS` const**: exported from runtime but never consumed anywhere. Dead export.
- **`// Add header parameters` comment**: orphan section header with no content below it in most cases. The actual header-param emission logic is kept; only the dead comment is dropped.
- **`// Prepare request body` + `const requestBody = undefined;`**: emitted for body-less methods too. Now skipped entirely when the operation has no request body; `body: undefined` is inlined in the request call instead.

Net effect in goldens: 491 deletions across 96 files, no behavior change.

Closes #30.

## Test plan

- [x] `cargo test -p openapi-nexus-typescript-fetch --test golden_tests_typescript_fetch` — 49/49 pass
- [x] `just golden::build-ts` — 46/46 generated projects compile with `tsc --noEmit`
- [x] Spot-checked `petstore/apis/PetApi.ts.golden`: body-less methods now inline `body: undefined,`; body-bearing methods retain `// Prepare request body` + `requestBody` variable