### PR TITLE
fix(typescript-fetch): unify runtime.ts indentation to 2-space

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/project_files/runtime.ts.txt
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/project_files/runtime.ts.txt
@@ -1,72 +1,72 @@
 export const BASE_PATH = "{{BASE_PATH}}".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -76,191 +76,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -276,157 +276,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
@@ -11,72 +11,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -86,191 +86,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -286,157 +286,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
@@ -11,72 +11,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -86,191 +86,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -286,157 +286,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
@@ -11,72 +11,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -86,191 +86,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -286,157 +286,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
@@ -11,72 +11,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -86,191 +86,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -286,157 +286,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
@@ -11,72 +11,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -86,191 +86,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -286,157 +286,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "https://api.example.com/v1".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
@@ -23,72 +23,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -98,191 +98,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -298,157 +298,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
@@ -16,72 +16,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -91,191 +91,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -291,157 +291,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
@@ -17,72 +17,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -92,191 +92,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -292,157 +292,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
@@ -15,72 +15,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -90,191 +90,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -290,157 +290,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
@@ -13,72 +13,72 @@
 export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+  basePath?: string; // override base path
+  fetchApi?: FetchAPI; // override for fetch implementation
+  middleware?: Middleware[]; // middleware to apply before/after fetch requests
+  queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
+  username?: string; // parameter for basic security
+  password?: string; // parameter for basic security
+  apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
+  accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
+  headers?: HTTPHeaders; //header params we want to use on every request
+  credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
-    constructor(private configuration: ConfigurationParameters = {}) {}
+  constructor(private configuration: ConfigurationParameters = {}) {}
 
-    set config(configuration: Configuration) {
-        this.configuration = configuration;
-    }
+  set config(configuration: Configuration) {
+    this.configuration = configuration;
+  }
 
-    get basePath(): string {
-        return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
-    }
+  get basePath(): string {
+    return this.configuration.basePath != null ? this.configuration.basePath : BASE_PATH;
+  }
 
-    get fetchApi(): FetchAPI | undefined {
-        return this.configuration.fetchApi;
-    }
+  get fetchApi(): FetchAPI | undefined {
+    return this.configuration.fetchApi;
+  }
 
-    get middleware(): Middleware[] {
-        return this.configuration.middleware || [];
-    }
+  get middleware(): Middleware[] {
+    return this.configuration.middleware || [];
+  }
 
-    get queryParamsStringify(): (params: HTTPQuery) => string {
-        return this.configuration.queryParamsStringify || querystring;
-    }
+  get queryParamsStringify(): (params: HTTPQuery) => string {
+    return this.configuration.queryParamsStringify || querystring;
+  }
 
-    get username(): string | undefined {
-        return this.configuration.username;
-    }
+  get username(): string | undefined {
+    return this.configuration.username;
+  }
 
-    get password(): string | undefined {
-        return this.configuration.password;
-    }
+  get password(): string | undefined {
+    return this.configuration.password;
+  }
 
-    get apiKey(): ((name: string) => string | Promise<string>) | undefined {
-        const apiKey = this.configuration.apiKey;
-        if (apiKey) {
-            return typeof apiKey === 'function' ? apiKey : () => apiKey;
-        }
-        return undefined;
+  get apiKey(): ((name: string) => string | Promise<string>) | undefined {
+    const apiKey = this.configuration.apiKey;
+    if (apiKey) {
+      return typeof apiKey === 'function' ? apiKey : () => apiKey;
     }
+    return undefined;
+  }
 
-    get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
-        const accessToken = this.configuration.accessToken;
-        if (accessToken) {
-            return typeof accessToken === 'function' ? accessToken : async () => accessToken;
-        }
-        return undefined;
+  get accessToken(): ((name?: string, scopes?: string[]) => string | Promise<string>) | undefined {
+    const accessToken = this.configuration.accessToken;
+    if (accessToken) {
+      return typeof accessToken === 'function' ? accessToken : async () => accessToken;
     }
+    return undefined;
+  }
 
-    get headers(): HTTPHeaders | undefined {
-        return this.configuration.headers;
-    }
+  get headers(): HTTPHeaders | undefined {
+    return this.configuration.headers;
+  }
 
-    get credentials(): RequestCredentials | undefined {
-        return this.configuration.credentials;
-    }
+  get credentials(): RequestCredentials | undefined {
+    return this.configuration.credentials;
+  }
 }
 
 export const DefaultConfig = new Configuration();
