### PR TITLE
feat(typescript-fetch): extract per-operation raw response type aliases

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -83,6 +83,11 @@ fn emit_api_file(tag: &str, ops: &[&IrOperation]) -> Result<FileSpec<TypeScript>
         }
     }
 
+    // Per-operation raw response type aliases — emit each union member on its
+    // own line so readers can scan each `Wrapper & { status: N }` pair without
+    // the pretty printer splitting intersections across lines.
+    fb.add_code(build_response_aliases_block(ops)?);
+
     // ApiInterface — emit as a raw CodeBlock so `%T` slots propagate imports
     // for every arrow-function parameter and return type. (TypeSpec with
     // FieldSpec arrow-function fields can't carry structural TypeName for the
@@ -96,6 +101,69 @@ fn emit_api_file(tag: &str, ops: &[&IrOperation]) -> Result<FileSpec<TypeScript>
 
     fb.build()
         .map_err(|e| format!("sigil_emit_api: FileSpec build {tag}: {e}"))
+}
+
+/// Name of the exported type alias holding the raw (wrapped) response union
+/// for a given operation. E.g. `updatePet` → `UpdatePetRawResponse`.
+fn raw_response_alias_name(op: &IrOperation) -> String {
+    format!(
+        "{}RawResponse",
+        op.operation_id.to_lower_camel_case().to_pascal_case()
+    )
+}
+
+/// Emit one `export type {OpId}RawResponse = | A | B | C;` block per op.
+/// Each member is a `%T` slot so imports still flow through the collector,
+/// and each sits on its own line so intersections (`Wrapper & { status: N }`)
+/// stay intact.
+fn build_response_aliases_block(ops: &[&IrOperation]) -> Result<CodeBlock<TypeScript>, String> {
+    let mut cb = CodeBlock::<TypeScript>::builder();
+    for op in ops {
+        let alias = raw_response_alias_name(op);
+        let members = raw_response_members(op);
+        if members.len() == 1 {
+            cb.add(
+                &format!("export type {alias} = %T;\n\n"),
+                vec![Arg::TypeName(members.into_iter().next().unwrap())],
+            );
+        } else {
+            cb.add(&format!("export type {alias} =\n"), vec![]);
+            for (i, member) in members.into_iter().enumerate() {
+                let sep = if i == 0 { "  | " } else { "\n  | " };
+                cb.add(&format!("{sep}%T"), vec![Arg::TypeName(member)]);
+            }
+            cb.add(";\n\n", vec![]);
+        }
+    }
+    cb.build()
+        .map_err(|e| format!("sigil_emit_api: response aliases block: {e}"))
+}
+
+/// Compute the deduplicated list of union members for an operation's raw
+/// response type (wrapper intersected with status literal).
+fn raw_response_members(op: &IrOperation) -> Vec<TypeName<TypeScript>> {
+    let mut members: Vec<TypeName<TypeScript>> = Vec::new();
+    let mut any_body = false;
+    let mut has_default = false;
+
+    for resp in &op.responses {
+        if resp.status.eq_ignore_ascii_case("default") {
+            has_default = true;
+        }
+        let kind = classify_response(resp);
+        if !matches!(kind, ResponseKind::None) {
+            any_body = true;
+        }
+        members.push(raw_response_member(resp, &kind));
+    }
+    if !has_default {
+        members.push(fallback_member(any_body));
+    }
+
+    if members.is_empty() {
+        return vec![rt_value("VoidApiResponse")];
+    }
+    dedup_union_members(members)
 }
 
 // ============================================================================
