### PR TITLE
fix(typescript-fetch): use const urlPath when no path params present

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -340,7 +340,12 @@ fn emit_url_path(
     op: &IrOperation,
 ) {
     cb.add("// Build path with path parameters\n", vec![]);
-    cb.add(&format!("let urlPath = `{}`;\n", op.path), vec![]);
+    let has_path_params = op
+        .parameters
+        .iter()
+        .any(|p| matches!(p.location, IrParameterLocation::Path));
+    let binding = if has_path_params { "let" } else { "const" };
+    cb.add(&format!("{} urlPath = `{}`;\n", binding, op.path), vec![]);
 
     let names = resolve_param_names(op);
     for p in op

--- a/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
@@ -64,7 +64,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
       );
     }
     // Build path with path parameters
-    let urlPath = `/leaf`;
+    const urlPath = `/leaf`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -112,7 +112,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
       );
     }
     // Build path with path parameters
-    let urlPath = `/middle`;
+    const urlPath = `/middle`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -160,7 +160,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
       );
     }
     // Build path with path parameters
-    let urlPath = `/root`;
+    const urlPath = `/root`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
@@ -57,7 +57,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
       );
     }
     // Build path with path parameters
-    let urlPath = `/v1/api/test-resource`;
+    const urlPath = `/v1/api/test-resource`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
@@ -90,7 +90,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/adjacently-tagged`;
+    const urlPath = `/adjacently-tagged`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -140,7 +140,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/externally-tagged`;
+    const urlPath = `/externally-tagged`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -190,7 +190,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/internally-tagged`;
+    const urlPath = `/internally-tagged`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -238,7 +238,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/mixed`;
+    const urlPath = `/mixed`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -286,7 +286,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/untagged`;
+    const urlPath = `/untagged`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
@@ -27,7 +27,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
@@ -50,7 +50,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/api/v1/type-a/resources`;
+    const urlPath = `/api/v1/type-a/resources`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -95,7 +95,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/api/v1/type-b/resources`;
+    const urlPath = `/api/v1/type-b/resources`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
@@ -58,7 +58,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     if (requestParameters['snakeCaseParam'] !== undefined) {
@@ -137,7 +137,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
@@ -155,7 +155,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/pet`;
+    const urlPath = `/pet`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -210,7 +210,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/pet`;
+    const urlPath = `/pet`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -263,7 +263,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/pet/findByStatus`;
+    const urlPath = `/pet/findByStatus`;
     // Build query parameters
     const queryParameters: any = {};
     if (requestParameters['status'] !== undefined) {
@@ -311,7 +311,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/pet/findByTags`;
+    const urlPath = `/pet/findByTags`;
     // Build query parameters
     const queryParameters: any = {};
     if (requestParameters['tags'] !== undefined) {

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
@@ -75,7 +75,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
       | JSONApiResponse<any>
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/store/inventory`;
+    const urlPath = `/store/inventory`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -117,7 +117,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/store/order`;
+    const urlPath = `/store/order`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
@@ -119,7 +119,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/user`;
+    const urlPath = `/user`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -165,7 +165,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/user/createWithList`;
+    const urlPath = `/user/createWithList`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -204,7 +204,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/user/login`;
+    const urlPath = `/user/login`;
     // Build query parameters
     const queryParameters: any = {};
     if (requestParameters['username'] !== undefined) {
@@ -250,7 +250,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/user/logout`;
+    const urlPath = `/user/logout`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
@@ -39,7 +39,7 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
       | VoidApiResponse & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/items`;
+    const urlPath = `/items`;
     // Build query parameters
     const queryParameters: any = {};
     if (requestParameters['status'] !== undefined) {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
@@ -74,7 +74,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/form`;
+    const urlPath = `/form`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -119,7 +119,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/json`;
+    const urlPath = `/json`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -164,7 +164,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/json-or-xml`;
+    const urlPath = `/json-or-xml`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -209,7 +209,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/text`;
+    const urlPath = `/text`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -254,7 +254,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/xml`;
+    const urlPath = `/xml`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
@@ -29,7 +29,7 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
       | JSONApiResponse<ErrorResponse>
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/widgets`;
+    const urlPath = `/widgets`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
@@ -39,7 +39,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | VoidApiResponse
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/fallback/no-body`;
+    const urlPath = `/fallback/no-body`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -80,7 +80,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | JSONApiResponse<any>
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/fallback/with-body`;
+    const urlPath = `/fallback/with-body`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
@@ -40,7 +40,7 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
       | JSONApiResponse<any>
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/widgets`;
+    const urlPath = `/widgets`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
@@ -46,7 +46,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       | JSONApiResponse<any>
       & { status: number }> {
     // Build path with path parameters
-    let urlPath = `/users`;
+    const urlPath = `/users`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
@@ -39,7 +39,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
@@ -47,7 +47,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/event`;
+    const urlPath = `/event`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
@@ -40,7 +40,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/resource`;
+    const urlPath = `/resource`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
@@ -51,7 +51,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/container`;
+    const urlPath = `/container`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -96,7 +96,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/volume`;
+    const urlPath = `/volume`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
@@ -39,7 +39,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/container`;
+    const urlPath = `/container`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
@@ -39,7 +39,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
@@ -47,7 +47,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
@@ -38,7 +38,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
@@ -38,7 +38,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
@@ -38,7 +38,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
@@ -39,7 +39,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
@@ -39,7 +39,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
@@ -38,7 +38,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
@@ -39,7 +39,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       );
     }
     // Build path with path parameters
-    let urlPath = `/test`;
+    const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
     // Build headers


### PR DESCRIPTION
## Summary
- Emit `const urlPath` when the path has no `{placeholder}` tokens; keep `let` only when followed by `urlPath = urlPath.replace(...)`
- Satisfies `prefer-const` ESLint rule
- Goldens regenerated (47 files)

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `UPDATE_GOLDEN=1 cargo test -p openapi-nexus-typescript-fetch --test golden_tests_typescript_fetch` — 50/50
- [x] `just golden::build-ts` — 47/47 compile

Closes #31