### PR TITLE
fix(typescript-fetch): replace any with unknown across generated code and runtime

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/project_files/runtime.ts.txt
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/project_files/runtime.ts.txt
@@ -142,14 +142,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -157,7 +157,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -165,7 +165,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -227,18 +227,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -265,7 +265,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -315,13 +315,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -374,7 +374,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -392,7 +392,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit_api.rs
@@ -255,7 +255,14 @@ fn build_api_interface_block(
         cb.add(";\n", vec![]);
 
         cb.add(&format!("  {}: ", method_base), vec![]);
-        emit_arrow_signature(&mut cb, op, convenience_return_type(op));
+        emit_arrow_signature(
+            &mut cb,
+            op,
+            TypeName::generic(
+                TypeName::primitive("Promise"),
+                vec![convenience_body_type(op)],
+            ),
+        );
         cb.add(";\n", vec![]);
     }
 
@@ -465,7 +472,10 @@ fn emit_query_params(
     op: &IrOperation,
 ) {
     cb.add("// Build query parameters\n", vec![]);
-    cb.add("const queryParameters: any = {};\n", vec![]);
+    cb.add(
+        "const queryParameters: %T = {};\n",
+        vec![Arg::TypeName(rt_type("HTTPQuery"))],
+    );
     let names = resolve_param_names(op);
     for p in op
         .parameters
@@ -612,7 +622,7 @@ fn emit_response_return(
     };
     let wrapper_type = match kind.clone() {
         ResponseKind::Json(body_ty) => {
-            let body = body_ty.unwrap_or_else(|| TypeName::primitive("any"));
+            let body = body_ty.unwrap_or_else(|| TypeName::primitive("unknown"));
             TypeName::generic(rt_value("JSONApiResponse"), vec![body])
         }
         ResponseKind::Text => rt_value("TextApiResponse"),
@@ -629,7 +639,7 @@ fn emit_response_return(
     );
 }
 
-/// `return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };`
+/// `return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };`
 /// (or VoidApiResponse equivalent when no body appears anywhere).
 fn emit_fallback_return(
     cb: &mut sigil_stitch::code_block::CodeBlockBuilder<TypeScript>,
@@ -642,7 +652,7 @@ fn emit_fallback_return(
             vec![
                 Arg::TypeName(rt_value("JSONApiResponse")),
                 Arg::TypeName(rt_value("JSONApiResponse")),
-                Arg::TypeName(TypeName::primitive("any")),
+                Arg::TypeName(TypeName::primitive("unknown")),
             ],
         );
     } else {
@@ -670,21 +680,43 @@ fn build_convenience_method(op: &IrOperation) -> Result<FunSpec<TypeScript>, Str
     for param in method_param_specs(op) {
         fb.add_param(param);
     }
-    fb.returns(convenience_return_type(op));
+    let body_ty = convenience_body_type(op);
+    fb.returns(TypeName::generic(
+        TypeName::primitive("Promise"),
+        vec![body_ty.clone()],
+    ));
 
     let args_list = raw_call_args(op);
     let mut body = CodeBlock::<TypeScript>::builder();
-    body.add(
-        &format!(
-            "const response = await this.{}({});\nreturn await response.value();",
-            raw_name, args_list
-        ),
-        vec![],
-    );
+    // The raw union may include `JSONApiResponse<unknown>` for the fallback,
+    // so `response.value()` widens to `unknown`. Narrow it with a cast to
+    // the declared body type — this is a "genuine boundary" where the
+    // fallback's runtime shape isn't knowable from the OpenAPI spec.
+    if is_void_type(&body_ty) {
+        body.add(
+            &format!(
+                "const response = await this.{}({});\nreturn await response.value();",
+                raw_name, args_list
+            ),
+            vec![],
+        );
+    } else {
+        body.add(
+            &format!(
+                "const response = await this.{}({});\nreturn await response.value() as %T;",
+                raw_name, args_list
+            ),
+            vec![Arg::TypeName(body_ty)],
+        );
+    }
     fb.body(body.build().expect("CodeBlock builds"));
 
     fb.build()
         .map_err(|e| format!("sigil_emit_api: convenience method {method_base}: {e}"))
+}
+
+fn is_void_type(ty: &TypeName<TypeScript>) -> bool {
+    format!("{:?}", ty) == format!("{:?}", TypeName::<TypeScript>::primitive("void"))
 }
 
 // ============================================================================
@@ -759,7 +791,7 @@ fn raw_response_member(resp: &IrResponse, kind: &ResponseKind) -> TypeName<TypeS
         .unwrap_or_else(|| "{ status: number }".to_string());
     let wrapper_type = match kind.clone() {
         ResponseKind::Json(body_ty) => {
-            let body = body_ty.unwrap_or_else(|| TypeName::primitive("any"));
+            let body = body_ty.unwrap_or_else(|| TypeName::primitive("unknown"));
             TypeName::generic(rt_value("JSONApiResponse"), vec![body])
         }
         ResponseKind::Text => rt_value("TextApiResponse"),
@@ -773,7 +805,7 @@ fn fallback_member(any_body: bool) -> TypeName<TypeScript> {
     let wrapper = if any_body {
         TypeName::generic(
             rt_value("JSONApiResponse"),
-            vec![TypeName::primitive("any")],
+            vec![TypeName::primitive("unknown")],
         )
     } else {
         rt_value("VoidApiResponse")
@@ -781,7 +813,7 @@ fn fallback_member(any_body: bool) -> TypeName<TypeScript> {
     TypeName::intersection(vec![wrapper, TypeName::raw("{ status: number }")])
 }
 
-fn convenience_return_type(op: &IrOperation) -> TypeName<TypeScript> {
+fn convenience_body_type(op: &IrOperation) -> TypeName<TypeScript> {
     let mut members: Vec<TypeName<TypeScript>> = Vec::new();
     let mut any_body = false;
     for resp in &op.responses {
@@ -792,7 +824,7 @@ fn convenience_return_type(op: &IrOperation) -> TypeName<TypeScript> {
             }
             ResponseKind::Json(None) => {
                 any_body = true;
-                members.push(TypeName::primitive("any"));
+                members.push(TypeName::primitive("unknown"));
             }
             ResponseKind::Text => {
                 any_body = true;
@@ -805,14 +837,13 @@ fn convenience_return_type(op: &IrOperation) -> TypeName<TypeScript> {
             ResponseKind::None => {}
         }
     }
-    let body = if !any_body {
+    if !any_body {
         TypeName::primitive("void")
     } else if members.len() == 1 {
         members.pop().unwrap()
     } else {
         dedup_union(members)
-    };
-    TypeName::generic(TypeName::primitive("Promise"), vec![body])
+    }
 }
 
 /// Stable de-dup of union members by `Debug` representation (cheap, correct

--- a/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/apis/AdditionalPropertiesApi.ts.golden
@@ -7,7 +7,7 @@
 import type { LeafValue } from '../models/LeafValue';
 import type { MiddleLevel } from '../models/MiddleLevel';
 import type { RootLevel } from '../models/RootLevel';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiPostLeafRequest {
@@ -25,17 +25,17 @@ export interface ApiPostRootRequest {
 export type PostLeafRawResponse =
   | JSONApiResponse<LeafValue> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type PostMiddleRawResponse =
   | JSONApiResponse<MiddleLevel> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type PostRootRawResponse =
   | JSONApiResponse<RootLevel> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface AdditionalPropertiesApiInterface {
@@ -66,7 +66,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
     // Build path with path parameters
     const urlPath = `/leaf`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -91,7 +91,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -99,7 +99,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   async postLeaf(requestParameters: ApiPostLeafRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<LeafValue> {
     const response = await this.postLeafRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as LeafValue;
   }
 
   async postMiddleRaw(requestParameters: ApiPostMiddleRequest, initOverrides?: RequestInit
@@ -113,7 +113,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
     // Build path with path parameters
     const urlPath = `/middle`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -138,7 +138,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -146,7 +146,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   async postMiddle(requestParameters: ApiPostMiddleRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<MiddleLevel> {
     const response = await this.postMiddleRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as MiddleLevel;
   }
 
   async postRootRaw(requestParameters: ApiPostRootRequest, initOverrides?: RequestInit
@@ -160,7 +160,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
     // Build path with path parameters
     const urlPath = `/root`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -185,7 +185,7 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -193,6 +193,6 @@ export class AdditionalPropertiesApi extends BaseAPI implements AdditionalProper
   async postRoot(requestParameters: ApiPostRootRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<RootLevel> {
     const response = await this.postRootRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as RootLevel;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Comprehensive Schema Types Example — 1.0.0
  * Comprehensive test for all OpenAPI v3.1.2 schema types
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/apis/TestResourceApi.ts.golden
@@ -8,7 +8,7 @@ import type { CreateTestResourceRequest } from '../models/CreateTestResourceRequ
 import type { CreateTestResourceResponse } from '../models/CreateTestResourceResponse';
 import type { DeleteTestResourceResponse } from '../models/DeleteTestResourceResponse';
 import type { HttpErrorResponse } from '../models/HttpErrorResponse';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiCreateTestResourceRequest {
@@ -24,12 +24,12 @@ export interface ApiDeleteTestResourceRequest {
 
 export type CreateTestResourceRawResponse =
   | JSONApiResponse<CreateTestResourceResponse> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type DeleteTestResourceRawResponse =
   | JSONApiResponse<DeleteTestResourceResponse> & { status: 200 }
   | JSONApiResponse<HttpErrorResponse> & { status: number }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface TestResourceApiInterface {
@@ -59,7 +59,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
     // Build path with path parameters
     const urlPath = `/v1/api/test-resource`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -81,7 +81,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
       return new JSONApiResponse(response) as JSONApiResponse<CreateTestResourceResponse> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -89,7 +89,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
   async createTestResource(requestParameters: ApiCreateTestResourceRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<CreateTestResourceResponse> {
     const response = await this.createTestResourceRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as CreateTestResourceResponse;
   }
 
   async deleteTestResourceRaw(requestParameters: ApiDeleteTestResourceRequest,
@@ -104,7 +104,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
     let urlPath = `/v1/api/test-resource/{resource_id}`;
     urlPath = urlPath.replace(`{resource_id}`, encodeURIComponent(String(requestParameters.resourceId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -129,7 +129,7 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
       return new JSONApiResponse(response) as JSONApiResponse<HttpErrorResponse> & { status: number };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -138,6 +138,6 @@ export class TestResourceApi extends BaseAPI implements TestResourceApiInterface
   initOverrides?: RequestInit | InitOverrideFunction): Promise<DeleteTestResourceResponse
       | HttpErrorResponse> {
     const response = await this.deleteTestResourceRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as DeleteTestResourceResponse | HttpErrorResponse;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/ItemsApi.ts.golden
@@ -6,7 +6,7 @@
  */
 import type { CreateItemWithBodyConflictRequest } from '../models/CreateItemWithBodyConflictRequest';
 import type { CreateItemWithBodyConflictResponse200 } from '../models/CreateItemWithBodyConflictResponse200';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiCreateItemWithBodyConflictRequest {
@@ -24,7 +24,7 @@ export interface ApiCreateItemWithBodyConflictRequest {
 export type CreateItemWithBodyConflictRawResponse =
   | JSONApiResponse<CreateItemWithBodyConflictResponse200> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface ItemsApiInterface {
@@ -58,7 +58,7 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
     let urlPath = `/items/{itemId}`;
     urlPath = urlPath.replace(`{itemId}`, encodeURIComponent(String(requestParameters.itemId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     if (requestParameters.queryBody !== undefined) {
       queryParameters['body'] = requestParameters.queryBody;
     }
@@ -86,7 +86,7 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -94,6 +94,6 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
   async createItemWithBodyConflict(requestParameters: ApiCreateItemWithBodyConflictRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<CreateItemWithBodyConflictResponse200> {
     const response = await this.createItemWithBodyConflictRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as CreateItemWithBodyConflictResponse200;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/apis/UsersApi.ts.golden
@@ -5,7 +5,7 @@
  * Test API with duplicate parameter names across different locations
  */
 import type { GetUserByIdDuplicateResponse200 } from '../models/GetUserByIdDuplicateResponse200';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiGetUserByIdDuplicateRequest {
@@ -27,7 +27,7 @@ export type GetUserByIdDuplicateRawResponse =
   | JSONApiResponse<GetUserByIdDuplicateResponse200> & { status: 200 }
   | VoidApiResponse & { status: 400 }
   | VoidApiResponse & { status: 404 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface UsersApiInterface {
@@ -55,7 +55,7 @@ export class UsersApi extends BaseAPI implements UsersApiInterface {
     let urlPath = `/users/{id}`;
     urlPath = urlPath.replace(`{id}`, encodeURIComponent(String(requestParameters.pathId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     if (requestParameters.queryId !== undefined) {
       queryParameters['id'] = requestParameters.queryId;
     }
@@ -86,7 +86,7 @@ export class UsersApi extends BaseAPI implements UsersApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 404 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -94,6 +94,6 @@ export class UsersApi extends BaseAPI implements UsersApiInterface {
   async getUserByIdDuplicate(requestParameters: ApiGetUserByIdDuplicateRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<GetUserByIdDuplicateResponse200> {
     const response = await this.getUserByIdDuplicateRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as GetUserByIdDuplicateResponse200;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/apis/EnumReprApi.ts.golden
@@ -9,7 +9,7 @@ import type { ExternallyTaggedEnum } from '../models/ExternallyTaggedEnum';
 import type { InternallyTaggedEnum } from '../models/InternallyTaggedEnum';
 import type { MixedEnum } from '../models/MixedEnum';
 import type { UntaggedEnum } from '../models/UntaggedEnum';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiHandleAdjacentlyTaggedRequest {
@@ -35,27 +35,27 @@ export interface ApiHandleUntaggedRequest {
 export type HandleAdjacentlyTaggedRawResponse =
   | JSONApiResponse<AdjacentlyTaggedEnum> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type HandleExternallyTaggedRawResponse =
   | JSONApiResponse<ExternallyTaggedEnum> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type HandleInternallyTaggedRawResponse =
   | JSONApiResponse<InternallyTaggedEnum> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type HandleMixedRawResponse =
   | JSONApiResponse<MixedEnum> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type HandleUntaggedRawResponse =
   | JSONApiResponse<UntaggedEnum> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface EnumReprApiInterface {
@@ -90,7 +90,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build path with path parameters
     const urlPath = `/adjacently-tagged`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -115,7 +115,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -123,7 +123,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   async handleAdjacentlyTagged(requestParameters: ApiHandleAdjacentlyTaggedRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<AdjacentlyTaggedEnum> {
     const response = await this.handleAdjacentlyTaggedRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as AdjacentlyTaggedEnum;
   }
 
   async handleExternallyTaggedRaw(requestParameters: ApiHandleExternallyTaggedRequest,
@@ -137,7 +137,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build path with path parameters
     const urlPath = `/externally-tagged`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -162,7 +162,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -170,7 +170,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   async handleExternallyTagged(requestParameters: ApiHandleExternallyTaggedRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<ExternallyTaggedEnum> {
     const response = await this.handleExternallyTaggedRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as ExternallyTaggedEnum;
   }
 
   async handleInternallyTaggedRaw(requestParameters: ApiHandleInternallyTaggedRequest,
@@ -184,7 +184,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build path with path parameters
     const urlPath = `/internally-tagged`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -209,7 +209,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -217,7 +217,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   async handleInternallyTagged(requestParameters: ApiHandleInternallyTaggedRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<InternallyTaggedEnum> {
     const response = await this.handleInternallyTaggedRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as InternallyTaggedEnum;
   }
 
   async handleMixedRaw(requestParameters: ApiHandleMixedRequest, initOverrides?: RequestInit
@@ -231,7 +231,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build path with path parameters
     const urlPath = `/mixed`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -256,7 +256,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -264,7 +264,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   async handleMixed(requestParameters: ApiHandleMixedRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<MixedEnum> {
     const response = await this.handleMixedRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as MixedEnum;
   }
 
   async handleUntaggedRaw(requestParameters: ApiHandleUntaggedRequest, initOverrides?: RequestInit
@@ -278,7 +278,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
     // Build path with path parameters
     const urlPath = `/untagged`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -303,7 +303,7 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -311,6 +311,6 @@ export class EnumReprApi extends BaseAPI implements EnumReprApiInterface {
   async handleUntagged(requestParameters: ApiHandleUntaggedRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<UntaggedEnum> {
     const response = await this.handleUntaggedRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as UntaggedEnum;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/apis/DefaultApi.ts.golden
@@ -3,7 +3,7 @@
  *
  * Minimal API — 1.0.0
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type GetTestRawResponse =
@@ -28,7 +28,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
@@ -152,14 +152,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -167,7 +167,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -175,7 +175,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -237,18 +237,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -275,7 +275,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -325,13 +325,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -384,7 +384,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -402,7 +402,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/apis/TestApiApi.ts.golden
@@ -8,7 +8,7 @@ import type { CreateRequestTypeA } from '../models/CreateRequestTypeA';
 import type { CreateRequestTypeB } from '../models/CreateRequestTypeB';
 import type { ResourceTypeA } from '../models/ResourceTypeA';
 import type { ResourceTypeB } from '../models/ResourceTypeB';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiCreateTypeARequest {
@@ -21,11 +21,11 @@ export interface ApiCreateTypeBRequest {
 
 export type CreateTypeARawResponse =
   | JSONApiResponse<ResourceTypeA> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type CreateTypeBRawResponse =
   | JSONApiResponse<ResourceTypeB> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface TestApiApiInterface {
@@ -54,7 +54,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
     // Build path with path parameters
     const urlPath = `/api/v1/type-a/resources`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -76,7 +76,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<ResourceTypeA> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -84,7 +84,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
   async createTypeA(requestParameters: ApiCreateTypeARequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<ResourceTypeA> {
     const response = await this.createTypeARaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as ResourceTypeA;
   }
 
   async createTypeBRaw(requestParameters: ApiCreateTypeBRequest, initOverrides?: RequestInit
@@ -98,7 +98,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
     // Build path with path parameters
     const urlPath = `/api/v1/type-b/resources`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -120,7 +120,7 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<ResourceTypeB> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -128,6 +128,6 @@ export class TestApiApi extends BaseAPI implements TestApiApiInterface {
   async createTypeB(requestParameters: ApiCreateTypeBRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<ResourceTypeB> {
     const response = await this.createTypeBRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as ResourceTypeB;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture to verify language property naming conventions
  */
 import type { NamingConventionTest } from '../models/NamingConventionTest';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiGetWithQueryParamsRequest {
@@ -33,7 +33,7 @@ export type GetWithQueryParamsRawResponse =
 
 export type TestNamingConventionsRawResponse =
   | JSONApiResponse<NamingConventionTest> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -62,7 +62,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     if (requestParameters.snakeCaseParam !== undefined) {
       queryParameters['snake_case_param'] = requestParameters.snakeCaseParam;
     }
@@ -139,7 +139,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -161,7 +161,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<NamingConventionTest> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -169,6 +169,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testNamingConventions(requestParameters: ApiTestNamingConventionsRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<NamingConventionTest> {
     const response = await this.testNamingConventionsRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as NamingConventionTest;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/PetApi.ts.golden
@@ -6,7 +6,7 @@
  */
 import type { Pet } from '../models/Pet';
 import type { UploadResponse } from '../models/UploadResponse';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiUpdatePetRequest {
@@ -76,34 +76,34 @@ export type UpdatePetRawResponse =
   | VoidApiResponse & { status: 400 }
   | VoidApiResponse & { status: 404 }
   | VoidApiResponse & { status: 422 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type AddPetRawResponse =
   | JSONApiResponse<Pet> & { status: 200 }
   | VoidApiResponse & { status: 400 }
   | VoidApiResponse & { status: 422 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type FindPetsByStatusRawResponse =
   | JSONApiResponse<Pet[]> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type FindPetsByTagsRawResponse =
   | JSONApiResponse<Pet[]> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type GetPetByIdRawResponse =
   | JSONApiResponse<Pet> & { status: 200 }
   | VoidApiResponse & { status: 400 }
   | VoidApiResponse & { status: 404 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type UpdatePetWithFormRawResponse =
   | JSONApiResponse<Pet> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type DeletePetRawResponse =
   | VoidApiResponse & { status: 200 }
@@ -112,7 +112,7 @@ export type DeletePetRawResponse =
 
 export type UploadFileRawResponse =
   | JSONApiResponse<UploadResponse> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface PetApiInterface {
@@ -153,7 +153,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     // Build path with path parameters
     const urlPath = `/pet`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -184,7 +184,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 422 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -192,7 +192,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async updatePet(requestParameters: ApiUpdatePetRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Pet> {
     const response = await this.updatePetRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Pet;
   }
 
   async addPetRaw(requestParameters: ApiAddPetRequest, initOverrides?: RequestInit
@@ -206,7 +206,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     // Build path with path parameters
     const urlPath = `/pet`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -234,7 +234,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 422 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -242,7 +242,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async addPet(requestParameters: ApiAddPetRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Pet> {
     const response = await this.addPetRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Pet;
   }
 
   async findPetsByStatusRaw(requestParameters: ApiFindPetsByStatusRequest,
@@ -256,7 +256,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     // Build path with path parameters
     const urlPath = `/pet/findByStatus`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     if (requestParameters.status !== undefined) {
       queryParameters['status'] = requestParameters.status;
     }
@@ -281,7 +281,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -289,7 +289,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async findPetsByStatus(requestParameters: ApiFindPetsByStatusRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Pet[]> {
     const response = await this.findPetsByStatusRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Pet[];
   }
 
   async findPetsByTagsRaw(requestParameters: ApiFindPetsByTagsRequest, initOverrides?: RequestInit
@@ -303,7 +303,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     // Build path with path parameters
     const urlPath = `/pet/findByTags`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     if (requestParameters.tags !== undefined) {
       queryParameters['tags'] = requestParameters.tags;
     }
@@ -328,7 +328,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -336,7 +336,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async findPetsByTags(requestParameters: ApiFindPetsByTagsRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Pet[]> {
     const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Pet[];
   }
 
   async getPetByIdRaw(requestParameters: ApiGetPetByIdRequest, initOverrides?: RequestInit
@@ -351,7 +351,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     let urlPath = `/pet/{petId}`;
     urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -376,7 +376,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 404 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -384,7 +384,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async getPetById(requestParameters: ApiGetPetByIdRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Pet> {
     const response = await this.getPetByIdRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Pet;
   }
 
   async updatePetWithFormRaw(requestParameters: ApiUpdatePetWithFormRequest,
@@ -399,7 +399,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     let urlPath = `/pet/{petId}`;
     urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     if (requestParameters.name !== undefined) {
       queryParameters['name'] = requestParameters.name;
     }
@@ -427,7 +427,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -435,7 +435,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async updatePetWithForm(requestParameters: ApiUpdatePetWithFormRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<Pet> {
     const response = await this.updatePetWithFormRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Pet;
   }
 
   async deletePetRaw(requestParameters: ApiDeletePetRequest, initOverrides?: RequestInit
@@ -450,7 +450,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     let urlPath = `/pet/{petId}`;
     urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -495,7 +495,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
     let urlPath = `/pet/{petId}/uploadImage`;
     urlPath = urlPath.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     if (requestParameters.additionalMetadata !== undefined) {
       queryParameters['additionalMetadata'] = requestParameters.additionalMetadata;
     }
@@ -517,7 +517,7 @@ export class PetApi extends BaseAPI implements PetApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<UploadResponse> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -525,6 +525,6 @@ export class PetApi extends BaseAPI implements PetApiInterface {
   async uploadFile(requestParameters: ApiUploadFileRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<UploadResponse> {
     const response = await this.uploadFileRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as UploadResponse;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/StoreApi.ts.golden
@@ -5,7 +5,7 @@
  * This is a sample Pet Store Server based on the OpenAPI 3.1 specification
  */
 import type { Order } from '../models/Order';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiPlaceOrderRequest {
@@ -28,18 +28,18 @@ export interface ApiDeleteOrderRequest {
 
 export type GetInventoryRawResponse =
   | JSONApiResponse<Record<string, number>> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type PlaceOrderRawResponse =
   | JSONApiResponse<Order> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type GetOrderByIdRawResponse =
   | JSONApiResponse<Order> & { status: 200 }
   | VoidApiResponse & { status: 400 }
   | VoidApiResponse & { status: 404 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type DeleteOrderRawResponse =
   | VoidApiResponse & { status: 200 }
@@ -72,7 +72,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     // Build path with path parameters
     const urlPath = `/store/inventory`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -91,7 +91,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Record<string, number>> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -99,7 +99,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   async getInventory(initOverrides?: RequestInit | InitOverrideFunction): Promise<Record<string,
         number>> {
     const response = await this.getInventoryRaw(initOverrides);
-    return await response.value();
+    return await response.value() as Record<string, number>;
   }
 
   async placeOrderRaw(requestParameters: ApiPlaceOrderRequest, initOverrides?: RequestInit
@@ -113,7 +113,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     // Build path with path parameters
     const urlPath = `/store/order`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -138,7 +138,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -146,7 +146,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   async placeOrder(requestParameters: ApiPlaceOrderRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Order> {
     const response = await this.placeOrderRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Order;
   }
 
   async getOrderByIdRaw(requestParameters: ApiGetOrderByIdRequest, initOverrides?: RequestInit
@@ -161,7 +161,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     let urlPath = `/store/order/{orderId}`;
     urlPath = urlPath.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -186,7 +186,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 404 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -194,7 +194,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
   async getOrderById(requestParameters: ApiGetOrderByIdRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Order> {
     const response = await this.getOrderByIdRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Order;
   }
 
   async deleteOrderRaw(requestParameters: ApiDeleteOrderRequest, initOverrides?: RequestInit
@@ -209,7 +209,7 @@ export class StoreApi extends BaseAPI implements StoreApiInterface {
     let urlPath = `/store/order/{orderId}`;
     urlPath = urlPath.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/apis/UserApi.ts.golden
@@ -5,7 +5,7 @@
  * This is a sample Pet Store Server based on the OpenAPI 3.1 specification
  */
 import type { User } from '../models/User';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiCreateUserRequest {
@@ -51,11 +51,11 @@ export interface ApiDeleteUserRequest {
 
 export type CreateUserRawResponse =
   | JSONApiResponse<User> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type CreateUsersWithListInputRawResponse =
   | JSONApiResponse<User> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type LoginUserRawResponse =
   | VoidApiResponse & { status: 200 }
@@ -70,7 +70,7 @@ export type GetUserByNameRawResponse =
   | JSONApiResponse<User> & { status: 200 }
   | VoidApiResponse & { status: 400 }
   | VoidApiResponse & { status: 404 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type UpdateUserRawResponse =
   | VoidApiResponse & { status: 200 }
@@ -121,7 +121,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     // Build path with path parameters
     const urlPath = `/user`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -143,7 +143,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<User> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -151,7 +151,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   async createUser(requestParameters: ApiCreateUserRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<User> {
     const response = await this.createUserRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as User;
   }
 
   async createUsersWithListInputRaw(requestParameters: ApiCreateUsersWithListInputRequest,
@@ -165,7 +165,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     // Build path with path parameters
     const urlPath = `/user/createWithList`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -187,7 +187,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<User> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -195,7 +195,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   async createUsersWithListInput(requestParameters: ApiCreateUsersWithListInputRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<User> {
     const response = await this.createUsersWithListInputRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as User;
   }
 
   async loginUserRaw(requestParameters: ApiLoginUserRequest, initOverrides?: RequestInit
@@ -203,7 +203,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     // Build path with path parameters
     const urlPath = `/user/login`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     if (requestParameters.username !== undefined) {
       queryParameters['username'] = requestParameters.username;
     }
@@ -246,7 +246,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     // Build path with path parameters
     const urlPath = `/user/logout`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -287,7 +287,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     let urlPath = `/user/{username}`;
     urlPath = urlPath.replace(`{username}`, encodeURIComponent(String(requestParameters.username)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -312,7 +312,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 404 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -320,7 +320,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
   async getUserByName(requestParameters: ApiGetUserByNameRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<User> {
     const response = await this.getUserByNameRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as User;
   }
 
   async updateUserRaw(requestParameters: ApiUpdateUserRequest, initOverrides?: RequestInit
@@ -341,7 +341,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     let urlPath = `/user/{username}`;
     urlPath = urlPath.replace(`{username}`, encodeURIComponent(String(requestParameters.username)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -392,7 +392,7 @@ export class UserApi extends BaseAPI implements UserApiInterface {
     let urlPath = `/user/{username}`;
     urlPath = urlPath.replace(`{username}`, encodeURIComponent(String(requestParameters.username)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/apis/ItemsApi.ts.golden
@@ -6,7 +6,7 @@
  */
 import type { FooStatus } from '../models/FooStatus';
 import type { GetItemsResponse200 } from '../models/GetItemsResponse200';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiGetItemsRequest {
@@ -19,7 +19,7 @@ export interface ApiGetItemsRequest {
 export type GetItemsRawResponse =
   | JSONApiResponse<GetItemsResponse200> & { status: 200 }
   | VoidApiResponse & { status: 400 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface ItemsApiInterface {
@@ -40,7 +40,7 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
     // Build path with path parameters
     const urlPath = `/items`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     if (requestParameters.status !== undefined) {
       queryParameters['status'] = requestParameters.status;
     }
@@ -65,7 +65,7 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 400 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -73,6 +73,6 @@ export class ItemsApi extends BaseAPI implements ItemsApiInterface {
   async getItems(requestParameters: ApiGetItemsRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<GetItemsResponse200> {
     const response = await this.getItemsRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as GetItemsResponse200;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * All Optional Properties Test — 1.0.0
  * Test case for object with all optional properties including arrays, references, and inline objects
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Array of Inline Objects Test — 1.0.0
  * Test case for array of inline objects with snake_case to camelCase conversion (main case from user issue)
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Array of Referenced Types Test — 1.0.0
  * Test case for array of referenced model types with recursive FromJSON calls
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Array with Reference Property Test — 1.0.0
  * Test case for array of inline objects that contain a reference property
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Complex Array Structure Test — 1.0.0
  * Test case for array of inline objects where each object has nested inline objects
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Deeply Nested Inline Objects Test — 1.0.0
  * Test case for three levels of nested inline objects
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Empty Array Test — 1.0.0
  * Test case for empty array handling
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Inline Object with Array Test — 1.0.0
  * Test case for inline object containing an array of inline objects
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Inline Object Test — 1.0.0
  * Test case for inline objects (not arrays) with snake_case to camelCase conversion
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Mixed Property Types Test — 1.0.0
  * Test case for object with mix of simple types, arrays, references, and inline objects
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Nested Object Reference Test — 1.0.0
  * Test case for nested object reference with recursive FromJSON calls
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Optional Array of Inline Objects Test — 1.0.0
  * Test case for optional array of inline objects with snake_case to camelCase conversion
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Optional Array of Referenced Types Test — 1.0.0
  * Test case for optional array of referenced model types
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Optional Inline Object Test — 1.0.0
  * Test case for optional inline objects
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Optional Nested Object Reference Test — 1.0.0
  * Test case for optional nested object reference
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Primitive Array Test — 1.0.0
  * Test case for arrays with primitive items (should not be affected by recursive parsing)
  */
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, VoidApiResponse } from '../runtime/runtime';
 
 export type TestRawResponse =
@@ -29,7 +29,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Covers non-JSON request body media types to pin Content-Type emission.
  */
 import type { Payload } from '../models/Payload';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiPostFormRequest {
@@ -81,7 +81,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/form`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -125,7 +125,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/json`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -169,7 +169,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/json-or-xml`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -213,7 +213,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/text`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'text/plain',
@@ -257,7 +257,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/xml`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/xml',

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/apis/WidgetApi.ts.golden
@@ -5,7 +5,7 @@
  */
 import type { ErrorResponse } from '../models/ErrorResponse';
 import type { Widget } from '../models/Widget';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse } from '../runtime/runtime';
 
 export type GetWidgetRawResponse =
@@ -30,7 +30,7 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
     // Build path with path parameters
     const urlPath = `/widgets`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -57,6 +57,6 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
   async getWidget(initOverrides?: RequestInit | InitOverrideFunction): Promise<Widget
       | ErrorResponse> {
     const response = await this.getWidgetRaw(initOverrides);
-    return await response.value();
+    return await response.value() as Widget | ErrorResponse;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
@@ -152,14 +152,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -167,7 +167,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -175,7 +175,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -237,18 +237,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -275,7 +275,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -325,13 +325,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -384,7 +384,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -402,7 +402,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/apis/DefaultApi.ts.golden
@@ -4,7 +4,7 @@
  * Response Fallback Test API — 1.0.0
  */
 import type { GetFallbackWithBodyResponse200 } from '../models/GetFallbackWithBodyResponse200';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, VoidApiResponse } from '../runtime/runtime';
 
 export type GetFallbackNoBodyRawResponse =
@@ -15,7 +15,7 @@ export type GetFallbackNoBodyRawResponse =
 export type GetFallbackWithBodyRawResponse =
   | JSONApiResponse<GetFallbackWithBodyResponse200> & { status: 200 }
   | VoidApiResponse & { status: 404 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -37,7 +37,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/fallback/no-body`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -73,7 +73,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/fallback/with-body`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -95,13 +95,13 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new VoidApiResponse(response) as VoidApiResponse & { status: 404 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
 
   async getFallbackWithBody(initOverrides?: RequestInit | InitOverrideFunction): Promise<GetFallbackWithBodyResponse200> {
     const response = await this.getFallbackWithBodyRaw(initOverrides);
-    return await response.value();
+    return await response.value() as GetFallbackWithBodyResponse200;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
@@ -152,14 +152,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -167,7 +167,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -175,7 +175,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -237,18 +237,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -275,7 +275,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -325,13 +325,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -384,7 +384,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -402,7 +402,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/apis/WidgetApi.ts.golden
@@ -6,14 +6,14 @@
 import type { ErrorResponse } from '../models/ErrorResponse';
 import type { Widget } from '../models/Widget';
 import type { WidgetListPartial } from '../models/WidgetListPartial';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse } from '../runtime/runtime';
 
 export type ListWidgetsRawResponse =
   | JSONApiResponse<Widget[]> & { status: 200 }
   | JSONApiResponse<WidgetListPartial> & { status: 206 }
   | JSONApiResponse<ErrorResponse> & { status: 404 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface WidgetApiInterface {
@@ -35,7 +35,7 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
     // Build path with path parameters
     const urlPath = `/widgets`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -60,7 +60,7 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<ErrorResponse> & { status: 404 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -69,6 +69,6 @@ export class WidgetApi extends BaseAPI implements WidgetApiInterface {
       | WidgetListPartial
       | ErrorResponse> {
     const response = await this.listWidgetsRaw(initOverrides);
-    return await response.value();
+    return await response.value() as Widget[] | WidgetListPartial | ErrorResponse;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
@@ -152,14 +152,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -167,7 +167,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -175,7 +175,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -237,18 +237,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -275,7 +275,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -325,13 +325,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -384,7 +384,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -402,7 +402,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/apis/FooApi.ts.golden
@@ -5,7 +5,7 @@
  */
 import type { ErrorResponse } from '../models/ErrorResponse';
 import type { FooRequest } from '../models/FooRequest';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError, VoidApiResponse } from '../runtime/runtime';
 
 export interface ApiUpdateFooBarRequest {
@@ -17,7 +17,7 @@ export type UpdateFooBarRawResponse =
   | VoidApiResponse & { status: 204 }
   | JSONApiResponse<ErrorResponse> & { status: 400 }
   | JSONApiResponse<ErrorResponse> & { status: 500 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface FooApiInterface {
@@ -51,7 +51,7 @@ export class FooApi extends BaseAPI implements FooApiInterface {
     let urlPath = `/foo/bar`;
     urlPath = urlPath.replace(`{foo_id}`, encodeURIComponent(String(requestParameters.fooId)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -79,7 +79,7 @@ export class FooApi extends BaseAPI implements FooApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<ErrorResponse> & { status: 500 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -87,6 +87,6 @@ export class FooApi extends BaseAPI implements FooApiInterface {
   async updateFooBar(requestParameters: ApiUpdateFooBarRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<ErrorResponse> {
     const response = await this.updateFooBarRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as ErrorResponse;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
@@ -152,14 +152,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -167,7 +167,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -175,7 +175,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -237,18 +237,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -275,7 +275,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -325,13 +325,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -384,7 +384,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -402,7 +402,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/apis/DefaultApi.ts.golden
@@ -7,7 +7,7 @@
 import type { GetAllUsersResponse200Item } from '../models/GetAllUsersResponse200Item';
 import type { GetUserByIdResponse200 } from '../models/GetUserByIdResponse200';
 import type { GetUserByIdResponse404 } from '../models/GetUserByIdResponse404';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiGetUserByIdRequest {
@@ -19,12 +19,12 @@ export interface ApiGetUserByIdRequest {
 
 export type GetAllUsersRawResponse =
   | JSONApiResponse<GetAllUsersResponse200Item[]> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type GetUserByIdRawResponse =
   | JSONApiResponse<GetUserByIdResponse200> & { status: 200 }
   | JSONApiResponse<GetUserByIdResponse404> & { status: 404 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -47,7 +47,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/users`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -66,14 +66,14 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<GetAllUsersResponse200Item[]> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
 
   async getAllUsers(initOverrides?: RequestInit | InitOverrideFunction): Promise<GetAllUsersResponse200Item[]> {
     const response = await this.getAllUsersRaw(initOverrides);
-    return await response.value();
+    return await response.value() as GetAllUsersResponse200Item[];
   }
 
   async getUserByIdRaw(requestParameters: ApiGetUserByIdRequest, initOverrides?: RequestInit
@@ -88,7 +88,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     let urlPath = `/users/{id}`;
     urlPath = urlPath.replace(`{id}`, encodeURIComponent(String(requestParameters.id)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -110,7 +110,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<GetUserByIdResponse404> & { status: 404 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -118,6 +118,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async getUserById(requestParameters: ApiGetUserByIdRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<GetUserByIdResponse200 | GetUserByIdResponse404> {
     const response = await this.getUserByIdRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as GetUserByIdResponse200 | GetUserByIdResponse404;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for complex union types
  */
 import type { Foo } from '../models/Foo';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiTestComplexUnionRequest {
@@ -14,7 +14,7 @@ export interface ApiTestComplexUnionRequest {
 
 export type TestComplexUnionRawResponse =
   | JSONApiResponse<Foo> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -41,7 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Foo> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -71,6 +71,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testComplexUnion(requestParameters: ApiTestComplexUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Foo> {
     const response = await this.testComplexUnionRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Foo;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.ts.golden
@@ -14,7 +14,7 @@
  * "EventKindUnspecified" instead of generic "Kind".
  */
 import type { Event } from '../models/Event';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiCreateEventRequest {
@@ -23,7 +23,7 @@ export interface ApiCreateEventRequest {
 
 export type CreateEventRawResponse =
   | JSONApiResponse<Event> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -50,7 +50,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/event`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -72,7 +72,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Event> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -80,6 +80,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createEvent(requestParameters: ApiCreateEventRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Event> {
     const response = await this.createEventRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Event;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
@@ -164,14 +164,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -179,7 +179,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -187,7 +187,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -249,18 +249,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -287,7 +287,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -337,13 +337,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -396,7 +396,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -414,7 +414,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.ts.golden
@@ -7,7 +7,7 @@
  * See: https://www.openapis.org/understanding-openapi/specification/models/
  */
 import type { Resource } from '../models/Resource';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiCreateResourceRequest {
@@ -16,7 +16,7 @@ export interface ApiCreateResourceRequest {
 
 export type CreateResourceRawResponse =
   | JSONApiResponse<Resource> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -43,7 +43,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/resource`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -65,7 +65,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Resource> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -73,6 +73,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createResource(requestParameters: ApiCreateResourceRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Resource> {
     const response = await this.createResourceRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Resource;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
@@ -157,14 +157,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -172,7 +172,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -180,7 +180,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -242,18 +242,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -280,7 +280,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -330,13 +330,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -389,7 +389,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -407,7 +407,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/apis/DefaultApi.ts.golden
@@ -9,7 +9,7 @@
  */
 import type { ContainerKind } from '../models/ContainerKind';
 import type { VolumeKind } from '../models/VolumeKind';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiCreateContainerRequest {
@@ -22,11 +22,11 @@ export interface ApiCreateVolumeRequest {
 
 export type CreateContainerRawResponse =
   | JSONApiResponse<ContainerKind> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type CreateVolumeRawResponse =
   | JSONApiResponse<VolumeKind> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -55,7 +55,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/container`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -77,7 +77,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<ContainerKind> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -85,7 +85,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createContainer(requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<ContainerKind> {
     const response = await this.createContainerRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as ContainerKind;
   }
 
   async createVolumeRaw(requestParameters: ApiCreateVolumeRequest, initOverrides?: RequestInit
@@ -99,7 +99,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/volume`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -121,7 +121,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<VolumeKind> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -129,6 +129,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createVolume(requestParameters: ApiCreateVolumeRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<VolumeKind> {
     const response = await this.createVolumeRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as VolumeKind;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
@@ -158,14 +158,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -173,7 +173,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -181,7 +181,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -243,18 +243,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -281,7 +281,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -331,13 +331,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -390,7 +390,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -408,7 +408,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/apis/DefaultApi.ts.golden
@@ -6,7 +6,7 @@
  * This is similar to the ContainerImage pattern in the infiron API.
  */
 import type { ContainerImage } from '../models/ContainerImage';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiCreateContainerRequest {
@@ -15,7 +15,7 @@ export interface ApiCreateContainerRequest {
 
 export type CreateContainerRawResponse =
   | JSONApiResponse<ContainerImage> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -42,7 +42,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/container`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -64,7 +64,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<ContainerImage> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -72,6 +72,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createContainer(requestParameters: ApiCreateContainerRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<ContainerImage> {
     const response = await this.createContainerRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as ContainerImage;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
@@ -156,14 +156,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -171,7 +171,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -179,7 +179,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -241,18 +241,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -279,7 +279,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -329,13 +329,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -388,7 +388,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -406,7 +406,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for allOf intersection types
  */
 import type { Foo } from '../models/Foo';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiTestIntersectionRequest {
@@ -14,7 +14,7 @@ export interface ApiTestIntersectionRequest {
 
 export type TestIntersectionRawResponse =
   | JSONApiResponse<Foo> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -41,7 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Foo> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -71,6 +71,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testIntersection(requestParameters: ApiTestIntersectionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Foo> {
     const response = await this.testIntersectionRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Foo;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for allOf intersection types with nullable reference properties
  */
 import type { Baz } from '../models/Baz';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiCreateTestRequest {
@@ -18,11 +18,11 @@ export interface ApiGetTestRequest {
 
 export type CreateTestRawResponse =
   | JSONApiResponse<Baz> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 export type GetTestRawResponse =
   | JSONApiResponse<Baz> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -51,7 +51,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -73,7 +73,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Baz> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -81,7 +81,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async createTest(requestParameters: ApiCreateTestRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Baz> {
     const response = await this.createTestRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Baz;
   }
 
   async getTestRaw(requestParameters: ApiGetTestRequest, initOverrides?: RequestInit
@@ -96,7 +96,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     let urlPath = `/test/{id}`;
     urlPath = urlPath.replace(`{id}`, encodeURIComponent(String(requestParameters.id)));
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
     };
@@ -115,7 +115,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Baz> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -123,6 +123,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async getTest(requestParameters: ApiGetTestRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Baz> {
     const response = await this.getTestRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Baz;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for union types that reference other union types
  */
 import type { Foo } from '../models/Foo';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiTestNestedUnionRequest {
@@ -14,7 +14,7 @@ export interface ApiTestNestedUnionRequest {
 
 export type TestNestedUnionRawResponse =
   | JSONApiResponse<Foo> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -41,7 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Foo> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -71,6 +71,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testNestedUnion(requestParameters: ApiTestNestedUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Foo> {
     const response = await this.testNestedUnionRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Foo;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for simple type aliases (not unions or intersections)
  */
 import type { Foo } from '../models/Foo';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiTestSimpleAliasRequest {
@@ -14,7 +14,7 @@ export interface ApiTestSimpleAliasRequest {
 
 export type TestSimpleAliasRawResponse =
   | JSONApiResponse<Foo> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -41,7 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Foo> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -71,6 +71,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testSimpleAlias(requestParameters: ApiTestSimpleAliasRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Foo> {
     const response = await this.testSimpleAliasRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Foo;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for union types with both interfaces and primitives
  */
 import type { Foo } from '../models/Foo';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiTestMixedUnionRequest {
@@ -14,7 +14,7 @@ export interface ApiTestMixedUnionRequest {
 
 export type TestMixedUnionRawResponse =
   | JSONApiResponse<Foo> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -41,7 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Foo> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -71,6 +71,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testMixedUnion(requestParameters: ApiTestMixedUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Foo> {
     const response = await this.testMixedUnionRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Foo;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for union types that include the any type
  */
 import type { Config } from '../models/Config';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiTestUnionWithAnyRequest {
@@ -14,7 +14,7 @@ export interface ApiTestUnionWithAnyRequest {
 
 export type TestUnionWithAnyRawResponse =
   | JSONApiResponse<Config> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -41,7 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Config> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -71,6 +71,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testUnionWithAny(requestParameters: ApiTestUnionWithAnyRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Config> {
     const response = await this.testUnionWithAnyRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Config;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for union types (oneOf) with inline object schemas that should generate named interfaces
  */
 import type { Foo } from '../models/Foo';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiTestUnionWithInlineObjectsRequest {
@@ -14,7 +14,7 @@ export interface ApiTestUnionWithInlineObjectsRequest {
 
 export type TestUnionWithInlineObjectsRawResponse =
   | JSONApiResponse<Foo> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -41,7 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Foo> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -71,6 +71,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testUnionWithInlineObjects(requestParameters: ApiTestUnionWithInlineObjectsRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<Foo> {
     const response = await this.testUnionWithInlineObjectsRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Foo;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for oneOf/anyOf union types with interface members
  */
 import type { Foo } from '../models/Foo';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiTestUnionRequest {
@@ -14,7 +14,7 @@ export interface ApiTestUnionRequest {
 
 export type TestUnionRawResponse =
   | JSONApiResponse<Foo> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -41,7 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Foo> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -71,6 +71,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testUnion(requestParameters: ApiTestUnionRequest, initOverrides?: RequestInit
   | InitOverrideFunction): Promise<Foo> {
     const response = await this.testUnionRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Foo;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/apis/DefaultApi.ts.golden
@@ -5,7 +5,7 @@
  * Test fixture for union types with primitive members
  */
 import type { Foo } from '../models/Foo';
-import type { Configuration, InitOverrideFunction } from '../runtime/runtime';
+import type { Configuration, HTTPQuery, InitOverrideFunction } from '../runtime/runtime';
 import { BaseAPI, DefaultConfig, JSONApiResponse, RequiredError } from '../runtime/runtime';
 
 export interface ApiTestUnionPrimitivesRequest {
@@ -14,7 +14,7 @@ export interface ApiTestUnionPrimitivesRequest {
 
 export type TestUnionPrimitivesRawResponse =
   | JSONApiResponse<Foo> & { status: 200 }
-  | JSONApiResponse<any> & { status: number };
+  | JSONApiResponse<unknown> & { status: number };
 
 
 export interface DefaultApiInterface {
@@ -41,7 +41,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
     // Build path with path parameters
     const urlPath = `/test`;
     // Build query parameters
-    const queryParameters: any = {};
+    const queryParameters: HTTPQuery = {};
     // Build headers
     const headerParameters: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
       return new JSONApiResponse(response) as JSONApiResponse<Foo> & { status: 200 };
     }
     else {
-      return new JSONApiResponse(response) as JSONApiResponse<any> & { status: number };
+      return new JSONApiResponse(response) as JSONApiResponse<unknown> & { status: number };
     }
 
   }
@@ -71,6 +71,6 @@ export class DefaultApi extends BaseAPI implements DefaultApiInterface {
   async testUnionPrimitives(requestParameters: ApiTestUnionPrimitivesRequest,
   initOverrides?: RequestInit | InitOverrideFunction): Promise<Foo> {
     const response = await this.testUnionPrimitivesRaw(requestParameters, initOverrides);
-    return await response.value();
+    return await response.value() as Foo;
   }
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
@@ -154,14 +154,14 @@ export class BaseAPI {
                 ? initOverrides
                 : async () => initOverrides;
 
-        const initParams = {
+        const initParams: HTTPRequestInit = {
             method: context.method,
             headers,
             body: context.body,
             credentials: this.configuration.credentials,
         };
 
-        const overriddenInit: RequestInit = {
+        const overriddenInit = {
             ...initParams,
             ...(await initOverrideFn({
                 init: initParams,
@@ -169,7 +169,7 @@ export class BaseAPI {
             }))
         };
 
-        let body: any;
+        let body: BodyInit | null | undefined;
         if (isFormData(overriddenInit.body)
             || (overriddenInit.body instanceof URLSearchParams)
             || isBlob(overriddenInit.body)) {
@@ -177,7 +177,7 @@ export class BaseAPI {
         } else if (this.isJsonMime(headers['Content-Type'])) {
           body = JSON.stringify(overriddenInit.body);
         } else {
-          body = overriddenInit.body;
+          body = overriddenInit.body as BodyInit | null | undefined;
         }
 
         const init: RequestInit = {
@@ -239,18 +239,18 @@ export class BaseAPI {
      * and then shallow cloning data members.
      */
     private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
+        const constructor = this.constructor as new (configuration: Configuration) => T;
         const next = new constructor(this.configuration);
         next.middleware = this.middleware.slice();
         return next;
     }
 }
 
-function isBlob(value: any): value is Blob {
+function isBlob(value: unknown): value is Blob {
     return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
-function isFormData(value: any): value is FormData {
+function isFormData(value: unknown): value is FormData {
     return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
@@ -277,7 +277,7 @@ export class RequiredError extends Error {
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
 
-export type Json = any;
+export type Json = unknown;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
@@ -327,13 +327,13 @@ function querystringSingleKey(key: string, value: string | number | null | undef
     return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
-export function exists(json: any, key: string) {
+export function exists(json: Record<string, unknown>, key: string): boolean {
     const value = json[key];
     return value !== null && value !== undefined;
 }
 
-export function mapValues(data: any, fn: (item: any) => any) {
-    const result: { [key: string]: any } = {};
+export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
+    const result: Record<string, U> = {};
     for (const key of Object.keys(data)) {
         result[key] = fn(data[key]);
     }
@@ -386,7 +386,7 @@ export interface ApiResponse<T> {
 }
 
 export interface ResponseTransformer<T> {
-    (json: any): T;
+    (json: unknown): T;
 }
 
 class ApiResponseBase {
@@ -404,7 +404,7 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: any) => jsonValue) {
+    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
         super(raw);
     }
 


### PR DESCRIPTION
## Summary
- `queryParameters: any` → `HTTPQuery`
- `JSONApiResponse<any>` fallback → `JSONApiResponse<unknown>`
- runtime `Json = any` → `unknown`; `exists`/`mapValues` use generics; `BaseAPI.clone` drops `as any`
- `isBlob`/`isFormData` guards and `ResponseTransformer` json param use `unknown`
- Convenience methods cast `response.value()` to the declared body type (the raw union's `unknown` fallback widens `.value()` otherwise)
- Runtime `createFetchParams` retypes local `body` as `BodyInit | null | undefined`

## Test plan
- [x] `just golden::update-ts` — 50/50 golden tests pass
- [x] `just golden::build-ts` — 47/47 generated TS projects compile under `strict`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all` green

Closes #32