@@ -674,35 +742,12 @@ fn raw_call_args(op: &IrOperation) -> String {
 // ============================================================================
 
 fn raw_return_type(op: &IrOperation) -> TypeName<TypeScript> {
-    let mut members: Vec<TypeName<TypeScript>> = Vec::new();
-    let mut any_body = false;
-    let mut has_default = false;
-
-    for resp in &op.responses {
-        if resp.status.eq_ignore_ascii_case("default") {
-            has_default = true;
-        }
-        let kind = classify_response(resp);
-        if !matches!(kind, ResponseKind::None) {
-            any_body = true;
-        }
-        members.push(raw_response_member(resp, &kind));
-    }
-    if !has_default {
-        // Synthesize fallback matching `emit_fallback_return`.
-        members.push(fallback_member(any_body));
-    }
-
-    let body = if members.is_empty() {
-        rt_value("VoidApiResponse")
-    } else if members.len() == 1 {
-        members.pop().unwrap()
-    } else {
-        // Deduplicate equivalent members by rendered form. Sigil's union
-        // renders each member as-is and order is preserved.
-        dedup_union(members)
-    };
-    TypeName::generic(TypeName::primitive("Promise"), vec![body])
+    // Returns `Promise<{OpId}RawResponse>` — the alias itself lives in the
+    // same file (see `build_response_aliases_block`) so no import is needed.
+    TypeName::generic(
+        TypeName::primitive("Promise"),
+        vec![TypeName::raw(&raw_response_alias_name(op))],
+    )
 }
 
 fn raw_response_member(resp: &IrResponse, kind: &ResponseKind) -> TypeName<TypeScript> {
@@ -770,9 +815,9 @@ fn convenience_return_type(op: &IrOperation) -> TypeName<TypeScript> {
     TypeName::generic(TypeName::primitive("Promise"), vec![body])
 }
 
-/// Stable de-dup of union members. Cheap-and-correct: dedup by `Debug`
-/// representation — sigil's TypeName derives `Debug` for all variants.
-fn dedup_union(members: Vec<TypeName<TypeScript>>) -> TypeName<TypeScript> {
+/// Stable de-dup of union members by `Debug` representation (cheap, correct
+/// for sigil's `TypeName` variants).
+fn dedup_union_members(members: Vec<TypeName<TypeScript>>) -> Vec<TypeName<TypeScript>> {
     let mut seen: BTreeSet<String> = BTreeSet::new();
     let mut out: Vec<TypeName<TypeScript>> = Vec::new();
     for m in members {
@@ -781,6 +826,11 @@ fn dedup_union(members: Vec<TypeName<TypeScript>>) -> TypeName<TypeScript> {
             out.push(m);
         }
     }
+    out
+}
+
+fn dedup_union(members: Vec<TypeName<TypeScript>>) -> TypeName<TypeScript> {
+    let mut out = dedup_union_members(members);
     if out.len() == 1 {
         out.pop().unwrap()
     } else {

--- a/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
@@ -22,27 +22,28 @@ export interface ApiPostRootRequest {
   body: RootLevel;
 }
 
+export type PostLeafRawResponse =
+  | JSONApiResponse<LeafValue> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type PostMiddleRawResponse =
+  | JSONApiResponse<MiddleLevel> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type PostRootRawResponse =
+  | JSONApiResponse<RootLevel> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface AdditionalPropertiesApiInterface {
-  postLeafRaw: (requestParameters: ApiPostLeafRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<LeafValue>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  postLeafRaw: (requestParameters: ApiPostLeafRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<PostLeafRawResponse>;
   postLeaf: (requestParameters: ApiPostLeafRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<LeafValue>;
-  postMiddleRaw: (requestParameters: ApiPostMiddleRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<MiddleLevel>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  postMiddleRaw: (requestParameters: ApiPostMiddleRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<PostMiddleRawResponse>;
   postMiddle: (requestParameters: ApiPostMiddleRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<MiddleLevel>;
-  postRootRaw: (requestParameters: ApiPostRootRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<RootLevel>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  postRootRaw: (requestParameters: ApiPostRootRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<PostRootRawResponse>;
   postRoot: (requestParameters: ApiPostRootRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<RootLevel>;
 }
 
@@ -55,8 +56,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   }
 
   async postLeafRaw(requestParameters: ApiPostLeafRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<LeafValue> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<PostLeafRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -103,8 +103,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   }
 
   async postMiddleRaw(requestParameters: ApiPostMiddleRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<MiddleLevel> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<PostMiddleRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -151,8 +150,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   }
 
   async postRootRaw(requestParameters: ApiPostRootRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<RootLevel> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<PostRootRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
@@ -22,18 +22,20 @@ export interface ApiDeleteTestResourceRequest {
   resourceId: string;
 }
 
+export type CreateTestResourceRawResponse =
+  | JSONApiResponse<CreateTestResourceResponse> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+export type DeleteTestResourceRawResponse =
+  | JSONApiResponse<DeleteTestResourceResponse> & { status: 200 }
+  | JSONApiResponse<HttpErrorResponse> & { status: number }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface TestResourceApiInterface {
-  createTestResourceRaw: (requestParameters: ApiCreateTestResourceRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<CreateTestResourceResponse>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createTestResourceRaw: (requestParameters: ApiCreateTestResourceRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateTestResourceRawResponse>;
   createTestResource: (requestParameters: ApiCreateTestResourceRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateTestResourceResponse>;
-  deleteTestResourceRaw: (requestParameters: ApiDeleteTestResourceRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<DeleteTestResourceResponse>
-  & { status: 200 }
-  | JSONApiResponse<HttpErrorResponse>
-  & { status: number }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  deleteTestResourceRaw: (requestParameters: ApiDeleteTestResourceRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<DeleteTestResourceRawResponse>;
   deleteTestResource: (requestParameters: ApiDeleteTestResourceRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<DeleteTestResourceResponse
   | HttpErrorResponse>;
 }
@@ -47,9 +49,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
   }
 
   async createTestResourceRaw(requestParameters: ApiCreateTestResourceRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<CreateTestResourceResponse>
-      & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<CreateTestResourceRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -93,11 +93,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
   }
 
   async deleteTestResourceRaw(requestParameters: ApiDeleteTestResourceRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<DeleteTestResourceResponse>
-      & { status: 200 }
-      | JSONApiResponse<HttpErrorResponse>
-      & { status: number } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<DeleteTestResourceRawResponse> {
     if (requestParameters.resourceId === undefined || requestParameters.resourceId === null) {
       throw new RequiredError(
         'resourceId',

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
@@ -21,13 +21,14 @@ export interface ApiCreateItemWithBodyConflictRequest {
   bodyBody: CreateItemWithBodyConflictRequest;
 }
 
+export type CreateItemWithBodyConflictRawResponse =
+  | JSONApiResponse<CreateItemWithBodyConflictResponse200> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface ItemsApiInterface {
-  createItemWithBodyConflictRaw: (requestParameters: ApiCreateItemWithBodyConflictRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<CreateItemWithBodyConflictResponse200>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createItemWithBodyConflictRaw: (requestParameters: ApiCreateItemWithBodyConflictRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateItemWithBodyConflictRawResponse>;
   createItemWithBodyConflict: (requestParameters: ApiCreateItemWithBodyConflictRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateItemWithBodyConflictResponse200>;
 }
 
@@ -40,10 +41,7 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
   }
 
   async createItemWithBodyConflictRaw(requestParameters: ApiCreateItemWithBodyConflictRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<CreateItemWithBodyConflictResponse200>
-      & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<CreateItemWithBodyConflictRawResponse> {
     if (requestParameters.itemId === undefined || requestParameters.itemId === null) {
       throw new RequiredError(
         'itemId',

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
@@ -23,15 +23,15 @@ export interface ApiGetUserByIdDuplicateRequest {
   headerId?: string;
 }
 
+export type GetUserByIdDuplicateRawResponse =
+  | JSONApiResponse<GetUserByIdDuplicateResponse200> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: 404 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface UsersApiInterface {
-  getUserByIdDuplicateRaw: (requestParameters: ApiGetUserByIdDuplicateRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<GetUserByIdDuplicateResponse200>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: 404 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getUserByIdDuplicateRaw: (requestParameters: ApiGetUserByIdDuplicateRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetUserByIdDuplicateRawResponse>;
   getUserByIdDuplicate: (requestParameters: ApiGetUserByIdDuplicateRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetUserByIdDuplicateResponse200>;
 }
 
@@ -44,11 +44,7 @@ export class UsersApi extends BaseAPI implements UsersApiInterface {
   }
 
   async getUserByIdDuplicateRaw(requestParameters: ApiGetUserByIdDuplicateRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<GetUserByIdDuplicateResponse200>
-      & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse
-      & { status: 404 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<GetUserByIdDuplicateRawResponse> {
     if (requestParameters.pathId === undefined || requestParameters.pathId === null) {
       throw new RequiredError(
         'pathId',

--- a/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
@@ -32,41 +32,42 @@ export interface ApiHandleUntaggedRequest {
   body: UntaggedEnum;
 }
 
+export type HandleAdjacentlyTaggedRawResponse =
+  | JSONApiResponse<AdjacentlyTaggedEnum> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type HandleExternallyTaggedRawResponse =
+  | JSONApiResponse<ExternallyTaggedEnum> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type HandleInternallyTaggedRawResponse =
+  | JSONApiResponse<InternallyTaggedEnum> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type HandleMixedRawResponse =
+  | JSONApiResponse<MixedEnum> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type HandleUntaggedRawResponse =
+  | JSONApiResponse<UntaggedEnum> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface EnumReprApiInterface {
-  handleAdjacentlyTaggedRaw: (requestParameters: ApiHandleAdjacentlyTaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<AdjacentlyTaggedEnum>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  handleAdjacentlyTaggedRaw: (requestParameters: ApiHandleAdjacentlyTaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<HandleAdjacentlyTaggedRawResponse>;
   handleAdjacentlyTagged: (requestParameters: ApiHandleAdjacentlyTaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<AdjacentlyTaggedEnum>;
-  handleExternallyTaggedRaw: (requestParameters: ApiHandleExternallyTaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<ExternallyTaggedEnum>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  handleExternallyTaggedRaw: (requestParameters: ApiHandleExternallyTaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<HandleExternallyTaggedRawResponse>;
   handleExternallyTagged: (requestParameters: ApiHandleExternallyTaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<ExternallyTaggedEnum>;
-  handleInternallyTaggedRaw: (requestParameters: ApiHandleInternallyTaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<InternallyTaggedEnum>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  handleInternallyTaggedRaw: (requestParameters: ApiHandleInternallyTaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<HandleInternallyTaggedRawResponse>;
   handleInternallyTagged: (requestParameters: ApiHandleInternallyTaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<InternallyTaggedEnum>;
-  handleMixedRaw: (requestParameters: ApiHandleMixedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<MixedEnum>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  handleMixedRaw: (requestParameters: ApiHandleMixedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<HandleMixedRawResponse>;
   handleMixed: (requestParameters: ApiHandleMixedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<MixedEnum>;
-  handleUntaggedRaw: (requestParameters: ApiHandleUntaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<UntaggedEnum>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  handleUntaggedRaw: (requestParameters: ApiHandleUntaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<HandleUntaggedRawResponse>;
   handleUntagged: (requestParameters: ApiHandleUntaggedRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<UntaggedEnum>;
 }
 
@@ -79,10 +80,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   }
 
   async handleAdjacentlyTaggedRaw(requestParameters: ApiHandleAdjacentlyTaggedRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<AdjacentlyTaggedEnum>
-      & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<HandleAdjacentlyTaggedRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -129,10 +127,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   }
 
   async handleExternallyTaggedRaw(requestParameters: ApiHandleExternallyTaggedRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<ExternallyTaggedEnum>
-      & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<HandleExternallyTaggedRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -179,10 +174,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   }
 
   async handleInternallyTaggedRaw(requestParameters: ApiHandleInternallyTaggedRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<InternallyTaggedEnum>
-      & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<HandleInternallyTaggedRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -229,8 +221,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   }
 
   async handleMixedRaw(requestParameters: ApiHandleMixedRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<MixedEnum> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<HandleMixedRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -277,8 +268,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   }
 
   async handleUntaggedRaw(requestParameters: ApiHandleUntaggedRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<UntaggedEnum> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<HandleUntaggedRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
@@ -6,11 +6,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type GetTestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  getTestRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  getTestRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetTestRawResponse>;
   getTest: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -22,10 +24,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async getTestRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async getTestRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<GetTestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
@@ -19,16 +19,19 @@ export interface ApiCreateTypeBRequest {
   body: CreateRequestTypeB;
 }
 
+export type CreateTypeARawResponse =
+  | JSONApiResponse<ResourceTypeA> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+export type CreateTypeBRawResponse =
+  | JSONApiResponse<ResourceTypeB> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface TestApiApiInterface {
-  createTypeARaw: (requestParameters: ApiCreateTypeARequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<ResourceTypeA>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createTypeARaw: (requestParameters: ApiCreateTypeARequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateTypeARawResponse>;
   createTypeA: (requestParameters: ApiCreateTypeARequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<ResourceTypeA>;
-  createTypeBRaw: (requestParameters: ApiCreateTypeBRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<ResourceTypeB>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createTypeBRaw: (requestParameters: ApiCreateTypeBRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateTypeBRawResponse>;
   createTypeB: (requestParameters: ApiCreateTypeBRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<ResourceTypeB>;
 }
 
@@ -41,8 +44,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
   }
 
   async createTypeARaw(requestParameters: ApiCreateTypeARequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<ResourceTypeA> & { status: 200 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<CreateTypeARawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -86,8 +88,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
   }
 
   async createTypeBRaw(requestParameters: ApiCreateTypeBRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<ResourceTypeB> & { status: 200 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<CreateTypeBRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
@@ -27,16 +27,19 @@ export interface ApiTestNamingConventionsRequest {
   body: NamingConventionTest;
 }
 
+export type GetWithQueryParamsRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+export type TestNamingConventionsRawResponse =
+  | JSONApiResponse<NamingConventionTest> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  getWithQueryParamsRaw: (requestParameters: ApiGetWithQueryParamsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  getWithQueryParamsRaw: (requestParameters: ApiGetWithQueryParamsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetWithQueryParamsRawResponse>;
   getWithQueryParams: (requestParameters: ApiGetWithQueryParamsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  testNamingConventionsRaw: (requestParameters: ApiTestNamingConventionsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<NamingConventionTest>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testNamingConventionsRaw: (requestParameters: ApiTestNamingConventionsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestNamingConventionsRawResponse>;
   testNamingConventions: (requestParameters: ApiTestNamingConventionsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<NamingConventionTest>;
 }
 
@@ -49,8 +52,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async getWithQueryParamsRaw(requestParameters: ApiGetWithQueryParamsRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 }
-      | VoidApiResponse & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<GetWithQueryParamsRawResponse> {
     if (requestParameters.snakeCaseParam === undefined || requestParameters.snakeCaseParam === null) {
       throw new RequiredError(
         'snakeCaseParam',
@@ -127,9 +129,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testNamingConventionsRaw(requestParameters: ApiTestNamingConventionsRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<NamingConventionTest>
-      & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<TestNamingConventionsRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
@@ -71,68 +71,66 @@ export interface ApiUploadFileRequest {
   additionalMetadata?: string;
 }
 
+export type UpdatePetRawResponse =
+  | JSONApiResponse<Pet> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: 404 }
+  | VoidApiResponse & { status: 422 }
+  | JSONApiResponse<any> & { status: number };
+
+export type AddPetRawResponse =
+  | JSONApiResponse<Pet> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: 422 }
+  | JSONApiResponse<any> & { status: number };
+
+export type FindPetsByStatusRawResponse =
+  | JSONApiResponse<Pet[]> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type FindPetsByTagsRawResponse =
+  | JSONApiResponse<Pet[]> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type GetPetByIdRawResponse =
+  | JSONApiResponse<Pet> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: 404 }
+  | JSONApiResponse<any> & { status: number };
+
+export type UpdatePetWithFormRawResponse =
+  | JSONApiResponse<Pet> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type DeletePetRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: number };
+
+export type UploadFileRawResponse =
+  | JSONApiResponse<UploadResponse> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface PetApiInterface {
-  updatePetRaw: (requestParameters: ApiUpdatePetRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Pet>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: 404 }
-  | VoidApiResponse
-  & { status: 422 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  updatePetRaw: (requestParameters: ApiUpdatePetRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<UpdatePetRawResponse>;
   updatePet: (requestParameters: ApiUpdatePetRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Pet>;
-  addPetRaw: (requestParameters: ApiAddPetRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Pet>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: 422 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  addPetRaw: (requestParameters: ApiAddPetRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<AddPetRawResponse>;
   addPet: (requestParameters: ApiAddPetRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Pet>;
-  findPetsByStatusRaw: (requestParameters: ApiFindPetsByStatusRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Pet[]>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  findPetsByStatusRaw: (requestParameters: ApiFindPetsByStatusRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<FindPetsByStatusRawResponse>;
   findPetsByStatus: (requestParameters: ApiFindPetsByStatusRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Pet[]>;
-  findPetsByTagsRaw: (requestParameters: ApiFindPetsByTagsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Pet[]>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  findPetsByTagsRaw: (requestParameters: ApiFindPetsByTagsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<FindPetsByTagsRawResponse>;
   findPetsByTags: (requestParameters: ApiFindPetsByTagsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Pet[]>;
-  getPetByIdRaw: (requestParameters: ApiGetPetByIdRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Pet>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: 404 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getPetByIdRaw: (requestParameters: ApiGetPetByIdRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetPetByIdRawResponse>;
   getPetById: (requestParameters: ApiGetPetByIdRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Pet>;
-  updatePetWithFormRaw: (requestParameters: ApiUpdatePetWithFormRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Pet>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  updatePetWithFormRaw: (requestParameters: ApiUpdatePetWithFormRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<UpdatePetWithFormRawResponse>;
   updatePetWithForm: (requestParameters: ApiUpdatePetWithFormRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Pet>;
-  deletePetRaw: (requestParameters: ApiDeletePetRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: number }>;
+  deletePetRaw: (requestParameters: ApiDeletePetRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<DeletePetRawResponse>;
   deletePet: (requestParameters: ApiDeletePetRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  uploadFileRaw: (requestParameters: ApiUploadFileRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<UploadResponse>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  uploadFileRaw: (requestParameters: ApiUploadFileRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<UploadFileRawResponse>;
   uploadFile: (requestParameters: ApiUploadFileRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<UploadResponse>;
 }
 
@@ -145,9 +143,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   }
 
   async updatePetRaw(requestParameters: ApiUpdatePetRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Pet> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
-      & { status: 422 } | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<UpdatePetRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -200,9 +196,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   }
 
   async addPetRaw(requestParameters: ApiAddPetRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Pet> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: 422 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<AddPetRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -252,10 +246,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   }
 
   async findPetsByStatusRaw(requestParameters: ApiFindPetsByStatusRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Pet[]>
-      & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<FindPetsByStatusRawResponse> {
     if (requestParameters.status === undefined || requestParameters.status === null) {
       throw new RequiredError(
         'status',
@@ -302,8 +293,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   }
 
   async findPetsByTagsRaw(requestParameters: ApiFindPetsByTagsRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Pet[]> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<FindPetsByTagsRawResponse> {
     if (requestParameters.tags === undefined || requestParameters.tags === null) {
       throw new RequiredError(
         'tags',
@@ -350,9 +340,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   }
 
   async getPetByIdRaw(requestParameters: ApiGetPetByIdRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Pet> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: 404 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<GetPetByIdRawResponse> {
     if (requestParameters.petId === undefined || requestParameters.petId === null) {
       throw new RequiredError(
         'petId',
@@ -400,10 +388,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   }
 
   async updatePetWithFormRaw(requestParameters: ApiUpdatePetWithFormRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Pet>
-      & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<UpdatePetWithFormRawResponse> {
     if (requestParameters.petId === undefined || requestParameters.petId === null) {
       throw new RequiredError(
         'petId',
@@ -454,8 +439,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   }
 
   async deletePetRaw(requestParameters: ApiDeletePetRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: number }> {
+  | InitOverrideFunction): Promise<DeletePetRawResponse> {
     if (requestParameters.petId === undefined || requestParameters.petId === null) {
       throw new RequiredError(
         'petId',
@@ -500,8 +484,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   }
 
   async uploadFileRaw(requestParameters: ApiUploadFileRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<UploadResponse> & { status: 200 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<UploadFileRawResponse> {
     if (requestParameters.petId === undefined || requestParameters.petId === null) {
       throw new RequiredError(
         'petId',

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
@@ -26,38 +26,37 @@ export interface ApiDeleteOrderRequest {
   orderId: number;
 }
 
+export type GetInventoryRawResponse =
+  | JSONApiResponse<Record<string, number>> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+export type PlaceOrderRawResponse =
+  | JSONApiResponse<Order> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+export type GetOrderByIdRawResponse =
+  | JSONApiResponse<Order> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: 404 }
+  | JSONApiResponse<any> & { status: number };
+
+export type DeleteOrderRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: 404 }
+  | VoidApiResponse & { status: number };
+
+
 export interface StoreApiInterface {
-  getInventoryRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Record<string,
-      number>>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getInventoryRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetInventoryRawResponse>;
   getInventory: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<Record<string,
     number>>;
-  placeOrderRaw: (requestParameters: ApiPlaceOrderRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Order>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  placeOrderRaw: (requestParameters: ApiPlaceOrderRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<PlaceOrderRawResponse>;
   placeOrder: (requestParameters: ApiPlaceOrderRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Order>;
-  getOrderByIdRaw: (requestParameters: ApiGetOrderByIdRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Order>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: 404 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getOrderByIdRaw: (requestParameters: ApiGetOrderByIdRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetOrderByIdRawResponse>;
   getOrderById: (requestParameters: ApiGetOrderByIdRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Order>;
-  deleteOrderRaw: (requestParameters: ApiDeleteOrderRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: 404 }
-  | VoidApiResponse
-  & { status: number }>;
+  deleteOrderRaw: (requestParameters: ApiDeleteOrderRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<DeleteOrderRawResponse>;
   deleteOrder: (requestParameters: ApiDeleteOrderRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -69,11 +68,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async getInventoryRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Record<string,
-          number>>
-      & { status: 200 }
-      | JSONApiResponse<any>
-      & { status: number }> {
+  async getInventoryRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<GetInventoryRawResponse> {
     // Build path with path parameters
     const urlPath = `/store/inventory`;
     // Build query parameters
@@ -108,8 +103,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   }
 
   async placeOrderRaw(requestParameters: ApiPlaceOrderRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Order> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<PlaceOrderRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -156,9 +150,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   }
 
   async getOrderByIdRaw(requestParameters: ApiGetOrderByIdRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Order> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: 404 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<GetOrderByIdRawResponse> {
     if (requestParameters.orderId === undefined || requestParameters.orderId === null) {
       throw new RequiredError(
         'orderId',
@@ -206,9 +198,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   }
 
   async deleteOrderRaw(requestParameters: ApiDeleteOrderRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
-      & { status: number }> {
+  | InitOverrideFunction): Promise<DeleteOrderRawResponse> {
     if (requestParameters.orderId === undefined || requestParameters.orderId === null) {
       throw new RequiredError(
         'orderId',

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
@@ -49,55 +49,56 @@ export interface ApiDeleteUserRequest {
   username: string;
 }
 
+export type CreateUserRawResponse =
+  | JSONApiResponse<User> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+export type CreateUsersWithListInputRawResponse =
+  | JSONApiResponse<User> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+export type LoginUserRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: number };
+
+export type LogoutUserRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+export type GetUserByNameRawResponse =
+  | JSONApiResponse<User> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: 404 }
+  | JSONApiResponse<any> & { status: number };
+
+export type UpdateUserRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: 404 }
+  | VoidApiResponse & { status: number };
+
+export type DeleteUserRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: 404 }
+  | VoidApiResponse & { status: number };
+
+
 export interface UserApiInterface {
-  createUserRaw: (requestParameters: ApiCreateUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<User>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createUserRaw: (requestParameters: ApiCreateUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateUserRawResponse>;
   createUser: (requestParameters: ApiCreateUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<User>;
-  createUsersWithListInputRaw: (requestParameters: ApiCreateUsersWithListInputRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<User>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createUsersWithListInputRaw: (requestParameters: ApiCreateUsersWithListInputRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateUsersWithListInputRawResponse>;
   createUsersWithListInput: (requestParameters: ApiCreateUsersWithListInputRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<User>;
-  loginUserRaw: (requestParameters: ApiLoginUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: number }>;
+  loginUserRaw: (requestParameters: ApiLoginUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<LoginUserRawResponse>;
   loginUser: (requestParameters: ApiLoginUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  logoutUserRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  logoutUserRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<LogoutUserRawResponse>;
   logoutUser: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  getUserByNameRaw: (requestParameters: ApiGetUserByNameRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<User>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: 404 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getUserByNameRaw: (requestParameters: ApiGetUserByNameRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetUserByNameRawResponse>;
   getUserByName: (requestParameters: ApiGetUserByNameRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<User>;
-  updateUserRaw: (requestParameters: ApiUpdateUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: 404 }
-  | VoidApiResponse
-  & { status: number }>;
+  updateUserRaw: (requestParameters: ApiUpdateUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<UpdateUserRawResponse>;
   updateUser: (requestParameters: ApiUpdateUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  deleteUserRaw: (requestParameters: ApiDeleteUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: 404 }
-  | VoidApiResponse
-  & { status: number }>;
+  deleteUserRaw: (requestParameters: ApiDeleteUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<DeleteUserRawResponse>;
   deleteUser: (requestParameters: ApiDeleteUserRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -110,8 +111,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   }
 
   async createUserRaw(requestParameters: ApiCreateUserRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<User> & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  | InitOverrideFunction): Promise<CreateUserRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -155,9 +155,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   }
 
   async createUsersWithListInputRaw(requestParameters: ApiCreateUsersWithListInputRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<User>
-      & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<CreateUsersWithListInputRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -201,8 +199,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   }
 
   async loginUserRaw(requestParameters: ApiLoginUserRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: number }> {
+  | InitOverrideFunction): Promise<LoginUserRawResponse> {
     // Build path with path parameters
     const urlPath = `/user/login`;
     // Build query parameters
@@ -245,10 +242,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     return await response.value();
   }
 
-  async logoutUserRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async logoutUserRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<LogoutUserRawResponse> {
     // Build path with path parameters
     const urlPath = `/user/logout`;
     // Build query parameters
@@ -282,9 +276,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   }
 
   async getUserByNameRaw(requestParameters: ApiGetUserByNameRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<User> & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: 404 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<GetUserByNameRawResponse> {
     if (requestParameters.username === undefined || requestParameters.username === null) {
       throw new RequiredError(
         'username',
@@ -332,9 +324,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   }
 
   async updateUserRaw(requestParameters: ApiUpdateUserRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
-      & { status: number }> {
+  | InitOverrideFunction): Promise<UpdateUserRawResponse> {
     if (requestParameters.username === undefined || requestParameters.username === null) {
       throw new RequiredError(
         'username',
@@ -391,9 +381,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   }
 
   async deleteUserRaw(requestParameters: ApiDeleteUserRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: 400 } | VoidApiResponse & { status: 404 } | VoidApiResponse
-      & { status: number }> {
+  | InitOverrideFunction): Promise<DeleteUserRawResponse> {
     if (requestParameters.username === undefined || requestParameters.username === null) {
       throw new RequiredError(
         'username',

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
@@ -16,13 +16,14 @@ export interface ApiGetItemsRequest {
   status?: FooStatus;
 }
 
+export type GetItemsRawResponse =
+  | JSONApiResponse<GetItemsResponse200> & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface ItemsApiInterface {
-  getItemsRaw: (requestParameters: ApiGetItemsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<GetItemsResponse200>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getItemsRaw: (requestParameters: ApiGetItemsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetItemsRawResponse>;
   getItems: (requestParameters: ApiGetItemsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetItemsResponse200>;
 }
 
@@ -35,9 +36,7 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
   }
 
   async getItemsRaw(requestParameters: ApiGetItemsRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<GetItemsResponse200> & { status: 200 }
-      | VoidApiResponse & { status: 400 } | JSONApiResponse<any>
-      & { status: number }> {
+  | InitOverrideFunction): Promise<GetItemsRawResponse> {
     // Build path with path parameters
     const urlPath = `/items`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
@@ -7,11 +7,13 @@
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
+export type TestRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  testRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestRawResponse>;
   test: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -23,10 +25,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: number }> {
+  async testRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<TestRawResponse> {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
@@ -28,31 +28,37 @@ export interface ApiPostXmlRequest {
   body: Payload;
 }
 
+export type PostFormRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+export type PostJsonRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+export type PostJsonOrXmlRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+export type PostTextRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+export type PostXmlRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: number };
+
+
 export interface DefaultApiInterface {
-  postFormRaw: (requestParameters: ApiPostFormRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  postFormRaw: (requestParameters: ApiPostFormRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<PostFormRawResponse>;
   postForm: (requestParameters: ApiPostFormRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  postJsonRaw: (requestParameters: ApiPostJsonRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  postJsonRaw: (requestParameters: ApiPostJsonRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<PostJsonRawResponse>;
   postJson: (requestParameters: ApiPostJsonRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  postJsonOrXmlRaw: (requestParameters: ApiPostJsonOrXmlRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  postJsonOrXmlRaw: (requestParameters: ApiPostJsonOrXmlRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<PostJsonOrXmlRawResponse>;
   postJsonOrXml: (requestParameters: ApiPostJsonOrXmlRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  postTextRaw: (requestParameters: ApiPostTextRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  postTextRaw: (requestParameters: ApiPostTextRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<PostTextRawResponse>;
   postText: (requestParameters: ApiPostTextRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  postXmlRaw: (requestParameters: ApiPostXmlRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: number }>;
+  postXmlRaw: (requestParameters: ApiPostXmlRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<PostXmlRawResponse>;
   postXml: (requestParameters: ApiPostXmlRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
 }
 
@@ -65,8 +71,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async postFormRaw(requestParameters: ApiPostFormRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: number }> {
+  | InitOverrideFunction): Promise<PostFormRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -110,8 +115,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async postJsonRaw(requestParameters: ApiPostJsonRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: number }> {
+  | InitOverrideFunction): Promise<PostJsonRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -155,8 +159,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async postJsonOrXmlRaw(requestParameters: ApiPostJsonOrXmlRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: number }> {
+  | InitOverrideFunction): Promise<PostJsonOrXmlRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -200,8 +203,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async postTextRaw(requestParameters: ApiPostTextRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: number }> {
+  | InitOverrideFunction): Promise<PostTextRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -245,8 +247,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async postXmlRaw(requestParameters: ApiPostXmlRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 200 } | VoidApiResponse
-      & { status: number }> {
+  | InitOverrideFunction): Promise<PostXmlRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
@@ -8,11 +8,13 @@ import type { Widget } from '../models/Widget';
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse } from '../runtime/runtime';
 
+export type GetWidgetRawResponse =
+  | JSONApiResponse<Widget> & { status: 200 }
+  | JSONApiResponse<ErrorResponse> & { status: number };
+
+
 export interface WidgetApiInterface {
-  getWidgetRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Widget>
-  & { status: 200 }
-  | JSONApiResponse<ErrorResponse>
-  & { status: number }>;
+  getWidgetRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetWidgetRawResponse>;
   getWidget: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<Widget | ErrorResponse>;
 }
 
@@ -24,10 +26,7 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async getWidgetRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Widget>
-      & { status: 200 }
-      | JSONApiResponse<ErrorResponse>
-      & { status: number }> {
+  async getWidgetRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<GetWidgetRawResponse> {
     // Build path with path parameters
     const urlPath = `/widgets`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
@@ -7,20 +7,21 @@ import type { GetFallbackWithBodyResponse200 } from '../models/GetFallbackWithBo
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, VoidApiResponse } from '../runtime/runtime';
 
+export type GetFallbackNoBodyRawResponse =
+  | VoidApiResponse & { status: 200 }
+  | VoidApiResponse & { status: 400 }
+  | VoidApiResponse & { status: number };
+
+export type GetFallbackWithBodyRawResponse =
+  | JSONApiResponse<GetFallbackWithBodyResponse200> & { status: 200 }
+  | VoidApiResponse & { status: 404 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  getFallbackNoBodyRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 400 }
-  | VoidApiResponse
-  & { status: number }>;
+  getFallbackNoBodyRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetFallbackNoBodyRawResponse>;
   getFallbackNoBody: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<void>;
-  getFallbackWithBodyRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<GetFallbackWithBodyResponse200>
-  & { status: 200 }
-  | VoidApiResponse
-  & { status: 404 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getFallbackWithBodyRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetFallbackWithBodyRawResponse>;
   getFallbackWithBody: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetFallbackWithBodyResponse200>;
 }
 
@@ -32,12 +33,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async getFallbackNoBodyRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<VoidApiResponse
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: 400 }
-      | VoidApiResponse
-      & { status: number }> {
+  async getFallbackNoBodyRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<GetFallbackNoBodyRawResponse> {
     // Build path with path parameters
     const urlPath = `/fallback/no-body`;
     // Build query parameters
@@ -73,12 +69,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     return await response.value();
   }
 
-  async getFallbackWithBodyRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<GetFallbackWithBodyResponse200>
-      & { status: 200 }
-      | VoidApiResponse
-      & { status: 404 }
-      | JSONApiResponse<any>
-      & { status: number }> {
+  async getFallbackWithBodyRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<GetFallbackWithBodyRawResponse> {
     // Build path with path parameters
     const urlPath = `/fallback/with-body`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
@@ -9,15 +9,15 @@ import type { WidgetListPartial } from '../models/WidgetListPartial';
 import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse } from '../runtime/runtime';
 
+export type ListWidgetsRawResponse =
+  | JSONApiResponse<Widget[]> & { status: 200 }
+  | JSONApiResponse<WidgetListPartial> & { status: 206 }
+  | JSONApiResponse<ErrorResponse> & { status: 404 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface WidgetApiInterface {
-  listWidgetsRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Widget[]>
-  & { status: 200 }
-  | JSONApiResponse<WidgetListPartial>
-  & { status: 206 }
-  | JSONApiResponse<ErrorResponse>
-  & { status: 404 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  listWidgetsRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<ListWidgetsRawResponse>;
   listWidgets: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<Widget[]
   | WidgetListPartial
   | ErrorResponse>;
@@ -31,14 +31,7 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async listWidgetsRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Widget[]>
-      & { status: 200 }
-      | JSONApiResponse<WidgetListPartial>
-      & { status: 206 }
-      | JSONApiResponse<ErrorResponse>
-      & { status: 404 }
-      | JSONApiResponse<any>
-      & { status: number }> {
+  async listWidgetsRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<ListWidgetsRawResponse> {
     // Build path with path parameters
     const urlPath = `/widgets`;
     // Build query parameters

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
@@ -13,15 +13,15 @@ export interface ApiUpdateFooBarRequest {
   body: FooRequest;
 }
 
+export type UpdateFooBarRawResponse =
+  | VoidApiResponse & { status: 204 }
+  | JSONApiResponse<ErrorResponse> & { status: 400 }
+  | JSONApiResponse<ErrorResponse> & { status: 500 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface FooApiInterface {
-  updateFooBarRaw: (requestParameters: ApiUpdateFooBarRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VoidApiResponse
-  & { status: 204 }
-  | JSONApiResponse<ErrorResponse>
-  & { status: 400 }
-  | JSONApiResponse<ErrorResponse>
-  & { status: 500 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  updateFooBarRaw: (requestParameters: ApiUpdateFooBarRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<UpdateFooBarRawResponse>;
   updateFooBar: (requestParameters: ApiUpdateFooBarRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<ErrorResponse>;
 }
 
@@ -34,10 +34,7 @@ export class FooApi extends BaseAPI implements FooApiInterface {
   }
 
   async updateFooBarRaw(requestParameters: ApiUpdateFooBarRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<VoidApiResponse & { status: 204 }
-      | JSONApiResponse<ErrorResponse> & { status: 400 }
-      | JSONApiResponse<ErrorResponse> & { status: 500 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<UpdateFooBarRawResponse> {
     if (requestParameters.fooId === undefined || requestParameters.fooId === null) {
       throw new RequiredError(
         'fooId',

--- a/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
@@ -17,18 +17,20 @@ export interface ApiGetUserByIdRequest {
   id: number;
 }
 
+export type GetAllUsersRawResponse =
+  | JSONApiResponse<GetAllUsersResponse200Item[]> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+export type GetUserByIdRawResponse =
+  | JSONApiResponse<GetUserByIdResponse200> & { status: 200 }
+  | JSONApiResponse<GetUserByIdResponse404> & { status: 404 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  getAllUsersRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<GetAllUsersResponse200Item[]>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getAllUsersRaw: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetAllUsersRawResponse>;
   getAllUsers: (initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetAllUsersResponse200Item[]>;
-  getUserByIdRaw: (requestParameters: ApiGetUserByIdRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<GetUserByIdResponse200>
-  & { status: 200 }
-  | JSONApiResponse<GetUserByIdResponse404>
-  & { status: 404 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getUserByIdRaw: (requestParameters: ApiGetUserByIdRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetUserByIdRawResponse>;
   getUserById: (requestParameters: ApiGetUserByIdRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetUserByIdResponse200
   | GetUserByIdResponse404>;
 }
@@ -41,10 +43,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     super(configuration ?? DefaultConfig);
   }
 
-  async getAllUsersRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<GetAllUsersResponse200Item[]>
-      & { status: 200 }
-      | JSONApiResponse<any>
-      & { status: number }> {
+  async getAllUsersRaw(initOverrides?: RequestInit | InitOverrideFunction): Promise<GetAllUsersRawResponse> {
     // Build path with path parameters
     const urlPath = `/users`;
     // Build query parameters
@@ -78,9 +77,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async getUserByIdRaw(requestParameters: ApiGetUserByIdRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<GetUserByIdResponse200> & { status: 200 }
-      | JSONApiResponse<GetUserByIdResponse404> & { status: 404 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<GetUserByIdRawResponse> {
     if (requestParameters.id === undefined || requestParameters.id === null) {
       throw new RequiredError(
         'id',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
@@ -12,11 +12,13 @@ export interface ApiTestComplexUnionRequest {
   body: Foo;
 }
 
+export type TestComplexUnionRawResponse =
+  | JSONApiResponse<Foo> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  testComplexUnionRaw: (requestParameters: ApiTestComplexUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Foo>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testComplexUnionRaw: (requestParameters: ApiTestComplexUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestComplexUnionRawResponse>;
   testComplexUnion: (requestParameters: ApiTestComplexUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Foo>;
 }
 
@@ -29,9 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testComplexUnionRaw(requestParameters: ApiTestComplexUnionRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
-      & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<TestComplexUnionRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
@@ -21,11 +21,13 @@ export interface ApiCreateEventRequest {
   body: Event;
 }
 
+export type CreateEventRawResponse =
+  | JSONApiResponse<Event> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  createEventRaw: (requestParameters: ApiCreateEventRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Event>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createEventRaw: (requestParameters: ApiCreateEventRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateEventRawResponse>;
   createEvent: (requestParameters: ApiCreateEventRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Event>;
 }
 
@@ -38,8 +40,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async createEventRaw(requestParameters: ApiCreateEventRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Event> & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  | InitOverrideFunction): Promise<CreateEventRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
@@ -14,11 +14,13 @@ export interface ApiCreateResourceRequest {
   body: Resource;
 }
 
+export type CreateResourceRawResponse =
+  | JSONApiResponse<Resource> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  createResourceRaw: (requestParameters: ApiCreateResourceRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Resource>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createResourceRaw: (requestParameters: ApiCreateResourceRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateResourceRawResponse>;
   createResource: (requestParameters: ApiCreateResourceRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Resource>;
 }
 
@@ -31,8 +33,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async createResourceRaw(requestParameters: ApiCreateResourceRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Resource> & { status: 200 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<CreateResourceRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
@@ -20,16 +20,19 @@ export interface ApiCreateVolumeRequest {
   body: VolumeKind;
 }
 
+export type CreateContainerRawResponse =
+  | JSONApiResponse<ContainerKind> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+export type CreateVolumeRawResponse =
+  | JSONApiResponse<VolumeKind> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  createContainerRaw: (requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<ContainerKind>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createContainerRaw: (requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateContainerRawResponse>;
   createContainer: (requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<ContainerKind>;
-  createVolumeRaw: (requestParameters: ApiCreateVolumeRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<VolumeKind>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createVolumeRaw: (requestParameters: ApiCreateVolumeRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateVolumeRawResponse>;
   createVolume: (requestParameters: ApiCreateVolumeRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<VolumeKind>;
 }
 
@@ -42,8 +45,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async createContainerRaw(requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<ContainerKind> & { status: 200 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<CreateContainerRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -87,8 +89,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async createVolumeRaw(requestParameters: ApiCreateVolumeRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<VolumeKind> & { status: 200 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<CreateVolumeRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
@@ -13,11 +13,13 @@ export interface ApiCreateContainerRequest {
   body: ContainerImage;
 }
 
+export type CreateContainerRawResponse =
+  | JSONApiResponse<ContainerImage> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  createContainerRaw: (requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<ContainerImage>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createContainerRaw: (requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateContainerRawResponse>;
   createContainer: (requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<ContainerImage>;
 }
 
@@ -30,8 +32,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async createContainerRaw(requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<ContainerImage> & { status: 200 }
-      | JSONApiResponse<any> & { status: number }> {
+  | InitOverrideFunction): Promise<CreateContainerRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
@@ -12,11 +12,13 @@ export interface ApiTestIntersectionRequest {
   body: Foo;
 }
 
+export type TestIntersectionRawResponse =
+  | JSONApiResponse<Foo> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  testIntersectionRaw: (requestParameters: ApiTestIntersectionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Foo>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testIntersectionRaw: (requestParameters: ApiTestIntersectionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestIntersectionRawResponse>;
   testIntersection: (requestParameters: ApiTestIntersectionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Foo>;
 }
 
@@ -29,9 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testIntersectionRaw(requestParameters: ApiTestIntersectionRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
-      & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<TestIntersectionRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
@@ -16,16 +16,19 @@ export interface ApiGetTestRequest {
   id: string;
 }
 
+export type CreateTestRawResponse =
+  | JSONApiResponse<Baz> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+export type GetTestRawResponse =
+  | JSONApiResponse<Baz> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  createTestRaw: (requestParameters: ApiCreateTestRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Baz>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  createTestRaw: (requestParameters: ApiCreateTestRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<CreateTestRawResponse>;
   createTest: (requestParameters: ApiCreateTestRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Baz>;
-  getTestRaw: (requestParameters: ApiGetTestRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Baz>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  getTestRaw: (requestParameters: ApiGetTestRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<GetTestRawResponse>;
   getTest: (requestParameters: ApiGetTestRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Baz>;
 }
 
@@ -38,8 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async createTestRaw(requestParameters: ApiCreateTestRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Baz> & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  | InitOverrideFunction): Promise<CreateTestRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',
@@ -83,8 +85,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async getTestRaw(requestParameters: ApiGetTestRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Baz> & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  | InitOverrideFunction): Promise<GetTestRawResponse> {
     if (requestParameters.id === undefined || requestParameters.id === null) {
       throw new RequiredError(
         'id',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
@@ -12,11 +12,13 @@ export interface ApiTestNestedUnionRequest {
   body: Foo;
 }
 
+export type TestNestedUnionRawResponse =
+  | JSONApiResponse<Foo> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  testNestedUnionRaw: (requestParameters: ApiTestNestedUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Foo>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testNestedUnionRaw: (requestParameters: ApiTestNestedUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestNestedUnionRawResponse>;
   testNestedUnion: (requestParameters: ApiTestNestedUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Foo>;
 }
 
@@ -29,8 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testNestedUnionRaw(requestParameters: ApiTestNestedUnionRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  | InitOverrideFunction): Promise<TestNestedUnionRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
@@ -12,11 +12,13 @@ export interface ApiTestSimpleAliasRequest {
   body: Foo;
 }
 
+export type TestSimpleAliasRawResponse =
+  | JSONApiResponse<Foo> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  testSimpleAliasRaw: (requestParameters: ApiTestSimpleAliasRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Foo>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testSimpleAliasRaw: (requestParameters: ApiTestSimpleAliasRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestSimpleAliasRawResponse>;
   testSimpleAlias: (requestParameters: ApiTestSimpleAliasRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Foo>;
 }
 
@@ -29,8 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testSimpleAliasRaw(requestParameters: ApiTestSimpleAliasRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  | InitOverrideFunction): Promise<TestSimpleAliasRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
@@ -12,11 +12,13 @@ export interface ApiTestMixedUnionRequest {
   body: Foo;
 }
 
+export type TestMixedUnionRawResponse =
+  | JSONApiResponse<Foo> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  testMixedUnionRaw: (requestParameters: ApiTestMixedUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Foo>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testMixedUnionRaw: (requestParameters: ApiTestMixedUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestMixedUnionRawResponse>;
   testMixedUnion: (requestParameters: ApiTestMixedUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Foo>;
 }
 
@@ -29,8 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testMixedUnionRaw(requestParameters: ApiTestMixedUnionRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  | InitOverrideFunction): Promise<TestMixedUnionRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
@@ -12,11 +12,13 @@ export interface ApiTestUnionWithAnyRequest {
   body: Config;
 }
 
+export type TestUnionWithAnyRawResponse =
+  | JSONApiResponse<Config> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  testUnionWithAnyRaw: (requestParameters: ApiTestUnionWithAnyRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Config>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testUnionWithAnyRaw: (requestParameters: ApiTestUnionWithAnyRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestUnionWithAnyRawResponse>;
   testUnionWithAny: (requestParameters: ApiTestUnionWithAnyRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Config>;
 }
 
@@ -29,9 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testUnionWithAnyRaw(requestParameters: ApiTestUnionWithAnyRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Config>
-      & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<TestUnionWithAnyRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
@@ -12,11 +12,13 @@ export interface ApiTestUnionWithInlineObjectsRequest {
   body: Foo;
 }
 
+export type TestUnionWithInlineObjectsRawResponse =
+  | JSONApiResponse<Foo> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  testUnionWithInlineObjectsRaw: (requestParameters: ApiTestUnionWithInlineObjectsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Foo>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testUnionWithInlineObjectsRaw: (requestParameters: ApiTestUnionWithInlineObjectsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestUnionWithInlineObjectsRawResponse>;
   testUnionWithInlineObjects: (requestParameters: ApiTestUnionWithInlineObjectsRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Foo>;
 }
 
@@ -29,9 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testUnionWithInlineObjectsRaw(requestParameters: ApiTestUnionWithInlineObjectsRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
-      & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<TestUnionWithInlineObjectsRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
@@ -12,11 +12,13 @@ export interface ApiTestUnionRequest {
   body: Foo;
 }
 
+export type TestUnionRawResponse =
+  | JSONApiResponse<Foo> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  testUnionRaw: (requestParameters: ApiTestUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Foo>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testUnionRaw: (requestParameters: ApiTestUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestUnionRawResponse>;
   testUnion: (requestParameters: ApiTestUnionRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Foo>;
 }
 
@@ -29,8 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testUnionRaw(requestParameters: ApiTestUnionRequest, initOverrides?: RequestInit
-  | InitOverrideFunction): Promise<JSONApiResponse<Foo> & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  | InitOverrideFunction): Promise<TestUnionRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
@@ -12,11 +12,13 @@ export interface ApiTestUnionPrimitivesRequest {
   body: Foo;
 }
 
+export type TestUnionPrimitivesRawResponse =
+  | JSONApiResponse<Foo> & { status: 200 }
+  | JSONApiResponse<any> & { status: number };
+
+
 export interface DefaultApiInterface {
-  testUnionPrimitivesRaw: (requestParameters: ApiTestUnionPrimitivesRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<JSONApiResponse<Foo>
-  & { status: 200 }
-  | JSONApiResponse<any>
-  & { status: number }>;
+  testUnionPrimitivesRaw: (requestParameters: ApiTestUnionPrimitivesRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<TestUnionPrimitivesRawResponse>;
   testUnionPrimitives: (requestParameters: ApiTestUnionPrimitivesRequest, initOverrides?: RequestInit | InitOverrideFunction) => Promise<Foo>;
 }
 
@@ -29,9 +31,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   }
 
   async testUnionPrimitivesRaw(requestParameters: ApiTestUnionPrimitivesRequest,
-  initOverrides?: RequestInit | InitOverrideFunction): Promise<JSONApiResponse<Foo>
-      & { status: 200 } | JSONApiResponse<any>
-      & { status: number }> {
+  initOverrides?: RequestInit | InitOverrideFunction): Promise<TestUnionPrimitivesRawResponse> {
     if (requestParameters.body === undefined || requestParameters.body === null) {
       throw new RequiredError(
         'body',


### PR DESCRIPTION
## Summary
- Emit `export type {OperationId}RawResponse = | A | B | ...;` per operation, with each union member on its own line
- Raw method signatures become `Promise<UpdatePetRawResponse>` instead of inline intersections
- Fixes operators-at-line-start wrapping that split `Wrapper & { status: N }` pairs across lines
- Goldens regenerated (50 files, -708/+666 lines — the interface and class-method signatures shrink dramatically)

## Surface change
New exports per op (`UpdatePetRawResponse`, `AddPetRawResponse`, …). Consumers who want to narrow raw responses can now import them by name.

## Before
```ts
updatePetRaw: (...) => Promise<JSONApiResponse<Pet>
  & { status: 200 }
  | VoidApiResponse
  & { status: 400 }
  | VoidApiResponse
  & { status: 404 }
  | ...>;
```

## After
```ts
export type UpdatePetRawResponse =
  | JSONApiResponse<Pet> & { status: 200 }
  | VoidApiResponse & { status: 400 }
  | VoidApiResponse & { status: 404 }
  | VoidApiResponse & { status: 422 }
  | JSONApiResponse<any> & { status: number };

updatePetRaw: (...) => Promise<UpdatePetRawResponse>;
```

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `UPDATE_GOLDEN=1 cargo test -p openapi-nexus-typescript-fetch --test golden_tests_typescript_fetch` — 50/50
- [x] `just golden::build-ts` — 47/47 compile

Closes #34