### PR TITLE
feat(typescript-fetch): add AbortSignal support to RequestOpts and runtime

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/project_files/runtime.ts.txt
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/project_files/runtime.ts.txt
@@ -147,6 +147,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -270,7 +271,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -286,6 +287,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
@@ -157,6 +157,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -280,7 +281,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -296,6 +297,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
@@ -157,6 +157,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -280,7 +281,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -296,6 +297,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
@@ -157,6 +157,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -280,7 +281,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -296,6 +297,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
@@ -157,6 +157,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -280,7 +281,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -296,6 +297,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
@@ -157,6 +157,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -280,7 +281,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -296,6 +297,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
@@ -169,6 +169,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -292,7 +293,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -308,6 +309,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
@@ -162,6 +162,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -285,7 +286,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -301,6 +302,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
@@ -163,6 +163,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -286,7 +287,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -302,6 +303,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
@@ -161,6 +161,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -284,7 +285,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -300,6 +301,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
@@ -159,6 +159,7 @@ export class BaseAPI {
       headers,
       body: context.body,
       credentials: this.configuration.credentials,
+      signal: context.signal,
     };
 
     const overriddenInit = {
@@ -282,7 +283,7 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | Set<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData | URLSearchParams;
-export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody };
+export type HTTPRequestInit = { headers?: HTTPHeaders; method: HTTPMethod; credentials?: RequestCredentials; body?: HTTPBody; signal?: AbortSignal };
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export type InitOverrideFunction = (requestContext: { init: HTTPRequestInit, context: RequestOpts }) => Promise<RequestInit>
@@ -298,6 +299,7 @@ export interface RequestOpts {
   headers: HTTPHeaders;
   query?: HTTPQuery;
   body?: HTTPBody;
+  signal?: AbortSignal;
 }
 
 export function querystring(params: HTTPQuery, prefix: string = ''): string {


### PR DESCRIPTION
## Summary
- Add `signal?: AbortSignal` to `RequestOpts` and `HTTPRequestInit` in the runtime.
- Plumb signal through `createFetchParams` into `initParams` so it reaches `fetch()`.
- `initOverrides` can still override signal via spread (existing behavior preserved).

## Test plan
- [x] `just golden::update-ts` (50 tests pass)
- [x] `just golden::build-ts` (47/47 compile with `tsc --noEmit`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all` passes

Closes #37