### PR TITLE
fix(typescript-fetch): collapse nullable+optional fields to two states

### DIFF
--- a/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit.rs
+++ b/crates/generators/openapi-nexus-typescript-fetch/src/sigil_emit.rs
@@ -297,7 +297,7 @@ fn json_value_to_ts_literal(v: &serde_json::Value) -> Option<String> {
 fn build_field(prop: &IrProperty) -> FieldSpec<TypeScript> {
     let ts_field_name = prop.name.to_lower_camel_case();
     let inner_ty = type_expr_to_typename(&prop.type_expr);
-    let field_ty = if prop.nullable {
+    let field_ty = if prop.nullable && prop.required {
         TypeName::optional(inner_ty)
     } else {
         inner_ty

--- a/tests/golden/typescript/typescript-fetch/additional-properties/models/LeafValue.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/models/LeafValue.ts.golden
@@ -19,7 +19,7 @@ export interface LeafValue {
   /**
    * Optional label.
    */
-  readonly label?: string | null;
+  readonly label?: string;
   /**
    * Scores by name (additionalProperties: integer).
    */

--- a/tests/golden/typescript/typescript-fetch/petstore/models/Category.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/Category.ts.golden
@@ -11,9 +11,9 @@ export interface Category {
   /**
    * Category ID
    */
-  readonly id?: number | null;
+  readonly id?: number;
   /**
    * Category name
    */
-  readonly name?: string | null;
+  readonly name?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/Order.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/Order.ts.golden
@@ -13,22 +13,22 @@ export interface Order {
   /**
    * Complete flag
    */
-  readonly complete?: boolean | null;
+  readonly complete?: boolean;
   /**
    * Order ID
    */
-  readonly id?: number | null;
+  readonly id?: number;
   /**
    * Pet ID
    */
-  readonly petId?: number | null;
+  readonly petId?: number;
   /**
    * Quantity
    */
-  readonly quantity?: number | null;
+  readonly quantity?: number;
   /**
    * Ship date
    */
-  readonly shipDate?: string | null;
-  readonly status?: OrderStatus | null;
+  readonly shipDate?: string;
+  readonly status?: OrderStatus;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/Pet.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/Pet.ts.golden
@@ -12,11 +12,11 @@ import type { Tag } from './Tag';
  * Pet model
  */
 export interface Pet {
-  readonly category?: Category | null;
+  readonly category?: Category;
   /**
    * Pet ID
    */
-  readonly id?: number | null;
+  readonly id?: number;
   /**
    * Pet name
    */
@@ -25,9 +25,9 @@ export interface Pet {
    * Photo URLs
    */
   readonly photoUrls: readonly string[];
-  readonly status?: PetStatus | null;
+  readonly status?: PetStatus;
   /**
    * Pet tags
    */
-  readonly tags?: readonly Tag[] | null;
+  readonly tags?: readonly Tag[];
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/Tag.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/Tag.ts.golden
@@ -11,9 +11,9 @@ export interface Tag {
   /**
    * Tag ID
    */
-  readonly id?: number | null;
+  readonly id?: number;
   /**
    * Tag name
    */
-  readonly name?: string | null;
+  readonly name?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/UploadResponse.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/UploadResponse.ts.golden
@@ -11,13 +11,13 @@ export interface UploadResponse {
   /**
    * Response code
    */
-  readonly code?: number | null;
+  readonly code?: number;
   /**
    * Response message
    */
-  readonly message?: string | null;
+  readonly message?: string;
   /**
    * Response type
    */
-  readonly type_?: string | null;
+  readonly type_?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/petstore/models/User.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/models/User.ts.golden
@@ -11,33 +11,33 @@ export interface User {
   /**
    * Email
    */
-  readonly email?: string | null;
+  readonly email?: string;
   /**
    * First name
    */
-  readonly firstName?: string | null;
+  readonly firstName?: string;
   /**
    * User ID
    */
-  readonly id?: number | null;
+  readonly id?: number;
   /**
    * Last name
    */
-  readonly lastName?: string | null;
+  readonly lastName?: string;
   /**
    * Password
    */
-  readonly password?: string | null;
+  readonly password?: string;
   /**
    * Phone
    */
-  readonly phone?: string | null;
+  readonly phone?: string;
   /**
    * User status
    */
-  readonly userStatus?: number | null;
+  readonly userStatus?: number;
   /**
    * Username
    */
-  readonly username?: string | null;
+  readonly username?: string;
 }

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/models/BazAllOf2.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/models/BazAllOf2.ts.golden
@@ -10,5 +10,5 @@ export interface BazAllOf2 {
   /**
    * Metadata (nullable)
    */
-  readonly metaData?: Bar | null;
+  readonly metaData?: Bar;
 }


### PR DESCRIPTION
## Summary
- When a field is both optional and nullable, drop `| null` and rely on `?` alone (`readonly field?: T`).
- Required + nullable keeps `readonly field: T | null` (two states, not three).
- One-line change in `build_field` in `sigil_emit.rs`: only apply `TypeName::optional` (which adds `| null`) when `prop.nullable && prop.required`.

## Before / After

```ts
// Before: three states (T, null, undefined)
readonly category?: Category | null;
readonly tags?: readonly Tag[] | null;

// After: two states (T or absent)
readonly category?: Category;
readonly tags?: readonly Tag[];
```

## Test plan
- [x] `just golden::update-ts` (50 tests pass)
- [x] `just golden::build-ts` (47/47 compile with `tsc --noEmit`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all` passes

Closes #41