### PR TITLE
chore(deps): bump sigil-stitch to 0.2.2 to fix JSDoc indentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,9 +1536,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-stitch"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95478a48a293082334895f076ef1e436738e5c9a0adfeb36b57cb9e70e137643"
+checksum = "86256bdfed4d3e655dffa5281052778de302c1ee6aa3f2b69c67415149b127af"
 dependencies = [
  "pretty",
  "serde",
@@ -1548,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a96d674a3e63864720ebcdeab00c354bbebf35943056eabd652667d1c4985e"
+checksum = "e17cafd1652989556f7432da04546e590b9cda511e6bff5d3b55d095aeb7765b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ openapi-nexus-rust-reqwest = { version = "0.0.5", path = "crates/generators/open
 openapi-nexus-spec = { version = "0.0.5", path = "crates/openapi-nexus-spec" }
 openapi-nexus-typescript-fetch = { version = "0.0.5", path = "crates/generators/openapi-nexus-typescript-fetch" }
 
-sigil-stitch = "0.2.1"
+sigil-stitch = "0.2.2"
 
 [workspace.metadata.publish]
 order = [

--- a/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
@@ -48,8 +48,8 @@ export interface AdditionalPropertiesApiInterface {
 
 export class AdditionalPropertiesApi extends BaseAPI implements AdditionalPropertiesApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/additional-properties/models/LeafValue.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/models/LeafValue.ts.golden
@@ -9,23 +9,23 @@
  */
 export interface LeafValue {
   /**
- * Additional string attributes (additionalProperties: string).
- */
+   * Additional string attributes (additionalProperties: string).
+   */
   readonly attributes: Record<string, string>;
   /**
- * Free-form additional properties (additionalProperties: true).
- */
+   * Free-form additional properties (additionalProperties: true).
+   */
   readonly extras?: Record<string, unknown>;
   /**
- * Optional label.
- */
+   * Optional label.
+   */
   readonly label?: string | null;
   /**
- * Scores by name (additionalProperties: integer).
- */
+   * Scores by name (additionalProperties: integer).
+   */
   readonly scores?: Record<string, number>;
   /**
- * Numeric value.
- */
+   * Numeric value.
+   */
   readonly value: number;
 }

--- a/tests/golden/typescript/typescript-fetch/additional-properties/models/MiddleLevel.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/models/MiddleLevel.ts.golden
@@ -11,23 +11,23 @@ import type { LeafValue } from './LeafValue';
  */
 export interface MiddleLevel {
   /**
- * Count.
- */
+   * Count.
+   */
   readonly count: number;
   /**
- * Free-form additional properties (additionalProperties: true).
- */
+   * Free-form additional properties (additionalProperties: true).
+   */
   readonly extras?: Record<string, unknown>;
   /**
- * Flags by name (additionalProperties: boolean).
- */
+   * Flags by name (additionalProperties: boolean).
+   */
   readonly flags?: Record<string, boolean>;
   /**
- * Key identifying this middle node.
- */
+   * Key identifying this middle node.
+   */
   readonly key: string;
   /**
- * Nested leaf objects by name (additionalProperties: LeafValue).
- */
+   * Nested leaf objects by name (additionalProperties: LeafValue).
+   */
   readonly nested: Record<string, LeafValue>;
 }

--- a/tests/golden/typescript/typescript-fetch/additional-properties/models/RootLevel.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/models/RootLevel.ts.golden
@@ -11,23 +11,23 @@ import type { MiddleLevel } from './MiddleLevel';
  */
 export interface RootLevel {
   /**
- * Child nodes by name (additionalProperties: MiddleLevel).
- */
+   * Child nodes by name (additionalProperties: MiddleLevel).
+   */
   readonly children: Record<string, MiddleLevel>;
   /**
- * Free-form additional properties (additionalProperties: true).
- */
+   * Free-form additional properties (additionalProperties: true).
+   */
   readonly extras?: Record<string, unknown>;
   /**
- * Root id.
- */
+   * Root id.
+   */
   readonly id: number;
   /**
- * Labels by key (additionalProperties: array of string).
- */
+   * Labels by key (additionalProperties: array of string).
+   */
   readonly labels?: Record<string, readonly string[]>;
   /**
- * Root name.
- */
+   * Root name.
+   */
   readonly name: string;
 }

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/BasicObject.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/BasicObject.ts.golden
@@ -9,15 +9,15 @@
  */
 export interface BasicObject {
   /**
- * Whether the object is currently active
- */
+   * Whether the object is currently active
+   */
   readonly active?: boolean;
   /**
- * Unique identifier for the object
- */
+   * Unique identifier for the object
+   */
   readonly id: number;
   /**
- * Human-readable name of the object
- */
+   * Human-readable name of the object
+   */
   readonly name: string;
 }

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/NestedObject.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/NestedObject.ts.golden
@@ -12,11 +12,11 @@ import type { NestedObjectUser } from './NestedObjectUser';
  */
 export interface NestedObject {
   /**
- * Additional metadata about the object
- */
+   * Additional metadata about the object
+   */
   readonly metadata?: NestedObjectMetadata;
   /**
- * User information object
- */
+   * User information object
+   */
   readonly user?: NestedObjectUser;
 }

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/NestedObjectMetadata.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/NestedObjectMetadata.ts.golden
@@ -9,7 +9,7 @@
  */
 export interface NestedObjectMetadata {
   /**
- * Timestamp when the object was created
- */
+   * Timestamp when the object was created
+   */
   readonly created?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/NestedObjectUser.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/NestedObjectUser.ts.golden
@@ -9,11 +9,11 @@
  */
 export interface NestedObjectUser {
   /**
- * User's unique identifier
- */
+   * User's unique identifier
+   */
   readonly id: number;
   /**
- * User's display name
- */
+   * User's display name
+   */
   readonly name?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/ObjectArrayItems.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/ObjectArrayItems.ts.golden
@@ -6,7 +6,7 @@
  */
 export interface ObjectArrayItems {
   /**
- * Name of the item in the array
- */
+   * Name of the item in the array
+   */
   readonly name?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/ObjectWithDefaults.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/models/ObjectWithDefaults.ts.golden
@@ -9,15 +9,15 @@
  */
 export interface ObjectWithDefaults {
   /**
- * Whether the person is currently active
- */
+   * Whether the person is currently active
+   */
   readonly active?: boolean;
   /**
- * Age in years
- */
+   * Age in years
+   */
   readonly age?: number;
   /**
- * Full name of the person
- */
+   * Full name of the person
+   */
   readonly name?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
@@ -17,8 +17,8 @@ export interface ApiCreateTestResourceRequest {
 
 export interface ApiDeleteTestResourceRequest {
   /**
- * Unique identifier of the test resource
- */
+   * Unique identifier of the test resource
+   */
   resourceId: string;
 }
 
@@ -40,8 +40,8 @@ export interface TestResourceApiInterface {
 
 export class TestResourceApi extends BaseAPI implements TestResourceApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
@@ -11,12 +11,12 @@ import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse
 
 export interface ApiCreateItemWithBodyConflictRequest {
   /**
- * Item ID in path
- */
+   * Item ID in path
+   */
   itemId: string;
   /**
- * Body parameter in query (conflicts with request body)
- */
+   * Body parameter in query (conflicts with request body)
+   */
   queryBody?: string;
   bodyBody: CreateItemWithBodyConflictRequest;
 }
@@ -33,8 +33,8 @@ export interface ItemsApiInterface {
 
 export class ItemsApi extends BaseAPI implements ItemsApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
@@ -10,16 +10,16 @@ import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse
 
 export interface ApiGetUserByIdDuplicateRequest {
   /**
- * User ID in path
- */
+   * User ID in path
+   */
   pathId: number;
   /**
- * User ID in query (filter)
- */
+   * User ID in query (filter)
+   */
   queryId?: number;
   /**
- * User ID in header
- */
+   * User ID in header
+   */
   headerId?: string;
 }
 
@@ -37,8 +37,8 @@ export interface UsersApiInterface {
 
 export class UsersApi extends BaseAPI implements UsersApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
@@ -72,8 +72,8 @@ export interface EnumReprApiInterface {
 
 export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/enum-repr/models/VariantA.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/models/VariantA.ts.golden
@@ -9,11 +9,11 @@
  */
 export interface VariantA {
   /**
- * First field of variant A
- */
+   * First field of variant A
+   */
   readonly field1: string;
   /**
- * Second field of variant A
- */
+   * Second field of variant A
+   */
   readonly field2: number;
 }

--- a/tests/golden/typescript/typescript-fetch/enum-repr/models/VariantB.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/models/VariantB.ts.golden
@@ -9,11 +9,11 @@
  */
 export interface VariantB {
   /**
- * First field of variant B
- */
+   * First field of variant B
+   */
   readonly field3: boolean;
   /**
- * Second field of variant B
- */
+   * Second field of variant B
+   */
   readonly field4: number;
 }

--- a/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/models/BarService.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/models/BarService.ts.golden
@@ -8,8 +8,8 @@ import type { BarStatus } from './BarStatus';
 
 export interface BarService {
   /**
- * DIY name ASAP
- */
+   * DIY name ASAP
+   */
   readonly diYnameAsap?: string;
   readonly status: BarStatus;
 }

--- a/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
@@ -16,8 +16,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
@@ -34,8 +34,8 @@ export interface TestApiApiInterface {
 
 export class TestApiApi extends BaseAPI implements TestApiApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
@@ -42,8 +42,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/models/NamingConventionTest.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/models/NamingConventionTest.ts.golden
@@ -10,50 +10,50 @@ import type { NamingConventionTestPascalCaseObject } from './NamingConventionTes
 
 export interface NamingConventionTest {
   /**
- * A field in PascalCase
- */
+   * A field in PascalCase
+   */
   readonly pascalCaseField?: string;
   readonly pascalCaseObject?: NamingConventionTestPascalCaseObject;
   /**
- * A number in SCREAMING_SNAKE_CASE
- */
+   * A number in SCREAMING_SNAKE_CASE
+   */
   readonly screamingNumber?: number;
   /**
- * A field in SCREAMING_SNAKE_CASE
- */
+   * A field in SCREAMING_SNAKE_CASE
+   */
   readonly screamingSnakeCase?: string;
   /**
- * A field in camelCase
- */
+   * A field in camelCase
+   */
   readonly camelCaseField: string;
   /**
- * A number in camelCase
- */
+   * A number in camelCase
+   */
   readonly camelCaseNumber?: number;
   /**
- * A single letter abbreviation
- */
+   * A single letter abbreviation
+   */
   readonly id?: number;
   readonly itemsArray?: readonly NamingConventionTestItemsArrayItem[];
   /**
- * An array field in kebab-case
- */
+   * An array field in kebab-case
+   */
   readonly kebabCaseArray?: readonly string[];
   /**
- * A field in kebab-case
- */
+   * A field in kebab-case
+   */
   readonly kebabCaseField?: string;
   readonly nestedObject?: NamingConventionTestNestedObject;
   /**
- * A single word field
- */
+   * A single word field
+   */
   readonly singleword: string;
   /**
- * A field in snake_case
- */
+   * A field in snake_case
+   */
   readonly snakeCaseField: string;
   /**
- * A number field in snake_case
- */
+   * A number field in snake_case
+   */
   readonly snakeCaseNumber?: number;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
@@ -19,55 +19,55 @@ export interface ApiAddPetRequest {
 
 export interface ApiFindPetsByStatusRequest {
   /**
- * Status values that need to be considered for filter
- */
+   * Status values that need to be considered for filter
+   */
   status: string;
 }
 
 export interface ApiFindPetsByTagsRequest {
   /**
- * Tags to filter by
- */
+   * Tags to filter by
+   */
   tags: string[];
 }
 
 export interface ApiGetPetByIdRequest {
   /**
- * ID of pet to return
- */
+   * ID of pet to return
+   */
   petId: number;
 }
 
 export interface ApiUpdatePetWithFormRequest {
   /**
- * ID of pet that needs to be updated
- */
+   * ID of pet that needs to be updated
+   */
   petId: number;
   /**
- * Name of pet that needs to be updated
- */
+   * Name of pet that needs to be updated
+   */
   name?: string;
   /**
- * Status of pet that needs to be updated
- */
+   * Status of pet that needs to be updated
+   */
   status?: string;
 }
 
 export interface ApiDeletePetRequest {
   /**
- * Pet id to delete
- */
+   * Pet id to delete
+   */
   petId: number;
 }
 
 export interface ApiUploadFileRequest {
   /**
- * ID of pet to update
- */
+   * ID of pet to update
+   */
   petId: number;
   /**
- * Additional Metadata
- */
+   * Additional Metadata
+   */
   additionalMetadata?: string;
 }
 
@@ -138,8 +138,8 @@ export interface PetApiInterface {
 
 export class PetApi extends BaseAPI implements PetApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
@@ -14,15 +14,15 @@ export interface ApiPlaceOrderRequest {
 
 export interface ApiGetOrderByIdRequest {
   /**
- * ID of order that needs to be fetched
- */
+   * ID of order that needs to be fetched
+   */
   orderId: number;
 }
 
 export interface ApiDeleteOrderRequest {
   /**
- * ID of the order that needs to be deleted
- */
+   * ID of the order that needs to be deleted
+   */
   orderId: number;
 }
 
@@ -63,8 +63,8 @@ export interface StoreApiInterface {
 
 export class StoreApi extends BaseAPI implements StoreApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
@@ -18,34 +18,34 @@ export interface ApiCreateUsersWithListInputRequest {
 
 export interface ApiLoginUserRequest {
   /**
- * The user name for login
- */
+   * The user name for login
+   */
   username?: string;
   /**
- * The password for login in clear text
- */
+   * The password for login in clear text
+   */
   password?: string;
 }
 
 export interface ApiGetUserByNameRequest {
   /**
- * The name that needs to be fetched. Use user1 for testing
- */
+   * The name that needs to be fetched. Use user1 for testing
+   */
   username: string;
 }
 
 export interface ApiUpdateUserRequest {
   /**
- * name that need to be deleted
- */
+   * name that need to be deleted
+   */
   username: string;
   body: User;
 }
 
 export interface ApiDeleteUserRequest {
   /**
- * The name that needs to be deleted
- */
+   * The name that needs to be deleted
+   */
   username: string;
 }
 
@@ -103,8 +103,8 @@ export interface UserApiInterface {
 
 export class UserApi extends BaseAPI implements UserApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/Category.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/Category.ts.golden
@@ -9,11 +9,11 @@
  */
 export interface Category {
   /**
- * Category ID
- */
+   * Category ID
+   */
   readonly id?: number | null;
   /**
- * Category name
- */
+   * Category name
+   */
   readonly name?: string | null;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/ErrorResponse.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/ErrorResponse.ts.golden
@@ -9,11 +9,11 @@
  */
 export interface ErrorResponse {
   /**
- * Error code
- */
+   * Error code
+   */
   readonly code: number;
   /**
- * Error message
- */
+   * Error message
+   */
   readonly message: string;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/Order.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/Order.ts.golden
@@ -11,24 +11,24 @@ import type { OrderStatus } from './OrderStatus';
  */
 export interface Order {
   /**
- * Complete flag
- */
+   * Complete flag
+   */
   readonly complete?: boolean | null;
   /**
- * Order ID
- */
+   * Order ID
+   */
   readonly id?: number | null;
   /**
- * Pet ID
- */
+   * Pet ID
+   */
   readonly petId?: number | null;
   /**
- * Quantity
- */
+   * Quantity
+   */
   readonly quantity?: number | null;
   /**
- * Ship date
- */
+   * Ship date
+   */
   readonly shipDate?: string | null;
   readonly status?: OrderStatus | null;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/Pet.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/Pet.ts.golden
@@ -14,20 +14,20 @@ import type { Tag } from './Tag';
 export interface Pet {
   readonly category?: Category | null;
   /**
- * Pet ID
- */
+   * Pet ID
+   */
   readonly id?: number | null;
   /**
- * Pet name
- */
+   * Pet name
+   */
   readonly name: string;
   /**
- * Photo URLs
- */
+   * Photo URLs
+   */
   readonly photoUrls: readonly string[];
   readonly status?: PetStatus | null;
   /**
- * Pet tags
- */
+   * Pet tags
+   */
   readonly tags?: readonly Tag[] | null;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/Tag.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/Tag.ts.golden
@@ -9,11 +9,11 @@
  */
 export interface Tag {
   /**
- * Tag ID
- */
+   * Tag ID
+   */
   readonly id?: number | null;
   /**
- * Tag name
- */
+   * Tag name
+   */
   readonly name?: string | null;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/UploadResponse.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/UploadResponse.ts.golden
@@ -9,15 +9,15 @@
  */
 export interface UploadResponse {
   /**
- * Response code
- */
+   * Response code
+   */
   readonly code?: number | null;
   /**
- * Response message
- */
+   * Response message
+   */
   readonly message?: string | null;
   /**
- * Response type
- */
+   * Response type
+   */
   readonly type_?: string | null;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/User.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/User.ts.golden
@@ -9,35 +9,35 @@
  */
 export interface User {
   /**
- * Email
- */
+   * Email
+   */
   readonly email?: string | null;
   /**
- * First name
- */
+   * First name
+   */
   readonly firstName?: string | null;
   /**
- * User ID
- */
+   * User ID
+   */
   readonly id?: number | null;
   /**
- * Last name
- */
+   * Last name
+   */
   readonly lastName?: string | null;
   /**
- * Password
- */
+   * Password
+   */
   readonly password?: string | null;
   /**
- * Phone
- */
+   * Phone
+   */
   readonly phone?: string | null;
   /**
- * User status
- */
+   * User status
+   */
   readonly userStatus?: number | null;
   /**
- * Username
- */
+   * Username
+   */
   readonly username?: string | null;
 }

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
@@ -11,8 +11,8 @@ import { BaseAPI, DefaultConfig, JSONApiResponse, VoidApiResponse } from '../run
 
 export interface ApiGetItemsRequest {
   /**
- * Optional. The status to filter items by.
- */
+   * Optional. The status to filter items by.
+   */
   status?: FooStatus;
 }
 
@@ -28,8 +28,8 @@ export interface ItemsApiInterface {
 
 export class ItemsApi extends BaseAPI implements ItemsApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
@@ -17,8 +17,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
@@ -18,8 +18,8 @@ export interface WidgetApiInterface {
 
 export class WidgetApi extends BaseAPI implements WidgetApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
@@ -26,8 +26,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
@@ -25,8 +25,8 @@ export interface WidgetApiInterface {
 
 export class WidgetApi extends BaseAPI implements WidgetApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
@@ -27,8 +27,8 @@ export interface FooApiInterface {
 
 export class FooApi extends BaseAPI implements FooApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
@@ -12,8 +12,8 @@ import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runti
 
 export interface ApiGetUserByIdRequest {
   /**
- * User ID
- */
+   * User ID
+   */
   id: number;
 }
 
@@ -35,8 +35,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/server-object/models/User.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/models/User.ts.golden
@@ -6,23 +6,23 @@
  */
 export interface User {
   /**
- * When the user was created
- */
+   * When the user was created
+   */
   readonly createdAt?: string;
   /**
- * User's email address
- */
+   * User's email address
+   */
   readonly email: string;
   /**
- * Unique identifier for the user
- */
+   * Unique identifier for the user
+   */
   readonly id: number;
   /**
- * User's full name
- */
+   * User's full name
+   */
   readonly name: string;
   /**
- * When the user was last updated
- */
+   * When the user was last updated
+   */
   readonly updatedAt?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
@@ -22,8 +22,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
@@ -31,8 +31,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/models/EventMember2.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/models/EventMember2.ts.golden
@@ -19,7 +19,7 @@
 export interface EventMember2 {
   readonly kind: 'EVENT_CREATED';
   /**
- * When the event was created
- */
+   * When the event was created
+   */
   readonly timestamp: string;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/models/EventMember3.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/models/EventMember3.ts.golden
@@ -19,7 +19,7 @@
 export interface EventMember3 {
   readonly kind: 'EVENT_UPDATED';
   /**
- * The new value after update
- */
+   * The new value after update
+   */
   readonly newValue: string;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
@@ -24,8 +24,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
@@ -35,8 +35,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
@@ -23,8 +23,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
@@ -22,8 +22,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
@@ -31,8 +31,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/models/Bar.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/models/Bar.ts.golden
@@ -9,19 +9,19 @@
  */
 export interface Bar {
   /**
- * First field
- */
+   * First field
+   */
   readonly field1?: string;
   /**
- * Second field
- */
+   * Second field
+   */
   readonly field2?: string;
   /**
- * Third field
- */
+   * Third field
+   */
   readonly field3?: string;
   /**
- * Fourth field
- */
+   * Fourth field
+   */
   readonly field4?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/models/BazAllOf2.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/models/BazAllOf2.ts.golden
@@ -8,7 +8,7 @@ import type { Bar } from './Bar';
 
 export interface BazAllOf2 {
   /**
- * Metadata (nullable)
- */
+   * Metadata (nullable)
+   */
   readonly metaData?: Bar | null;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/models/Foo.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/models/Foo.ts.golden
@@ -9,23 +9,23 @@
  */
 export interface Foo {
   /**
- * First count
- */
+   * First count
+   */
   readonly count1: number;
   /**
- * Second count
- */
+   * Second count
+   */
   readonly count2: number;
   /**
- * Creation timestamp
- */
+   * Creation timestamp
+   */
   readonly createdAt: string;
   /**
- * Unique identifier
- */
+   * Unique identifier
+   */
   readonly id: string;
   /**
- * Status
- */
+   * Status
+   */
   readonly status: 'active' | 'inactive' | 'pending';
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
@@ -22,8 +22,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
@@ -22,8 +22,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
@@ -22,8 +22,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
@@ -22,8 +22,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
@@ -22,8 +22,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember1.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember1.ts.golden
@@ -11,7 +11,7 @@ import type { FooMember1Bar } from './FooMember1Bar';
  */
 export interface FooMember1 {
   /**
- * Nested object in first type
- */
+   * Nested object in first type
+   */
   readonly bar: FooMember1Bar;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember1Bar.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember1Bar.ts.golden
@@ -9,11 +9,11 @@
  */
 export interface FooMember1Bar {
   /**
- * First property
- */
+   * First property
+   */
   readonly baz: string;
   /**
- * Second property
- */
+   * Second property
+   */
   readonly qux: string;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember2.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember2.ts.golden
@@ -11,7 +11,7 @@ import type { FooMember2Quux } from './FooMember2Quux';
  */
 export interface FooMember2 {
   /**
- * Nested object in second type
- */
+   * Nested object in second type
+   */
   readonly quux: FooMember2Quux;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember2Quux.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember2Quux.ts.golden
@@ -9,7 +9,7 @@
  */
 export interface FooMember2Quux {
   /**
- * Property in second type
- */
+   * Property in second type
+   */
   readonly corge: string;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember3.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember3.ts.golden
@@ -11,7 +11,7 @@ import type { FooMember3Grault } from './FooMember3Grault';
  */
 export interface FooMember3 {
   /**
- * Nested object in third type
- */
+   * Nested object in third type
+   */
   readonly grault: FooMember3Grault;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember3Grault.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/models/FooMember3Grault.ts.golden
@@ -9,7 +9,7 @@
  */
 export interface FooMember3Grault {
   /**
- * Property in third type
- */
+   * Property in third type
+   */
   readonly garply: string;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
@@ -22,8 +22,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
@@ -22,8 +22,8 @@ export interface DefaultApiInterface {
 
 export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   /**
- * Initialize the API client
- */
+   * Initialize the API client
+   */
   constructor(configuration?: Configuration) {
     super(configuration ?? DefaultConfig);
   }


### PR DESCRIPTION
## Summary

sigil-stitch 0.2.2 fixes a multi-line literal indentation bug in `CodeRenderer::render_direct`: when a `%L` literal contained embedded newlines, subsequent lines were emitted flush-left instead of re-indenting to match the surrounding block.

This hit every `.doc(...)` call site inside an indented context in our TypeScript codegen, producing JSDoc like:

```ts
export interface ApiFindPetsByStatusRequest {
  /**
 * Status values that need to be considered for filter
 */
  status: string;
}
```

With 0.2.2 the doc bodies align with the opening `/**`:

```ts
export interface ApiFindPetsByStatusRequest {
  /**
   * Status values that need to be considered for filter
   */
  status: string;
}
```

No openapi-nexus source changes. The fix is entirely upstream — this PR bumps the dep and regenerates the golden files.

Closes #27.

## Test plan

- [x] `cargo test` — all tests pass
- [x] `UPDATE_GOLDEN=1 cargo test -p openapi-nexus-typescript-fetch --test golden_tests_typescript_fetch` — 49/49
- [x] `just golden::build-ts` — 46/46 generated projects compile with `tsc --noEmit`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Spot-checked `petstore/apis/PetApi.ts.golden`: JSDoc body lines now aligned with their opening `/**`