### PR TITLE
fix(typescript-fetch): strict equality in required-param guards

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -327,7 +327,7 @@ fn emit_required_param_checks(
     for pname in all_required {
         cb.add(
             &format!(
-                "if (requestParameters['{0}'] == null) {{\n  throw new %T(\n    '{0}',\n    'Required parameter \"{0}\" was null or undefined when calling {1}().'\n  );\n}}\n",
+                "if (requestParameters['{0}'] === undefined || requestParameters['{0}'] === null) {{\n  throw new %T(\n    '{0}',\n    'Required parameter \"{0}\" was null or undefined when calling {1}().'\n  );\n}}\n",
                 pname, method_name
             ),
             vec![Arg::TypeName(rt_value("RequiredError"))],

--- a/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
@@ -57,7 +57,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   async postLeafRaw(requestParameters: ApiPostLeafRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<LeafValue> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postLeafRaw().'
@@ -106,7 +106,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   async postMiddleRaw(requestParameters: ApiPostMiddleRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<MiddleLevel> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postMiddleRaw().'
@@ -155,7 +155,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   async postRootRaw(requestParameters: ApiPostRootRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<RootLevel> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postRootRaw().'

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
@@ -50,7 +50,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<CreateTestResourceResponse>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createTestResourceRaw().'
@@ -99,7 +99,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
       | JSONApiResponse<HttpErrorResponse>
       & { status: number } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['resourceId'] == null) {
+    if (requestParameters['resourceId'] === undefined || requestParameters['resourceId'] === null) {
       throw new RequiredError(
         'resourceId',
         'Required parameter "resourceId" was null or undefined when calling deleteTestResourceRaw().'

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
@@ -44,13 +44,13 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['itemId'] == null) {
+    if (requestParameters['itemId'] === undefined || requestParameters['itemId'] === null) {
       throw new RequiredError(
         'itemId',
         'Required parameter "itemId" was null or undefined when calling createItemWithBodyConflictRaw().'
       );
     }
-    if (requestParameters['bodyBody'] == null) {
+    if (requestParameters['bodyBody'] === undefined || requestParameters['bodyBody'] === null) {
       throw new RequiredError(
         'bodyBody',
         'Required parameter "bodyBody" was null or undefined when calling createItemWithBodyConflictRaw().'

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
@@ -49,7 +49,7 @@ export class UsersApi extends BaseAPI implements UsersApiInterface {
       & { status: 400 } | VoidApiResponse
       & { status: 404 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['pathId'] == null) {
+    if (requestParameters['pathId'] === undefined || requestParameters['pathId'] === null) {
       throw new RequiredError(
         'pathId',
         'Required parameter "pathId" was null or undefined when calling getUserByIdDuplicateRaw().'

--- a/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
@@ -83,7 +83,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleAdjacentlyTaggedRaw().'
@@ -134,7 +134,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleExternallyTaggedRaw().'
@@ -185,7 +185,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleInternallyTaggedRaw().'
@@ -234,7 +234,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   async handleMixedRaw(requestParameters: ApiHandleMixedRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<MixedEnum> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleMixedRaw().'
@@ -283,7 +283,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   async handleUntaggedRaw(requestParameters: ApiHandleUntaggedRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<UntaggedEnum> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleUntaggedRaw().'

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
@@ -43,7 +43,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
   async createTypeARaw(requestParameters: ApiCreateTypeARequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<ResourceTypeA> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createTypeARaw().'
@@ -89,7 +89,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
   async createTypeBRaw(requestParameters: ApiCreateTypeBRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<ResourceTypeB> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createTypeBRaw().'

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
@@ -51,7 +51,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async getWithQueryParamsRaw(requestParameters: ApiGetWithQueryParamsRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 }
       | VoidApiResponse & { status: number }> {
-    if (requestParameters['snakeCaseParam'] == null) {
+    if (requestParameters['snakeCaseParam'] === undefined || requestParameters['snakeCaseParam'] === null) {
       throw new RequiredError(
         'snakeCaseParam',
         'Required parameter "snakeCaseParam" was null or undefined when calling getWithQueryParamsRaw().'
@@ -131,7 +131,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<NamingConventionTest>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testNamingConventionsRaw().'

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
@@ -148,7 +148,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<Pet> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
       & { status: 422 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling updatePetRaw().'
@@ -204,7 +204,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<Pet> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 422 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling addPetRaw().'
@@ -258,7 +258,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['status'] == null) {
+    if (requestParameters['status'] === undefined || requestParameters['status'] === null) {
       throw new RequiredError(
         'status',
         'Required parameter "status" was null or undefined when calling findPetsByStatusRaw().'
@@ -307,7 +307,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async findPetsByTagsRaw(requestParameters: ApiFindPetsByTagsRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Pet[]> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['tags'] == null) {
+    if (requestParameters['tags'] === undefined || requestParameters['tags'] === null) {
       throw new RequiredError(
         'tags',
         'Required parameter "tags" was null or undefined when calling findPetsByTagsRaw().'
@@ -357,7 +357,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<Pet> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['petId'] == null) {
+    if (requestParameters['petId'] === undefined || requestParameters['petId'] === null) {
       throw new RequiredError(
         'petId',
         'Required parameter "petId" was null or undefined when calling getPetByIdRaw().'
@@ -409,7 +409,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['petId'] == null) {
+    if (requestParameters['petId'] === undefined || requestParameters['petId'] === null) {
       throw new RequiredError(
         'petId',
         'Required parameter "petId" was null or undefined when calling updatePetWithFormRaw().'
@@ -462,7 +462,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async deletePetRaw(requestParameters: ApiDeletePetRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: number }> {
-    if (requestParameters['petId'] == null) {
+    if (requestParameters['petId'] === undefined || requestParameters['petId'] === null) {
       throw new RequiredError(
         'petId',
         'Required parameter "petId" was null or undefined when calling deletePetRaw().'
@@ -509,7 +509,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async uploadFileRaw(requestParameters: ApiUploadFileRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<UploadResponse> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['petId'] == null) {
+    if (requestParameters['petId'] === undefined || requestParameters['petId'] === null) {
       throw new RequiredError(
         'petId',
         'Required parameter "petId" was null or undefined when calling uploadFileRaw().'

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
@@ -111,7 +111,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   async placeOrderRaw(requestParameters: ApiPlaceOrderRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Order> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling placeOrderRaw().'
@@ -161,7 +161,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<Order> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['orderId'] == null) {
+    if (requestParameters['orderId'] === undefined || requestParameters['orderId'] === null) {
       throw new RequiredError(
         'orderId',
         'Required parameter "orderId" was null or undefined when calling getOrderByIdRaw().'
@@ -212,7 +212,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['orderId'] == null) {
+    if (requestParameters['orderId'] === undefined || requestParameters['orderId'] === null) {
       throw new RequiredError(
         'orderId',
         'Required parameter "orderId" was null or undefined when calling deleteOrderRaw().'

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
@@ -112,7 +112,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   async createUserRaw(requestParameters: ApiCreateUserRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<User> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createUserRaw().'
@@ -159,7 +159,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<User>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createUsersWithListInputRaw().'
@@ -289,7 +289,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<User> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['username'] == null) {
+    if (requestParameters['username'] === undefined || requestParameters['username'] === null) {
       throw new RequiredError(
         'username',
         'Required parameter "username" was null or undefined when calling getUserByNameRaw().'
@@ -340,13 +340,13 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['username'] == null) {
+    if (requestParameters['username'] === undefined || requestParameters['username'] === null) {
       throw new RequiredError(
         'username',
         'Required parameter "username" was null or undefined when calling updateUserRaw().'
       );
     }
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling updateUserRaw().'
@@ -400,7 +400,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['username'] == null) {
+    if (requestParameters['username'] === undefined || requestParameters['username'] === null) {
       throw new RequiredError(
         'username',
         'Required parameter "username" was null or undefined when calling deleteUserRaw().'

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
@@ -67,7 +67,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postFormRaw(requestParameters: ApiPostFormRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postFormRaw().'
@@ -113,7 +113,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postJsonRaw(requestParameters: ApiPostJsonRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postJsonRaw().'
@@ -159,7 +159,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postJsonOrXmlRaw(requestParameters: ApiPostJsonOrXmlRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postJsonOrXmlRaw().'
@@ -205,7 +205,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postTextRaw(requestParameters: ApiPostTextRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postTextRaw().'
@@ -251,7 +251,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postXmlRaw(requestParameters: ApiPostXmlRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postXmlRaw().'

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
@@ -38,13 +38,13 @@ export class FooApi extends BaseAPI implements FooApiInterface {
       | JSONApiResponse<ErrorResponse> & { status: 400 }
       | JSONApiResponse<ErrorResponse> & { status: 500 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['fooId'] == null) {
+    if (requestParameters['fooId'] === undefined || requestParameters['fooId'] === null) {
       throw new RequiredError(
         'fooId',
         'Required parameter "fooId" was null or undefined when calling updateFooBarRaw().'
       );
     }
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling updateFooBarRaw().'

--- a/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
@@ -82,7 +82,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<GetUserByIdResponse200> & { status: 200 }
       | JSONApiResponse<GetUserByIdResponse404> & { status: 404 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['id'] == null) {
+    if (requestParameters['id'] === undefined || requestParameters['id'] === null) {
       throw new RequiredError(
         'id',
         'Required parameter "id" was null or undefined when calling getUserByIdRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testComplexUnionRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
@@ -40,7 +40,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createEventRaw(requestParameters: ApiCreateEventRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Event> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createEventRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
@@ -33,7 +33,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createResourceRaw(requestParameters: ApiCreateResourceRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Resource> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createResourceRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
@@ -44,7 +44,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createContainerRaw(requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<ContainerKind> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createContainerRaw().'
@@ -90,7 +90,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createVolumeRaw(requestParameters: ApiCreateVolumeRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<VolumeKind> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createVolumeRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createContainerRaw(requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<ContainerImage> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createContainerRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testIntersectionRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
@@ -40,7 +40,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createTestRaw(requestParameters: ApiCreateTestRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Baz> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createTestRaw().'
@@ -86,7 +86,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async getTestRaw(requestParameters: ApiGetTestRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Baz> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['id'] == null) {
+    if (requestParameters['id'] === undefined || requestParameters['id'] === null) {
       throw new RequiredError(
         'id',
         'Required parameter "id" was null or undefined when calling getTestRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
@@ -31,7 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testNestedUnionRaw(requestParameters: ApiTestNestedUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testNestedUnionRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
@@ -31,7 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testSimpleAliasRaw(requestParameters: ApiTestSimpleAliasRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testSimpleAliasRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
@@ -31,7 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testMixedUnionRaw(requestParameters: ApiTestMixedUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testMixedUnionRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Config>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testUnionWithAnyRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testUnionWithInlineObjectsRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
@@ -31,7 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testUnionRaw(requestParameters: ApiTestUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testUnionRaw().'

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] == null) {
+    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testUnionPrimitivesRaw().'


### PR DESCRIPTION
## Summary
- Replace `requestParameters['x'] == null` with `=== undefined || === null` in generated required-param guards
- Generated code now passes `eslint --rule 'eqeqeq:error'`
- Goldens regenerated (28 files)

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `UPDATE_GOLDEN=1 cargo test -p openapi-nexus-typescript-fetch --test golden_tests_typescript_fetch` — 50/50
- [x] `just golden::build-ts` — 47/47 compile

Closes #29