@@ -88,191 +88,191 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
-    private middleware: Middleware[];
+  private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  private middleware: Middleware[];
 
-    constructor(protected configuration = DefaultConfig) {
-        this.middleware = configuration.middleware;
+  constructor(protected configuration = DefaultConfig) {
+    this.middleware = configuration.middleware;
+  }
+
+  withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    const next = this.clone<T>();
+    next.middleware = next.middleware.concat(...middlewares);
+    return next;
+  }
+
+  withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
+    const middlewares = preMiddlewares.map((pre) => ({ pre }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
+    const middlewares = postMiddlewares.map((post) => ({ post }));
+    return this.withMiddleware<T>(...middlewares);
+  }
+
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  protected isJsonMime(mime: string | null | undefined): boolean {
+    if (!mime) {
+      return false;
+    }
+    return BaseAPI.jsonRegex.test(mime);
+  }
+
+  protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
+    const { url, init } = await this.createFetchParams(context, initOverrides);
+    const response = await this.fetchApi(url, init);
+    if (response && (response.status >= 200 && response.status < 300)) {
+      return response;
+    }
+    throw new ResponseError(response, 'Response returned an error code');
+  }
+
+  private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
+    let url = this.configuration.basePath + context.path;
+    if (context.query !== undefined && Object.keys(context.query).length !== 0) {
+      // only add the querystring to the URL if there are query parameters.
+      // this is done to avoid urls ending with a "?" character which buggy webservers
+      // do not handle correctly sometimes.
+      url += '?' + this.configuration.queryParamsStringify(context.query);
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
-        const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
-        return next;
+    const headers = Object.assign({}, this.configuration.headers, context.headers);
+    Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
+
+    const initOverrideFn =
+      typeof initOverrides === "function"
+        ? initOverrides
+        : async () => initOverrides;
+
+    const initParams: HTTPRequestInit = {
+      method: context.method,
+      headers,
+      body: context.body,
+      credentials: this.configuration.credentials,
+    };
+
+    const overriddenInit = {
+      ...initParams,
+      ...(await initOverrideFn({
+        init: initParams,
+        context,
+      }))
+    };
+
+    let body: BodyInit | null | undefined;
+    if (isFormData(overriddenInit.body)
+      || (overriddenInit.body instanceof URLSearchParams)
+      || isBlob(overriddenInit.body)) {
+      body = overriddenInit.body;
+    } else if (this.isJsonMime(headers['Content-Type'])) {
+      body = JSON.stringify(overriddenInit.body);
+    } else {
+      body = overriddenInit.body as BodyInit | null | undefined;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    const init: RequestInit = {
+      ...overriddenInit,
+      body
+    };
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    return { url, init };
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    protected isJsonMime(mime: string | null | undefined): boolean {
-        if (!mime) {
-            return false;
+  private fetchApi = async (url: string, init: RequestInit) => {
+    let fetchParams = { url, init };
+    for (const middleware of this.middleware) {
+      if (middleware.pre) {
+        fetchParams = await middleware.pre({
+          fetch: this.fetchApi,
+          ...fetchParams,
+        }) || fetchParams;
+      }
+    }
+    let response: Response | undefined = undefined;
+    try {
+      response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
+    } catch (e) {
+      for (const middleware of this.middleware) {
+        if (middleware.onError) {
+          response = await middleware.onError({
+            fetch: this.fetchApi,
+            url: fetchParams.url,
+            init: fetchParams.init,
+            error: e,
+            response: response ? response.clone() : undefined,
+          }) || response;
         }
-        return BaseAPI.jsonRegex.test(mime);
-    }
-
-    protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
-        const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
-        }
-        throw new ResponseError(response, 'Response returned an error code');
-    }
-
-    private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {
-        let url = this.configuration.basePath + context.path;
-        if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
-            // this is done to avoid urls ending with a "?" character which buggy webservers
-            // do not handle correctly sometimes.
-            url += '?' + this.configuration.queryParamsStringify(context.query);
-        }
-
-        const headers = Object.assign({}, this.configuration.headers, context.headers);
-        Object.keys(headers).forEach(key => headers[key] === undefined ? delete headers[key] : {});
-
-        const initOverrideFn =
-            typeof initOverrides === "function"
-                ? initOverrides
-                : async () => initOverrides;
-
-        const initParams: HTTPRequestInit = {
-            method: context.method,
-            headers,
-            body: context.body,
-            credentials: this.configuration.credentials,
-        };
-
-        const overriddenInit = {
-            ...initParams,
-            ...(await initOverrideFn({
-                init: initParams,
-                context,
-            }))
-        };
-
-        let body: BodyInit | null | undefined;
-        if (isFormData(overriddenInit.body)
-            || (overriddenInit.body instanceof URLSearchParams)
-            || isBlob(overriddenInit.body)) {
-          body = overriddenInit.body;
-        } else if (this.isJsonMime(headers['Content-Type'])) {
-          body = JSON.stringify(overriddenInit.body);
+      }
+      if (response === undefined) {
+        if (e instanceof Error) {
+          throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
         } else {
-          body = overriddenInit.body as BodyInit | null | undefined;
+          throw e;
         }
-
-        const init: RequestInit = {
-            ...overriddenInit,
-            body
-        };
-
-        return { url, init };
+      }
     }
-
-    private fetchApi = async (url: string, init: RequestInit) => {
-        let fetchParams = { url, init };
-        for (const middleware of this.middleware) {
-            if (middleware.pre) {
-                fetchParams = await middleware.pre({
-                    fetch: this.fetchApi,
-                    ...fetchParams,
-                }) || fetchParams;
-            }
-        }
-        let response: Response | undefined = undefined;
-        try {
-            response = await (this.configuration.fetchApi || fetch)(fetchParams.url, fetchParams.init);
-        } catch (e) {
-            for (const middleware of this.middleware) {
-                if (middleware.onError) {
-                    response = await middleware.onError({
-                        fetch: this.fetchApi,
-                        url: fetchParams.url,
-                        init: fetchParams.init,
-                        error: e,
-                        response: response ? response.clone() : undefined,
-                    }) || response;
-                }
-            }
-            if (response === undefined) {
-              if (e instanceof Error) {
-                throw new FetchError(e, 'The request failed and the interceptors did not return an alternative response');
-              } else {
-                throw e;
-              }
-            }
-        }
-        for (const middleware of this.middleware) {
-            if (middleware.post) {
-                response = await middleware.post({
-                    fetch: this.fetchApi,
-                    url: fetchParams.url,
-                    init: fetchParams.init,
-                    response: response.clone(),
-                }) || response;
-            }
-        }
-        return response;
+    for (const middleware of this.middleware) {
+      if (middleware.post) {
+        response = await middleware.post({
+          fetch: this.fetchApi,
+          url: fetchParams.url,
+          init: fetchParams.init,
+          response: response.clone(),
+        }) || response;
+      }
     }
+    return response;
+  }
 
-    /**
-     * Create a shallow clone of `this` by constructing a new instance
-     * and then shallow cloning data members.
-     */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as new (configuration: Configuration) => T;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+  /**
+   * Create a shallow clone of `this` by constructing a new instance
+   * and then shallow cloning data members.
+   */
+  private clone<T extends BaseAPI>(this: T): T {
+    const constructor = this.constructor as new (configuration: Configuration) => T;
+    const next = new constructor(this.configuration);
+    next.middleware = this.middleware.slice();
+    return next;
+  }
 }
 
 function isBlob(value: unknown): value is Blob {
-    return typeof Blob !== 'undefined' && value instanceof Blob;
+  return typeof Blob !== 'undefined' && value instanceof Blob;
 }
 
 function isFormData(value: unknown): value is FormData {
-    return typeof FormData !== "undefined" && value instanceof FormData;
+  return typeof FormData !== "undefined" && value instanceof FormData;
 }
 
 export class ResponseError extends Error {
-    override name: "ResponseError" = "ResponseError";
-    constructor(public response: Response, msg?: string) {
-        super(msg);
-    }
+  override name: "ResponseError" = "ResponseError";
+  constructor(public response: Response, msg?: string) {
+    super(msg);
+  }
 }
 
 export class FetchError extends Error {
-    override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
-        super(msg);
-    }
+  override name: "FetchError" = "FetchError";
+  constructor(public cause: Error, msg?: string) {
+    super(msg);
+  }
 }
 
 export class RequiredError extends Error {
-    override name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
+  override name: "RequiredError" = "RequiredError";
+  constructor(public field: string, msg?: string) {
+    super(msg);
+  }
 }
 
 export type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
@@ -288,157 +288,157 @@ export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'o
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
 
 export interface FetchParams {
-    url: string;
-    init: RequestInit;
+  url: string;
+  init: RequestInit;
 }
 
 export interface RequestOpts {
-    path: string;
-    method: HTTPMethod;
-    headers: HTTPHeaders;
-    query?: HTTPQuery;
-    body?: HTTPBody;
+  path: string;
+  method: HTTPMethod;
+  headers: HTTPHeaders;
+  query?: HTTPQuery;
+  body?: HTTPBody;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
-    return Object.keys(params)
-        .map(key => querystringSingleKey(key, params[key], prefix))
-        .filter(part => part.length > 0)
-        .join('&');
+  return Object.keys(params)
+    .map(key => querystringSingleKey(key, params[key], prefix))
+    .filter(part => part.length > 0)
+    .join('&');
 }
 
 function querystringSingleKey(key: string, value: string | number | null | undefined | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery, keyPrefix: string = ''): string {
-    const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
-    if (value instanceof Array) {
-        const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
-            .join(`&${encodeURIComponent(fullKey)}=`);
-        return `${encodeURIComponent(fullKey)}=${multiValue}`;
-    }
-    if (value instanceof Set) {
-        const valueAsArray = Array.from(value);
-        return querystringSingleKey(key, valueAsArray, keyPrefix);
-    }
-    if (value instanceof Date) {
-        return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
-    }
-    if (value instanceof Object) {
-        return querystring(value as HTTPQuery, fullKey);
-    }
-    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
+  const fullKey = keyPrefix + (keyPrefix.length ? `[${key}]` : key);
+  if (value instanceof Array) {
+    const multiValue = value.map(singleValue => encodeURIComponent(String(singleValue)))
+      .join(`&${encodeURIComponent(fullKey)}=`);
+    return `${encodeURIComponent(fullKey)}=${multiValue}`;
+  }
+  if (value instanceof Set) {
+    const valueAsArray = Array.from(value);
+    return querystringSingleKey(key, valueAsArray, keyPrefix);
+  }
+  if (value instanceof Date) {
+    return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
+  }
+  if (value instanceof Object) {
+    return querystring(value as HTTPQuery, fullKey);
+  }
+  return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
 }
 
 export function exists(json: Record<string, unknown>, key: string): boolean {
-    const value = json[key];
-    return value !== null && value !== undefined;
+  const value = json[key];
+  return value !== null && value !== undefined;
 }
 
 export function mapValues<T, U>(data: Record<string, T>, fn: (item: T) => U): Record<string, U> {
-    const result: Record<string, U> = {};
-    for (const key of Object.keys(data)) {
-        result[key] = fn(data[key]);
-    }
-    return result;
+  const result: Record<string, U> = {};
+  for (const key of Object.keys(data)) {
+    result[key] = fn(data[key]);
+  }
+  return result;
 }
 
 export function canConsumeForm(consumes: Consume[]): boolean {
-    for (const consume of consumes) {
-        if ('multipart/form-data' === consume.contentType) {
-            return true;
-        }
+  for (const consume of consumes) {
+    if ('multipart/form-data' === consume.contentType) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 export interface Consume {
-    contentType: string;
+  contentType: string;
 }
 
 export interface RequestContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
 }
 
 export interface ResponseContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    response: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
 }
 
 export interface ErrorContext {
-    fetch: FetchAPI;
-    url: string;
-    init: RequestInit;
-    error: unknown;
-    response?: Response;
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  error: unknown;
+  response?: Response;
 }
 
 export interface Middleware {
-    pre?(context: RequestContext): Promise<FetchParams | void>;
-    post?(context: ResponseContext): Promise<Response | void>;
-    onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+  onError?(context: ErrorContext): Promise<Response | void>;
 }
 
 export interface ApiResponse<T> {
-    raw: Response;
-    value(): Promise<T>;
+  raw: Response;
+  value(): Promise<T>;
 }
 
 export interface ResponseTransformer<T> {
-    (json: unknown): T;
+  (json: unknown): T;
 }
 
 class ApiResponseBase {
-    public readonly status: number;
-    public readonly ok: boolean;
-    public readonly statusText: string;
-    public readonly headers: Headers;
+  public readonly status: number;
+  public readonly ok: boolean;
+  public readonly statusText: string;
+  public readonly headers: Headers;
 
-    constructor(public readonly raw: Response) {
-        this.status = raw.status;
-        this.ok = raw.ok;
-        this.statusText = raw.statusText;
-        this.headers = raw.headers;
-    }
+  constructor(public readonly raw: Response) {
+    this.status = raw.status;
+    this.ok = raw.ok;
+    this.statusText = raw.statusText;
+    this.headers = raw.headers;
+  }
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-    constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
-        super(raw);
-    }
+  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+    super(raw);
+  }
 
-    async value(): Promise<T> {
-        return this.transformer(await this.raw.json());
-    }
+  async value(): Promise<T> {
+    return this.transformer(await this.raw.json());
+  }
 }
 
 export class VoidApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<void> {
-        return undefined;
-    }
+  async value(): Promise<void> {
+    return undefined;
+  }
 }
 
 export class BlobApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<Blob> {
-        return await this.raw.blob();
-    };
+  async value(): Promise<Blob> {
+    return await this.raw.blob();
+  };
 }
 
 export class TextApiResponse extends ApiResponseBase {
-    constructor(raw: Response) {
-        super(raw);
-    }
+  constructor(raw: Response) {
+    super(raw);
+  }
 
-    async value(): Promise<string> {
-        return await this.raw.text();
-    };
+  async value(): Promise<string> {
+    return await this.raw.text();
+  };
 }


### PR DESCRIPTION
## Summary
- Convert `runtime.ts` from 4-space to 2-space indentation to match models/APIs and the TypeScript ecosystem default.
- Fixes a stray off-grid indent inside the `fetchApi` catch block where the inner `if (e instanceof Error)` / `else` throws weren't nested properly.
- Updates all 47 golden fixtures.

## Test plan
- [x] `just golden::update-ts` (50 tests pass)
- [x] `just golden::build-ts` (47/47 compile with `tsc --noEmit`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all` passes

Closes #35