### PR TITLE
fix(typescript-fetch): use dot access for statically-known requestParameters keys

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -305,6 +305,30 @@ fn build_raw_method(op: &IrOperation) -> Result<FunSpec<TypeScript>, String> {
         .map_err(|e| format!("sigil_emit_api: raw method {method_name}: {e}"))
 }
 
+/// True if `s` is shaped like a JS identifier — safe to use with dot access.
+/// ES5+ permits reserved words (`class`, `if`, ...) after a dot as property
+/// names, and ESLint `dot-notation` accepts them, so shape is sufficient.
+fn is_js_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
+/// Render `requestParameters.{key}` when `key` is a valid identifier,
+/// otherwise `requestParameters['{key}']`.
+fn request_parameters_access(key: &str) -> String {
+    if is_js_identifier(key) {
+        format!("requestParameters.{key}")
+    } else {
+        format!("requestParameters['{key}']")
+    }
+}
+
 fn emit_required_param_checks(
     cb: &mut sigil_stitch::code_block::CodeBlockBuilder<TypeScript>,
     op: &IrOperation,
@@ -325,10 +349,11 @@ fn emit_required_param_checks(
     }
 
     for pname in all_required {
+        let access = request_parameters_access(&pname);
         cb.add(
             &format!(
-                "if (requestParameters['{0}'] === undefined || requestParameters['{0}'] === null) {{\n  throw new %T(\n    '{0}',\n    'Required parameter \"{0}\" was null or undefined when calling {1}().'\n  );\n}}\n",
-                pname, method_name
+                "if ({0} === undefined || {0} === null) {{\n  throw new %T(\n    '{1}',\n    'Required parameter \"{1}\" was null or undefined when calling {2}().'\n  );\n}}\n",
+                access, pname, method_name
             ),
             vec![Arg::TypeName(rt_value("RequiredError"))],
         );
@@ -355,11 +380,12 @@ fn emit_url_path(
     {
         let resolved = resolved_param(&names, p);
         let original = &p.name;
+        let access = request_parameters_access(&resolved);
         // The backtick template and the ${...} must both survive into TS output.
         cb.add(
             &format!(
-                "urlPath = urlPath.replace(`{{{}}}`, encodeURIComponent(String(requestParameters['{}'])));\n",
-                original, resolved
+                "urlPath = urlPath.replace(`{{{}}}`, encodeURIComponent(String({})));\n",
+                original, access
             ),
             vec![],
         );
@@ -379,10 +405,11 @@ fn emit_query_params(
         .filter(|p| matches!(p.location, IrParameterLocation::Query))
     {
         let resolved = resolved_param(&names, p);
+        let access = request_parameters_access(&resolved);
         cb.add(
             &format!(
-                "if (requestParameters['{0}'] !== undefined) {{\n  queryParameters['{1}'] = requestParameters['{0}'];\n}}\n",
-                resolved, p.name
+                "if ({0} !== undefined) {{\n  queryParameters['{1}'] = {0};\n}}\n",
+                access, p.name
             ),
             vec![],
         );
@@ -408,10 +435,11 @@ fn emit_headers(cb: &mut sigil_stitch::code_block::CodeBlockBuilder<TypeScript>,
         .filter(|p| matches!(p.location, IrParameterLocation::Header))
     {
         let resolved = resolved_param(&names, p);
+        let access = request_parameters_access(&resolved);
         cb.add(
             &format!(
-                "if (requestParameters['{0}'] !== undefined) {{\n  headerParameters['{1}'] = String(requestParameters['{0}']);\n}}\n",
-                resolved, p.name
+                "if ({0} !== undefined) {{\n  headerParameters['{1}'] = String({0});\n}}\n",
+                access, p.name
             ),
             vec![],
         );
@@ -426,10 +454,8 @@ fn emit_request_body(
         cb.add("// Prepare request body\n", vec![]);
         let names = resolve_param_names(op);
         let body_name = resolved_body(&names);
-        cb.add(
-            &format!("const requestBody = requestParameters['{}'];\n", body_name),
-            vec![],
-        );
+        let access = request_parameters_access(&body_name);
+        cb.add(&format!("const requestBody = {};\n", access), vec![]);
     }
 }
 

--- a/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
@@ -57,7 +57,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   async postLeafRaw(requestParameters: ApiPostLeafRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<LeafValue> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postLeafRaw().'
@@ -73,7 +73,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -105,7 +105,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   async postMiddleRaw(requestParameters: ApiPostMiddleRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<MiddleLevel> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postMiddleRaw().'
@@ -121,7 +121,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -153,7 +153,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   async postRootRaw(requestParameters: ApiPostRootRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<RootLevel> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postRootRaw().'
@@ -169,7 +169,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
@@ -50,7 +50,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<CreateTestResourceResponse>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createTestResourceRaw().'
@@ -66,7 +66,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -98,7 +98,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
       | JSONApiResponse<HttpErrorResponse>
       & { status: number } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['resourceId'] === undefined || requestParameters['resourceId'] === null) {
+    if (requestParameters.resourceId === undefined || requestParameters.resourceId === null) {
       throw new RequiredError(
         'resourceId',
         'Required parameter "resourceId" was null or undefined when calling deleteTestResourceRaw().'
@@ -106,7 +106,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
     }
     // Build path with path parameters
     let urlPath = `/v1/api/test-resource/{resource_id}`;
-    urlPath = urlPath.replace(`{resource_id}`, encodeURIComponent(String(requestParameters['resourceId'])));
+    urlPath = urlPath.replace(`{resource_id}`, encodeURIComponent(String(requestParameters.resourceId)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
@@ -44,13 +44,13 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['itemId'] === undefined || requestParameters['itemId'] === null) {
+    if (requestParameters.itemId === undefined || requestParameters.itemId === null) {
       throw new RequiredError(
         'itemId',
         'Required parameter "itemId" was null or undefined when calling createItemWithBodyConflictRaw().'
       );
     }
-    if (requestParameters['bodyBody'] === undefined || requestParameters['bodyBody'] === null) {
+    if (requestParameters.bodyBody === undefined || requestParameters.bodyBody === null) {
       throw new RequiredError(
         'bodyBody',
         'Required parameter "bodyBody" was null or undefined when calling createItemWithBodyConflictRaw().'
@@ -58,11 +58,11 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/items/{itemId}`;
-    urlPath = urlPath.replace(`{itemId}`, encodeURIComponent(String(requestParameters['itemId'])));
+    urlPath = urlPath.replace(`{itemId}`, encodeURIComponent(String(requestParameters.itemId)));
     // Build query parameters
     const queryParameters: any = {};
-    if (requestParameters['queryBody'] !== undefined) {
-      queryParameters['body'] = requestParameters['queryBody'];
+    if (requestParameters.queryBody !== undefined) {
+      queryParameters['body'] = requestParameters.queryBody;
     }
     // Build headers
     const headerParameters: Record<string, string> = {
@@ -70,7 +70,7 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['bodyBody'];
+    const requestBody = requestParameters.bodyBody;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
@@ -49,7 +49,7 @@ export class UsersApi extends BaseAPI implements UsersApiInterface {
       & { status: 400 } | VoidApiResponse
       & { status: 404 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['pathId'] === undefined || requestParameters['pathId'] === null) {
+    if (requestParameters.pathId === undefined || requestParameters.pathId === null) {
       throw new RequiredError(
         'pathId',
         'Required parameter "pathId" was null or undefined when calling getUserByIdDuplicateRaw().'
@@ -57,18 +57,18 @@ export class UsersApi extends BaseAPI implements UsersApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/users/{id}`;
-    urlPath = urlPath.replace(`{id}`, encodeURIComponent(String(requestParameters['pathId'])));
+    urlPath = urlPath.replace(`{id}`, encodeURIComponent(String(requestParameters.pathId)));
     // Build query parameters
     const queryParameters: any = {};
-    if (requestParameters['queryId'] !== undefined) {
-      queryParameters['id'] = requestParameters['queryId'];
+    if (requestParameters.queryId !== undefined) {
+      queryParameters['id'] = requestParameters.queryId;
     }
     // Build headers
     const headerParameters: Record<string, string> = {
     };
 
-    if (requestParameters['headerId'] !== undefined) {
-      headerParameters['id'] = String(requestParameters['headerId']);
+    if (requestParameters.headerId !== undefined) {
+      headerParameters['id'] = String(requestParameters.headerId);
     }
     // Make request
     const response = await this.request({

--- a/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
@@ -83,7 +83,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleAdjacentlyTaggedRaw().'
@@ -99,7 +99,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -133,7 +133,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleExternallyTaggedRaw().'
@@ -149,7 +149,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -183,7 +183,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleInternallyTaggedRaw().'
@@ -199,7 +199,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -231,7 +231,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   async handleMixedRaw(requestParameters: ApiHandleMixedRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<MixedEnum> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleMixedRaw().'
@@ -247,7 +247,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -279,7 +279,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   async handleUntaggedRaw(requestParameters: ApiHandleUntaggedRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<UntaggedEnum> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling handleUntaggedRaw().'
@@ -295,7 +295,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
@@ -43,7 +43,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
   async createTypeARaw(requestParameters: ApiCreateTypeARequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<ResourceTypeA> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createTypeARaw().'
@@ -59,7 +59,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -88,7 +88,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
   async createTypeBRaw(requestParameters: ApiCreateTypeBRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<ResourceTypeB> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createTypeBRaw().'
@@ -104,7 +104,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
@@ -51,7 +51,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async getWithQueryParamsRaw(requestParameters: ApiGetWithQueryParamsRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 }
       | VoidApiResponse & { status: number }> {
-    if (requestParameters['snakeCaseParam'] === undefined || requestParameters['snakeCaseParam'] === null) {
+    if (requestParameters.snakeCaseParam === undefined || requestParameters.snakeCaseParam === null) {
       throw new RequiredError(
         'snakeCaseParam',
         'Required parameter "snakeCaseParam" was null or undefined when calling getWithQueryParamsRaw().'
@@ -61,41 +61,41 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     const urlPath = `/test`;
     // Build query parameters
     const queryParameters: any = {};
-    if (requestParameters['snakeCaseParam'] !== undefined) {
-      queryParameters['snake_case_param'] = requestParameters['snakeCaseParam'];
+    if (requestParameters.snakeCaseParam !== undefined) {
+      queryParameters['snake_case_param'] = requestParameters.snakeCaseParam;
     }
-    if (requestParameters['snakeCaseNumber'] !== undefined) {
-      queryParameters['snake_case_number'] = requestParameters['snakeCaseNumber'];
+    if (requestParameters.snakeCaseNumber !== undefined) {
+      queryParameters['snake_case_number'] = requestParameters.snakeCaseNumber;
     }
-    if (requestParameters['kebabCaseParam'] !== undefined) {
-      queryParameters['kebab-case-param'] = requestParameters['kebabCaseParam'];
+    if (requestParameters.kebabCaseParam !== undefined) {
+      queryParameters['kebab-case-param'] = requestParameters.kebabCaseParam;
     }
-    if (requestParameters['kebabCaseArray'] !== undefined) {
-      queryParameters['kebab-case-array'] = requestParameters['kebabCaseArray'];
+    if (requestParameters.kebabCaseArray !== undefined) {
+      queryParameters['kebab-case-array'] = requestParameters.kebabCaseArray;
     }
-    if (requestParameters['pascalCaseParam'] !== undefined) {
-      queryParameters['PascalCaseParam'] = requestParameters['pascalCaseParam'];
+    if (requestParameters.pascalCaseParam !== undefined) {
+      queryParameters['PascalCaseParam'] = requestParameters.pascalCaseParam;
     }
-    if (requestParameters['pascalCaseNumber'] !== undefined) {
-      queryParameters['PascalCaseNumber'] = requestParameters['pascalCaseNumber'];
+    if (requestParameters.pascalCaseNumber !== undefined) {
+      queryParameters['PascalCaseNumber'] = requestParameters.pascalCaseNumber;
     }
-    if (requestParameters['screamingSnakeCase'] !== undefined) {
-      queryParameters['SCREAMING_SNAKE_CASE'] = requestParameters['screamingSnakeCase'];
+    if (requestParameters.screamingSnakeCase !== undefined) {
+      queryParameters['SCREAMING_SNAKE_CASE'] = requestParameters.screamingSnakeCase;
     }
-    if (requestParameters['screamingNumber'] !== undefined) {
-      queryParameters['SCREAMING_NUMBER'] = requestParameters['screamingNumber'];
+    if (requestParameters.screamingNumber !== undefined) {
+      queryParameters['SCREAMING_NUMBER'] = requestParameters.screamingNumber;
     }
-    if (requestParameters['camelCaseParam'] !== undefined) {
-      queryParameters['camelCaseParam'] = requestParameters['camelCaseParam'];
+    if (requestParameters.camelCaseParam !== undefined) {
+      queryParameters['camelCaseParam'] = requestParameters.camelCaseParam;
     }
-    if (requestParameters['camelCaseNumber'] !== undefined) {
-      queryParameters['camelCaseNumber'] = requestParameters['camelCaseNumber'];
+    if (requestParameters.camelCaseNumber !== undefined) {
+      queryParameters['camelCaseNumber'] = requestParameters.camelCaseNumber;
     }
-    if (requestParameters['singleword'] !== undefined) {
-      queryParameters['singleword'] = requestParameters['singleword'];
+    if (requestParameters.singleword !== undefined) {
+      queryParameters['singleword'] = requestParameters.singleword;
     }
-    if (requestParameters['id'] !== undefined) {
-      queryParameters['id'] = requestParameters['id'];
+    if (requestParameters.id !== undefined) {
+      queryParameters['id'] = requestParameters.id;
     }
     // Build headers
     const headerParameters: Record<string, string> = {
@@ -130,7 +130,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<NamingConventionTest>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testNamingConventionsRaw().'
@@ -146,7 +146,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
@@ -148,7 +148,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<Pet> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
       & { status: 422 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling updatePetRaw().'
@@ -164,7 +164,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -203,7 +203,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<Pet> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 422 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling addPetRaw().'
@@ -219,7 +219,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -256,7 +256,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['status'] === undefined || requestParameters['status'] === null) {
+    if (requestParameters.status === undefined || requestParameters.status === null) {
       throw new RequiredError(
         'status',
         'Required parameter "status" was null or undefined when calling findPetsByStatusRaw().'
@@ -266,8 +266,8 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     const urlPath = `/pet/findByStatus`;
     // Build query parameters
     const queryParameters: any = {};
-    if (requestParameters['status'] !== undefined) {
-      queryParameters['status'] = requestParameters['status'];
+    if (requestParameters.status !== undefined) {
+      queryParameters['status'] = requestParameters.status;
     }
     // Build headers
     const headerParameters: Record<string, string> = {
@@ -304,7 +304,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async findPetsByTagsRaw(requestParameters: ApiFindPetsByTagsRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Pet[]> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['tags'] === undefined || requestParameters['tags'] === null) {
+    if (requestParameters.tags === undefined || requestParameters.tags === null) {
       throw new RequiredError(
         'tags',
         'Required parameter "tags" was null or undefined when calling findPetsByTagsRaw().'
@@ -314,8 +314,8 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     const urlPath = `/pet/findByTags`;
     // Build query parameters
     const queryParameters: any = {};
-    if (requestParameters['tags'] !== undefined) {
-      queryParameters['tags'] = requestParameters['tags'];
+    if (requestParameters.tags !== undefined) {
+      queryParameters['tags'] = requestParameters.tags;
     }
     // Build headers
     const headerParameters: Record<string, string> = {
@@ -353,7 +353,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<Pet> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['petId'] === undefined || requestParameters['petId'] === null) {
+    if (requestParameters.petId === undefined || requestParameters.petId === null) {
       throw new RequiredError(
         'petId',
         'Required parameter "petId" was null or undefined when calling getPetByIdRaw().'
@@ -361,7 +361,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/pet/{petId}`;
-    urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters['petId'])));
+    urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -404,7 +404,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['petId'] === undefined || requestParameters['petId'] === null) {
+    if (requestParameters.petId === undefined || requestParameters.petId === null) {
       throw new RequiredError(
         'petId',
         'Required parameter "petId" was null or undefined when calling updatePetWithFormRaw().'
@@ -412,14 +412,14 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/pet/{petId}`;
-    urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters['petId'])));
+    urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId)));
     // Build query parameters
     const queryParameters: any = {};
-    if (requestParameters['name'] !== undefined) {
-      queryParameters['name'] = requestParameters['name'];
+    if (requestParameters.name !== undefined) {
+      queryParameters['name'] = requestParameters.name;
     }
-    if (requestParameters['status'] !== undefined) {
-      queryParameters['status'] = requestParameters['status'];
+    if (requestParameters.status !== undefined) {
+      queryParameters['status'] = requestParameters.status;
     }
     // Build headers
     const headerParameters: Record<string, string> = {
@@ -456,7 +456,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async deletePetRaw(requestParameters: ApiDeletePetRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: number }> {
-    if (requestParameters['petId'] === undefined || requestParameters['petId'] === null) {
+    if (requestParameters.petId === undefined || requestParameters.petId === null) {
       throw new RequiredError(
         'petId',
         'Required parameter "petId" was null or undefined when calling deletePetRaw().'
@@ -464,7 +464,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/pet/{petId}`;
-    urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters['petId'])));
+    urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -502,7 +502,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async uploadFileRaw(requestParameters: ApiUploadFileRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<UploadResponse> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['petId'] === undefined || requestParameters['petId'] === null) {
+    if (requestParameters.petId === undefined || requestParameters.petId === null) {
       throw new RequiredError(
         'petId',
         'Required parameter "petId" was null or undefined when calling uploadFileRaw().'
@@ -510,11 +510,11 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/pet/{petId}/uploadImage`;
-    urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters['petId'])));
+    urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId)));
     // Build query parameters
     const queryParameters: any = {};
-    if (requestParameters['additionalMetadata'] !== undefined) {
-      queryParameters['additionalMetadata'] = requestParameters['additionalMetadata'];
+    if (requestParameters.additionalMetadata !== undefined) {
+      queryParameters['additionalMetadata'] = requestParameters.additionalMetadata;
     }
     // Build headers
     const headerParameters: Record<string, string> = {

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
@@ -110,7 +110,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   async placeOrderRaw(requestParameters: ApiPlaceOrderRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Order> & { status: 200 } | VoidApiResponse
       & { status: 400 } | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling placeOrderRaw().'
@@ -126,7 +126,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -159,7 +159,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<Order> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['orderId'] === undefined || requestParameters['orderId'] === null) {
+    if (requestParameters.orderId === undefined || requestParameters.orderId === null) {
       throw new RequiredError(
         'orderId',
         'Required parameter "orderId" was null or undefined when calling getOrderByIdRaw().'
@@ -167,7 +167,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/store/order/{orderId}`;
-    urlPath = urlPath.replace(`{orderId}`, encodeURIComponent(String(requestParameters['orderId'])));
+    urlPath = urlPath.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -209,7 +209,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['orderId'] === undefined || requestParameters['orderId'] === null) {
+    if (requestParameters.orderId === undefined || requestParameters.orderId === null) {
       throw new RequiredError(
         'orderId',
         'Required parameter "orderId" was null or undefined when calling deleteOrderRaw().'
@@ -217,7 +217,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/store/order/{orderId}`;
-    urlPath = urlPath.replace(`{orderId}`, encodeURIComponent(String(requestParameters['orderId'])));
+    urlPath = urlPath.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
@@ -112,7 +112,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   async createUserRaw(requestParameters: ApiCreateUserRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<User> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createUserRaw().'
@@ -128,7 +128,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -158,7 +158,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<User>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createUsersWithListInputRaw().'
@@ -174,7 +174,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -207,11 +207,11 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     const urlPath = `/user/login`;
     // Build query parameters
     const queryParameters: any = {};
-    if (requestParameters['username'] !== undefined) {
-      queryParameters['username'] = requestParameters['username'];
+    if (requestParameters.username !== undefined) {
+      queryParameters['username'] = requestParameters.username;
     }
-    if (requestParameters['password'] !== undefined) {
-      queryParameters['password'] = requestParameters['password'];
+    if (requestParameters.password !== undefined) {
+      queryParameters['password'] = requestParameters.password;
     }
     // Build headers
     const headerParameters: Record<string, string> = {
@@ -285,7 +285,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<User> & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['username'] === undefined || requestParameters['username'] === null) {
+    if (requestParameters.username === undefined || requestParameters.username === null) {
       throw new RequiredError(
         'username',
         'Required parameter "username" was null or undefined when calling getUserByNameRaw().'
@@ -293,7 +293,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/user/{username}`;
-    urlPath = urlPath.replace(`{username}`, encodeURIComponent(String(requestParameters['username'])));
+    urlPath = urlPath.replace(`{username}`, encodeURIComponent(String(requestParameters.username)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -335,13 +335,13 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['username'] === undefined || requestParameters['username'] === null) {
+    if (requestParameters.username === undefined || requestParameters.username === null) {
       throw new RequiredError(
         'username',
         'Required parameter "username" was null or undefined when calling updateUserRaw().'
       );
     }
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling updateUserRaw().'
@@ -349,7 +349,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/user/{username}`;
-    urlPath = urlPath.replace(`{username}`, encodeURIComponent(String(requestParameters['username'])));
+    urlPath = urlPath.replace(`{username}`, encodeURIComponent(String(requestParameters.username)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -358,7 +358,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -394,7 +394,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['username'] === undefined || requestParameters['username'] === null) {
+    if (requestParameters.username === undefined || requestParameters.username === null) {
       throw new RequiredError(
         'username',
         'Required parameter "username" was null or undefined when calling deleteUserRaw().'
@@ -402,7 +402,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/user/{username}`;
-    urlPath = urlPath.replace(`{username}`, encodeURIComponent(String(requestParameters['username'])));
+    urlPath = urlPath.replace(`{username}`, encodeURIComponent(String(requestParameters.username)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
@@ -42,8 +42,8 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
     const urlPath = `/items`;
     // Build query parameters
     const queryParameters: any = {};
-    if (requestParameters['status'] !== undefined) {
-      queryParameters['status'] = requestParameters['status'];
+    if (requestParameters.status !== undefined) {
+      queryParameters['status'] = requestParameters.status;
     }
     // Build headers
     const headerParameters: Record<string, string> = {

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
@@ -67,7 +67,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postFormRaw(requestParameters: ApiPostFormRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postFormRaw().'
@@ -83,7 +83,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -112,7 +112,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postJsonRaw(requestParameters: ApiPostJsonRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postJsonRaw().'
@@ -128,7 +128,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -157,7 +157,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postJsonOrXmlRaw(requestParameters: ApiPostJsonOrXmlRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postJsonOrXmlRaw().'
@@ -173,7 +173,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -202,7 +202,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postTextRaw(requestParameters: ApiPostTextRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postTextRaw().'
@@ -218,7 +218,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -247,7 +247,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async postXmlRaw(requestParameters: ApiPostXmlRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling postXmlRaw().'
@@ -263,7 +263,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
@@ -38,13 +38,13 @@ export class FooApi extends BaseAPI implements FooApiInterface {
       | JSONApiResponse<ErrorResponse> & { status: 400 }
       | JSONApiResponse<ErrorResponse> & { status: 500 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['fooId'] === undefined || requestParameters['fooId'] === null) {
+    if (requestParameters.fooId === undefined || requestParameters.fooId === null) {
       throw new RequiredError(
         'fooId',
         'Required parameter "fooId" was null or undefined when calling updateFooBarRaw().'
       );
     }
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling updateFooBarRaw().'
@@ -52,7 +52,7 @@ export class FooApi extends BaseAPI implements FooApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/foo/bar`;
-    urlPath = urlPath.replace(`{foo_id}`, encodeURIComponent(String(requestParameters['fooId'])));
+    urlPath = urlPath.replace(`{foo_id}`, encodeURIComponent(String(requestParameters.fooId)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers
@@ -61,7 +61,7 @@ export class FooApi extends BaseAPI implements FooApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
@@ -81,7 +81,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   | InitOverrideFunction): Promise<JSONApiResponse<GetUserByIdResponse200> & { status: 200 }
       | JSONApiResponse<GetUserByIdResponse404> & { status: 404 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['id'] === undefined || requestParameters['id'] === null) {
+    if (requestParameters.id === undefined || requestParameters.id === null) {
       throw new RequiredError(
         'id',
         'Required parameter "id" was null or undefined when calling getUserByIdRaw().'
@@ -89,7 +89,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/users/{id}`;
-    urlPath = urlPath.replace(`{id}`, encodeURIComponent(String(requestParameters['id'])));
+    urlPath = urlPath.replace(`{id}`, encodeURIComponent(String(requestParameters.id)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testComplexUnionRaw().'
@@ -48,7 +48,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
@@ -40,7 +40,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createEventRaw(requestParameters: ApiCreateEventRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Event> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createEventRaw().'
@@ -56,7 +56,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
@@ -33,7 +33,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createResourceRaw(requestParameters: ApiCreateResourceRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Resource> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createResourceRaw().'
@@ -49,7 +49,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
@@ -44,7 +44,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createContainerRaw(requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<ContainerKind> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createContainerRaw().'
@@ -60,7 +60,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -89,7 +89,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createVolumeRaw(requestParameters: ApiCreateVolumeRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<VolumeKind> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createVolumeRaw().'
@@ -105,7 +105,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createContainerRaw(requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<ContainerImage> & { status: 200 }
       | JSONApiResponse<any> & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createContainerRaw().'
@@ -48,7 +48,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testIntersectionRaw().'
@@ -48,7 +48,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
@@ -40,7 +40,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createTestRaw(requestParameters: ApiCreateTestRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Baz> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling createTestRaw().'
@@ -56,7 +56,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,
@@ -85,7 +85,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async getTestRaw(requestParameters: ApiGetTestRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Baz> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['id'] === undefined || requestParameters['id'] === null) {
+    if (requestParameters.id === undefined || requestParameters.id === null) {
       throw new RequiredError(
         'id',
         'Required parameter "id" was null or undefined when calling getTestRaw().'
@@ -93,7 +93,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     }
     // Build path with path parameters
     let urlPath = `/test/{id}`;
-    urlPath = urlPath.replace(`{id}`, encodeURIComponent(String(requestParameters['id'])));
+    urlPath = urlPath.replace(`{id}`, encodeURIComponent(String(requestParameters.id)));
     // Build query parameters
     const queryParameters: any = {};
     // Build headers

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
@@ -31,7 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testNestedUnionRaw(requestParameters: ApiTestNestedUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testNestedUnionRaw().'
@@ -47,7 +47,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
@@ -31,7 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testSimpleAliasRaw(requestParameters: ApiTestSimpleAliasRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testSimpleAliasRaw().'
@@ -47,7 +47,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
@@ -31,7 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testMixedUnionRaw(requestParameters: ApiTestMixedUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testMixedUnionRaw().'
@@ -47,7 +47,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Config>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testUnionWithAnyRaw().'
@@ -48,7 +48,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testUnionWithInlineObjectsRaw().'
@@ -48,7 +48,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
@@ -31,7 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testUnionRaw(requestParameters: ApiTestUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testUnionRaw().'
@@ -47,7 +47,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
@@ -32,7 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
       & { status: 200 } | JSONApiResponse<any>
       & { status: number }> {
-    if (requestParameters['body'] === undefined || requestParameters['body'] === null) {
+    if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
         'Required parameter "body" was null or undefined when calling testUnionPrimitivesRaw().'
@@ -48,7 +48,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     };
 
     // Prepare request body
-    const requestBody = requestParameters['body'];
+    const requestBody = requestParameters.body;
     // Make request
     const response = await this.request({
         path: urlPath,


### PR DESCRIPTION
## Summary
- Emit `requestParameters.body` / `requestParameters.petId` instead of `requestParameters['body']` when the resolved name is a valid JS identifier
- Bracket access kept as a fallback for names that aren't (kebab-case, digits-first, etc.)
- Added `is_js_identifier` + `request_parameters_access` helpers in `sigil_emit_api.rs`; all 5 call sites (required-param guards, path replace, query, header, body) go through the helper
- Goldens regenerated (29 files)

## Impact
- Better IDE rename refactoring (rename-symbol across call sites)
- Satisfies `dot-notation` ESLint rule
- More idiomatic generated TS

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `UPDATE_GOLDEN=1 cargo test -p openapi-nexus-typescript-fetch --test golden_tests_typescript_fetch` — 50/50
- [x] `just golden::build-ts` — 47/47 compile

Closes #33