### PR TITLE
fix(typescript-fetch): drop duplicate config headers merge in API methods

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -395,7 +395,6 @@ fn emit_headers(cb: &mut sigil_stitch::code_block::CodeBlockBuilder<TypeScript>,
     {
         cb.add(&format!("  'Content-Type': '{}',\n", media_type), vec![]);
     }
-    cb.add("  ...this.configuration?.headers,\n", vec![]);
     cb.add("};\n\n", vec![]);
     let names = resolve_param_names(op);
     for p in op

--- a/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
@@ -70,7 +70,6 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -119,7 +118,6 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -168,7 +166,6 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
@@ -63,7 +63,6 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -112,7 +111,6 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
@@ -67,7 +67,6 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
@@ -65,7 +65,6 @@ export class UsersApi extends BaseAPI implements UsersApiInterface {
     }
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     if (requestParameters['headerId'] !== undefined) {

--- a/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
@@ -96,7 +96,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -147,7 +146,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -198,7 +196,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -247,7 +244,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -296,7 +292,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
@@ -32,7 +32,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
@@ -56,7 +56,6 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -102,7 +101,6 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
@@ -99,7 +99,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     }
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -144,7 +143,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
@@ -161,7 +161,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -217,7 +216,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -273,7 +271,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     }
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -322,7 +319,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     }
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -370,7 +366,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -428,7 +423,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     }
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -475,7 +469,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -525,7 +518,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     }
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
@@ -80,7 +80,6 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -124,7 +123,6 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -174,7 +172,6 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -225,7 +222,6 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
@@ -125,7 +125,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -172,7 +171,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -217,7 +215,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     }
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -258,7 +255,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -302,7 +298,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -360,7 +355,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -413,7 +407,6 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
@@ -47,7 +47,6 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
     }
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
@@ -33,7 +33,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
@@ -80,7 +80,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/x-www-form-urlencoded',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -126,7 +125,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -172,7 +170,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -218,7 +215,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'text/plain',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -264,7 +260,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/xml',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
@@ -34,7 +34,6 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
@@ -44,7 +44,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -86,7 +85,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
@@ -45,7 +45,6 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
@@ -58,7 +58,6 @@ export class FooApi extends BaseAPI implements FooApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
@@ -51,7 +51,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request
@@ -95,7 +94,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
@@ -45,7 +45,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
@@ -53,7 +53,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
@@ -46,7 +46,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
@@ -57,7 +57,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -103,7 +102,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
@@ -45,7 +45,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
@@ -45,7 +45,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
@@ -53,7 +53,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body
@@ -99,7 +98,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const queryParameters: any = {};
     // Build headers
     const headerParameters: Record<string, string> = {
-      ...this.configuration?.headers,
     };
 
     // Make request

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
@@ -44,7 +44,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
@@ -44,7 +44,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
@@ -44,7 +44,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
@@ -45,7 +45,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
@@ -45,7 +45,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
@@ -44,7 +44,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
@@ -45,7 +45,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...this.configuration?.headers,
     };
 
     // Prepare request body


### PR DESCRIPTION
## Summary
- Generated API methods no longer spread `this.configuration?.headers` into their local `headerParameters`
- `BaseAPI.createFetchParams` already merges config headers into the final request, so the method-level spread was redundant
- Per-op headers (Content-Type, declared header params) still emitted and take precedence via `Object.assign(config.headers, context.headers)` in `createFetchParams`
- Goldens regenerated (50 files, 83 deletions)

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `UPDATE_GOLDEN=1 cargo test -p openapi-nexus-typescript-fetch --test golden_tests_typescript_fetch` — 50/50
- [x] `just golden::build-ts` — 47/47 compile

Closes #40