### PR TITLE
feat: add OpenAPI 3.2 spec types, parsing, and IR lowering

### DIFF
--- a/crates/openapi-nexus-ir/src/lower/mod.rs
+++ b/crates/openapi-nexus-ir/src/lower/mod.rs
@@ -5,6 +5,7 @@
 //! Dispatches to version-specific lowering functions that all produce the same `IrSpec`.
 
 pub mod v31;
+pub mod v32;
 
 use crate::types::IrSpec;
 use openapi_nexus_parser::ParsedSpec;
@@ -20,6 +21,7 @@ pub fn lower(parsed: ParsedSpec) -> Result<IrSpec, LowerError> {
 fn lower_impl(parsed: &ParsedSpec) -> Result<IrSpec, LowerError> {
     match parsed {
         ParsedSpec::V31(spec) => v31::lower_v31(spec),
+        ParsedSpec::V32(spec) => v32::lower_v32(spec),
         ParsedSpec::V30(_) => Err(LowerError::UnsupportedVersion {
             version: "3.0".to_string(),
         }),

--- a/crates/openapi-nexus-ir/src/lower/v32.rs
+++ b/crates/openapi-nexus-ir/src/lower/v32.rs
@@ -1,9 +1,9 @@
-//! OpenAPI v3.1 → IR lowering.
+//! OpenAPI v3.2 → IR lowering.
 
 use heck::ToPascalCase;
 use indexmap::IndexMap;
 
-use openapi_nexus_spec::oas31::spec::{
+use openapi_nexus_spec::oas32::spec::{
     self as oas, ObjectOrReference, ObjectSchema, Schema, SchemaType, SchemaTypeSet,
 };
 
@@ -20,7 +20,7 @@ use crate::types::{
 // Public entry point
 // ---------------------------------------------------------------------------
 
-pub fn lower_v31(spec: &oas::OpenApiV31Spec) -> Result<IrSpec, LowerError> {
+pub fn lower_v32(spec: &oas::OpenApiV32Spec) -> Result<IrSpec, LowerError> {
     let mut ctx = LowerCtx::new(spec);
 
     // 1. Lower component schemas
@@ -93,7 +93,7 @@ pub fn lower_v31(spec: &oas::OpenApiV31Spec) -> Result<IrSpec, LowerError> {
 // ---------------------------------------------------------------------------
 
 struct LowerCtx<'a> {
-    spec: &'a oas::OpenApiV31Spec,
+    spec: &'a oas::OpenApiV32Spec,
     schemas: IndexMap<String, IrSchema>,
     used_names: std::collections::HashSet<String>,
     /// When true, promoted schemas are marked as component schemas.
@@ -101,7 +101,7 @@ struct LowerCtx<'a> {
 }
 
 impl<'a> LowerCtx<'a> {
-    fn new(spec: &'a oas::OpenApiV31Spec) -> Self {
+    fn new(spec: &'a oas::OpenApiV32Spec) -> Self {
         let mut used_names = std::collections::HashSet::new();
         if let Some(components) = &spec.components {
             for name in components.schemas.keys() {
@@ -274,7 +274,7 @@ impl<'a> LowerCtx<'a> {
         let patterns: Vec<Option<TaggedEnumPattern>> = obj
             .one_of
             .iter()
-            .map(TaggedEnumPattern::detect_from_schema)
+            .map(TaggedEnumPattern::detect_from_schema_v32)
             .collect();
 
         // All must match for it to be a tagged union
@@ -400,7 +400,7 @@ impl<'a> LowerCtx<'a> {
         }
 
         Ok(Some(IrTaggedUnion {
-            discriminator_field: disc.property_name.clone(),
+            discriminator_field: disc.property_name.clone().unwrap_or_default(),
             tagging: TaggingStyle::Internal,
             variants,
         }))
@@ -789,6 +789,7 @@ impl<'a> LowerCtx<'a> {
         lower_method!(head, "HEAD");
         lower_method!(patch, "PATCH");
         lower_method!(trace, "TRACE");
+        lower_method!(query, "QUERY");
 
         Ok(ops)
     }
@@ -905,6 +906,7 @@ impl<'a> LowerCtx<'a> {
                 oas::ParameterIn::Query => ParameterLocation::Query,
                 oas::ParameterIn::Header => ParameterLocation::Header,
                 oas::ParameterIn::Cookie => ParameterLocation::Cookie,
+                oas::ParameterIn::Querystring => ParameterLocation::Query,
             },
             type_expr,
             required: param.required.unwrap_or(false),
@@ -984,6 +986,7 @@ impl<'a> LowerCtx<'a> {
         resp: &oas::Response,
     ) -> Result<IrResponse, LowerError> {
         let mut content = IndexMap::new();
+        let mut item_content = IndexMap::new();
         for (mime, media_type) in &resp.content {
             if let Some(schema_ref) = &media_type.schema {
                 let type_expr = self.lower_schema_ref_with_promotion(
@@ -991,6 +994,13 @@ impl<'a> LowerCtx<'a> {
                     schema_ref,
                 )?;
                 content.insert(mime.clone(), type_expr);
+            }
+            if let Some(item_schema_ref) = &media_type.item_schema {
+                let type_expr = self.lower_schema_ref_with_promotion(
+                    &format!("{parent_name}Response{status}Item"),
+                    item_schema_ref,
+                )?;
+                item_content.insert(mime.clone(), type_expr);
             }
         }
 
@@ -1016,7 +1026,7 @@ impl<'a> LowerCtx<'a> {
             status: status.to_string(),
             description: resp.description.clone().unwrap_or_default(),
             content,
-            item_content: IndexMap::new(),
+            item_content,
             headers,
         })
     }
@@ -1407,15 +1417,15 @@ mod tests {
     use super::*;
 
     fn lower_yaml(yaml: &str) -> IrSpec {
-        let spec = openapi_nexus_parser::parse_content_yaml_v31(yaml).unwrap();
-        lower_v31(&spec).unwrap()
+        let parsed = openapi_nexus_parser::parse_content_yaml(yaml).unwrap();
+        lower_v32(parsed.as_v32().unwrap()).unwrap()
     }
 
     #[test]
     fn test_lower_minimal_spec() {
         let ir = lower_yaml(
             r#"
-openapi: "3.1.0"
+openapi: "3.2.0"
 info:
   title: Test
   version: "1.0"
@@ -1432,7 +1442,7 @@ paths: {}
     fn test_lower_simple_object_schema() {
         let ir = lower_yaml(
             r#"
-openapi: "3.1.0"
+openapi: "3.2.0"
 info:
   title: Test
   version: "1.0"
@@ -1465,7 +1475,7 @@ components:
     fn test_lower_string_enum() {
         let ir = lower_yaml(
             r#"
-openapi: "3.1.0"
+openapi: "3.2.0"
 info:
   title: Test
   version: "1.0"
@@ -1491,7 +1501,7 @@ components:
     fn test_lower_nullable_type() {
         let ir = lower_yaml(
             r#"
-openapi: "3.1.0"
+openapi: "3.2.0"
 info:
   title: Test
   version: "1.0"
@@ -1515,7 +1525,7 @@ components:
     fn test_lower_operation() {
         let ir = lower_yaml(
             r#"
-openapi: "3.1.0"
+openapi: "3.2.0"
 info:
   title: Test
   version: "1.0"
@@ -1554,7 +1564,7 @@ paths:
     fn test_lower_array_alias() {
         let ir = lower_yaml(
             r#"
-openapi: "3.1.0"
+openapi: "3.2.0"
 info:
   title: Test
   version: "1.0"
@@ -1578,7 +1588,7 @@ components:
     fn test_lower_ref_schema() {
         let ir = lower_yaml(
             r##"
-openapi: "3.1.0"
+openapi: "3.2.0"
 info:
   title: Test
   version: "1.0"
@@ -1600,5 +1610,63 @@ components:
         } else {
             panic!("Expected Named alias");
         }
+    }
+
+    #[test]
+    fn test_lower_query_method() {
+        let ir = lower_yaml(
+            r#"
+openapi: "3.2.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /search:
+    query:
+      operationId: searchItems
+      responses:
+        "200":
+          description: OK
+"#,
+        );
+        assert_eq!(ir.operations.len(), 1);
+        let op = &ir.operations[0];
+        assert_eq!(op.operation_id, "searchItems");
+        assert_eq!(op.method, "QUERY");
+        assert_eq!(op.path, "/search");
+    }
+
+    #[test]
+    fn test_lower_item_schema_streaming() {
+        let ir = lower_yaml(
+            r#"
+openapi: "3.2.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /events:
+    get:
+      operationId: streamEvents
+      responses:
+        "200":
+          description: Event stream
+          content:
+            text/event-stream:
+              schema:
+                type: string
+              itemSchema:
+                type: object
+                properties:
+                  event:
+                    type: string
+                  data:
+                    type: string
+"#,
+        );
+        assert_eq!(ir.operations.len(), 1);
+        let resp = &ir.operations[0].responses[0];
+        assert!(!resp.item_content.is_empty());
+        assert!(resp.item_content.contains_key("text/event-stream"));
     }
 }

--- a/crates/openapi-nexus-ir/src/tagged_enum_pattern.rs
+++ b/crates/openapi-nexus-ir/src/tagged_enum_pattern.rs
@@ -5,6 +5,9 @@
 
 use heck::ToPascalCase as _;
 use openapi_nexus_spec::oas31::spec::{ObjectOrReference, ObjectSchema};
+use openapi_nexus_spec::oas32::spec::{
+    ObjectOrReference as ObjectOrReference32, ObjectSchema as ObjectSchema32,
+};
 
 /// Tagged enum pattern types
 ///
@@ -195,5 +198,101 @@ impl TaggedEnumPattern {
             | TaggedEnumPattern::InternallyTagged { tag_field, .. } => Some(tag_field),
             _ => None,
         }
+    }
+
+    /// Same as [`detect_from_schema`] but for OAS 3.2 types.
+    pub fn detect_from_schema_v32(
+        schema_ref: &ObjectOrReference32<ObjectSchema32>,
+    ) -> Option<Self> {
+        match schema_ref {
+            ObjectOrReference32::Object(obj_schema) if obj_schema.properties.len() == 1 => {
+                if let Some((prop_name, prop_schema)) = obj_schema.properties.iter().next()
+                    && obj_schema.required.contains(prop_name)
+                {
+                    let is_externally_tagged = match prop_schema {
+                        ObjectOrReference32::Object(prop_obj) => {
+                            !prop_obj.enum_values.is_empty()
+                                && prop_obj
+                                    .enum_values
+                                    .iter()
+                                    .any(|v| matches!(v, serde_json::Value::String(_)))
+                        }
+                        ObjectOrReference32::Ref { .. } => true,
+                    };
+                    if is_externally_tagged {
+                        let variant_name = prop_name.to_pascal_case();
+                        return Some(TaggedEnumPattern::ExternallyTagged { variant_name });
+                    }
+                }
+            }
+            ObjectOrReference32::Object(obj_schema) if obj_schema.properties.len() == 2 => {
+                let mut tag_field: Option<String> = None;
+                let mut content_field: Option<String> = None;
+                let mut enum_value: Option<String> = None;
+
+                for (prop_name, prop_schema) in &obj_schema.properties {
+                    if let ObjectOrReference32::Object(prop_obj) = prop_schema
+                        && !prop_obj.enum_values.is_empty()
+                        && let Some(serde_json::Value::String(enum_val)) =
+                            prop_obj.enum_values.first()
+                    {
+                        tag_field = Some(prop_name.clone());
+                        enum_value = Some(enum_val.clone());
+                        continue;
+                    }
+                    match prop_schema {
+                        ObjectOrReference32::Object(content_obj) => {
+                            if content_obj.enum_values.is_empty()
+                                && !content_obj.properties.is_empty()
+                            {
+                                content_field = Some(prop_name.clone());
+                            }
+                        }
+                        ObjectOrReference32::Ref { .. } => {
+                            content_field = Some(prop_name.clone());
+                        }
+                    }
+                }
+
+                if let (Some(tag), Some(content)) = (tag_field, content_field)
+                    && let Some(enum_val) = enum_value
+                {
+                    let variant_name = enum_val.to_pascal_case();
+                    return Some(TaggedEnumPattern::AdjacentlyTagged {
+                        variant_name,
+                        tag_field: tag,
+                        content_field: content,
+                    });
+                }
+            }
+            ObjectOrReference32::Object(obj_schema) if !obj_schema.all_of.is_empty() => {
+                for item in &obj_schema.all_of {
+                    if let ObjectOrReference32::Object(item_schema) = item {
+                        for (prop_name, prop_schema) in &item_schema.properties {
+                            if let ObjectOrReference32::Object(prop_obj) = prop_schema
+                                && !prop_obj.enum_values.is_empty()
+                                && let Some(serde_json::Value::String(enum_val)) =
+                                    prop_obj.enum_values.first()
+                            {
+                                let variant_name = enum_val.to_pascal_case();
+                                return Some(TaggedEnumPattern::InternallyTagged {
+                                    variant_name,
+                                    tag_field: prop_name.clone(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            ObjectOrReference32::Ref { ref_path, .. } => {
+                if let Some(schema_name) = ref_path.as_str().strip_prefix("#/components/schemas/") {
+                    return Some(TaggedEnumPattern::Untagged {
+                        variant_name: schema_name.to_pascal_case(),
+                    });
+                }
+            }
+            _ => {}
+        }
+        None
     }
 }

--- a/crates/openapi-nexus-ir/src/types/operation.rs
+++ b/crates/openapi-nexus-ir/src/types/operation.rs
@@ -56,6 +56,9 @@ pub struct IrResponse {
     pub status: String,
     pub description: String,
     pub content: IndexMap<String, IrTypeExpr>,
+    /// Streaming item types (from OAS 3.2 `itemSchema`).
+    /// Non-empty when the response is a streaming endpoint (e.g. text/event-stream).
+    pub item_content: IndexMap<String, IrTypeExpr>,
     pub headers: IndexMap<String, IrHeader>,
 }
 

--- a/crates/openapi-nexus-parser/src/error.rs
+++ b/crates/openapi-nexus-parser/src/error.rs
@@ -34,7 +34,7 @@ pub enum ParseError {
     OpenApiDeserializeYaml { source: serde_norway::Error },
 
     #[snafu(display(
-        "Unsupported OpenAPI version: '{}'. Supported versions: 3.0.x, 3.1.x",
+        "Unsupported OpenAPI version: '{}'. Supported versions: 3.0.x, 3.1.x, 3.2.x",
         version
     ))]
     UnsupportedVersion { version: String },

--- a/crates/openapi-nexus-parser/src/lib.rs
+++ b/crates/openapi-nexus-parser/src/lib.rs
@@ -15,7 +15,7 @@ pub use parser::{
 };
 pub use serde_error::SerdeErrorExtractor;
 
-use openapi_nexus_spec::{OpenApiV30Spec, OpenApiV31Spec};
+use openapi_nexus_spec::{OpenApiV30Spec, OpenApiV31Spec, OpenApiV32Spec};
 
 /// Parsed OpenAPI specification, version-tagged.
 /// The parser auto-detects the version from the `openapi` field and
@@ -24,14 +24,24 @@ use openapi_nexus_spec::{OpenApiV30Spec, OpenApiV31Spec};
 pub enum ParsedSpec {
     V30(Box<OpenApiV30Spec>),
     V31(Box<OpenApiV31Spec>),
+    V32(Box<OpenApiV32Spec>),
 }
 
 impl ParsedSpec {
-    /// Get the OpenAPI version string (e.g. "3.0" or "3.1").
+    /// Get the OpenAPI version string (e.g. "3.0", "3.1", or "3.2").
     pub fn version_tag(&self) -> &'static str {
         match self {
             ParsedSpec::V30(_) => "3.0",
             ParsedSpec::V31(_) => "3.1",
+            ParsedSpec::V32(_) => "3.2",
+        }
+    }
+
+    /// If this is a v3.2 spec, return a reference to it.
+    pub fn as_v32(&self) -> Option<&OpenApiV32Spec> {
+        match self {
+            ParsedSpec::V32(spec) => Some(spec),
+            _ => None,
         }
     }
 

--- a/crates/openapi-nexus-parser/src/parser.rs
+++ b/crates/openapi-nexus-parser/src/parser.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error};
 use crate::ParsedSpec;
 use crate::error::ParseError;
 use crate::serde_error::SerdeErrorExtractor;
-use openapi_nexus_spec::{OpenApiV30Spec, OpenApiV31Spec};
+use openapi_nexus_spec::{OpenApiV30Spec, OpenApiV31Spec, OpenApiV32Spec};
 
 fn extract_error_context(content: &str, error_msg: &str) -> Vec<String> {
     let (line, column) = SerdeErrorExtractor::new(error_msg).extract_location();
@@ -92,6 +92,8 @@ fn classify_version(version: &str) -> Result<OpenApiMajorMinor, ParseError> {
         Ok(OpenApiMajorMinor::V3_0)
     } else if version.starts_with("3.1") {
         Ok(OpenApiMajorMinor::V3_1)
+    } else if version.starts_with("3.2") {
+        Ok(OpenApiMajorMinor::V3_2)
     } else {
         Err(ParseError::UnsupportedVersion {
             version: version.to_string(),
@@ -102,6 +104,7 @@ fn classify_version(version: &str) -> Result<OpenApiMajorMinor, ParseError> {
 enum OpenApiMajorMinor {
     V3_0,
     V3_1,
+    V3_2,
 }
 
 pub fn parse_content_json(content: &str) -> Result<ParsedSpec, ParseError> {
@@ -131,6 +134,13 @@ pub fn parse_content_json(content: &str) -> Result<ParsedSpec, ParseError> {
                 ParseError::OpenApiDeserializeJson { source: e }
             })?;
             Ok(ParsedSpec::V31(Box::new(spec)))
+        }
+        OpenApiMajorMinor::V3_2 => {
+            let spec: OpenApiV32Spec = serde_json::from_value(value).map_err(|e| {
+                debug!("parse error: {}", e);
+                ParseError::OpenApiDeserializeJson { source: e }
+            })?;
+            Ok(ParsedSpec::V32(Box::new(spec)))
         }
     }
 }
@@ -162,6 +172,13 @@ pub fn parse_content_yaml(content: &str) -> Result<ParsedSpec, ParseError> {
                 ParseError::OpenApiDeserializeYaml { source: e }
             })?;
             Ok(ParsedSpec::V31(Box::new(spec)))
+        }
+        OpenApiMajorMinor::V3_2 => {
+            let spec: OpenApiV32Spec = serde_norway::from_value(value).map_err(|e| {
+                debug!("parse error: {}", e);
+                ParseError::OpenApiDeserializeYaml { source: e }
+            })?;
+            Ok(ParsedSpec::V32(Box::new(spec)))
         }
     }
 }

--- a/crates/openapi-nexus-spec/build.rs
+++ b/crates/openapi-nexus-spec/build.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 const FIXTURES_SUBDIR: &str = "tests/openapi-generator-fixtures";
 const OAS30_PREFIX: &str = "oas30/";
 const OAS31_PREFIX: &str = "oas31/";
+const OAS32_PREFIX: &str = "oas32/";
 const SUPPORTED_EXTENSIONS: &[&str] = &["yaml", "yml", "json"];
 const SKIP_SUFFIX: &str = "tags.json";
 const TEST_FN_PREFIX: &str = "test_oag_fixture_";
@@ -118,12 +119,16 @@ fn main() {
 
     let oas30 = fixtures_base.join("oas30");
     let oas31 = fixtures_base.join("oas31");
+    let oas32 = fixtures_base.join("oas32");
     let mut rel_paths = Vec::new();
     if oas30.exists() {
         collect_fixture_paths(&oas30, &oas30, OAS30_PREFIX, &skip_paths, &mut rel_paths);
     }
     if oas31.exists() {
         collect_fixture_paths(&oas31, &oas31, OAS31_PREFIX, &skip_paths, &mut rel_paths);
+    }
+    if oas32.exists() {
+        collect_fixture_paths(&oas32, &oas32, OAS32_PREFIX, &skip_paths, &mut rel_paths);
     }
     rel_paths.sort();
 

--- a/crates/openapi-nexus-spec/src/lib.rs
+++ b/crates/openapi-nexus-spec/src/lib.rs
@@ -1,7 +1,6 @@
 //! OpenAPI specification types for OpenAPI Nexus.
 //!
 //! This crate provides versioned modules for OpenAPI 3.0, 3.1, and 3.2.
-//! OpenAPI 3.0 and 3.1 are fully implemented; 3.2 is a stub for future use.
 
 pub mod oas30;
 pub mod oas31;
@@ -9,6 +8,7 @@ pub mod oas32;
 
 pub use oas30::OpenApiV30Spec;
 pub use oas31::OpenApiV31Spec;
+pub use oas32::OpenApiV32Spec;
 
 #[cfg(test)]
 mod test_utils;

--- a/crates/openapi-nexus-spec/src/oas32/mod.rs
+++ b/crates/openapi-nexus-spec/src/oas32/mod.rs
@@ -1,7 +1,7 @@
-//! OpenAPI 3.2.x specification (stub).
+//! OpenAPI 3.2.x specification types and parsing.
 //!
-//! Reserved for future 3.2 support.
+//! See <https://spec.openapis.org/oas/v3.2.0>.
 
-pub mod spec {
-    //! Placeholder for OpenAPI 3.2.x spec types.
-}
+pub mod spec;
+
+pub use spec::OpenApiV32Spec;

--- a/crates/openapi-nexus-spec/src/oas32/spec/callback.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/callback.rs
@@ -1,0 +1,73 @@
+use std::{collections::BTreeMap, error::Error as StdError};
+
+use serde::{Deserialize, Serialize};
+
+use super::PathItem;
+
+/// Map of possible out-of band callbacks related to the parent operation.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[serde(try_from = "CallbackSerde", into = "CallbackSerde")]
+pub struct Callback {
+    /// Map of Path Item Objects for the callback.
+    pub paths: BTreeMap<String, PathItem>,
+
+    /// Specification extensions (keys with "x-" prefix as in the document).
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(transparent)]
+struct CallbackSerde(serde_json::Map<String, serde_json::Value>);
+
+impl TryFrom<CallbackSerde> for Callback {
+    type Error = Box<dyn StdError>;
+
+    fn try_from(CallbackSerde(map): CallbackSerde) -> Result<Self, Self::Error> {
+        let (extensions, paths) = bisect_map(map, |key| key.starts_with("x-"));
+
+        let paths = paths
+            .into_iter()
+            .map(|(key, value)| serde_json::from_value(value).map(|v| (key, v)))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self {
+            paths,
+            extensions: extensions.into_iter().collect(),
+        })
+    }
+}
+
+fn bisect_map(
+    map: serde_json::Map<String, serde_json::Value>,
+    predicate: fn(&String) -> bool,
+) -> (
+    serde_json::Map<String, serde_json::Value>,
+    serde_json::Map<String, serde_json::Value>,
+) {
+    let mut first = map;
+    let mut second = first.clone();
+
+    first.retain(|key, _| predicate(key));
+    second.retain(|key, _| !predicate(key));
+
+    (first, second)
+}
+
+impl From<Callback> for CallbackSerde {
+    fn from(val: Callback) -> Self {
+        let Callback { paths, extensions } = val;
+
+        CallbackSerde(
+            paths
+                .into_iter()
+                .map(|(key, val)| {
+                    (
+                        key,
+                        serde_json::to_value(val).expect("path item serialization should not fail"),
+                    )
+                })
+                .chain(extensions)
+                .collect(),
+        )
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/components.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/components.rs
@@ -1,0 +1,64 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    Callback, Example, Header, Link, MediaType, ObjectOrReference, Parameter, PathItem,
+    RequestBody, Response, SecurityScheme, schema::ObjectSchema, spec_extensions,
+};
+
+/// Holds a set of reusable objects for different aspects of the OAS.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct Components {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub schemas: BTreeMap<String, ObjectOrReference<ObjectSchema>>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub responses: BTreeMap<String, ObjectOrReference<Response>>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub parameters: BTreeMap<String, ObjectOrReference<Parameter>>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub examples: BTreeMap<String, ObjectOrReference<Example>>,
+
+    #[serde(
+        rename = "requestBodies",
+        default,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub request_bodies: BTreeMap<String, ObjectOrReference<RequestBody>>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, ObjectOrReference<Header>>,
+
+    #[serde(
+        rename = "pathItems",
+        default,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub path_items: BTreeMap<String, ObjectOrReference<PathItem>>,
+
+    #[serde(
+        rename = "securitySchemes",
+        default,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub security_schemes: BTreeMap<String, ObjectOrReference<SecurityScheme>>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub links: BTreeMap<String, ObjectOrReference<Link>>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub callbacks: BTreeMap<String, ObjectOrReference<Callback>>,
+
+    #[serde(
+        rename = "mediaTypes",
+        default,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub media_types: BTreeMap<String, ObjectOrReference<MediaType>>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/contact.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/contact.rs
@@ -1,0 +1,44 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+use url::Url;
+
+use super::spec_extensions;
+
+/// Error raised when contact info contains an email field which is not a valid email.
+#[derive(Debug, Snafu)]
+#[snafu(display("Email address is not valid"))]
+#[non_exhaustive]
+pub struct ErrorInvalidEmail;
+
+/// Contact information for the exposed API.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct Contact {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<Url>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl Contact {
+    /// Validates email address field.
+    pub fn validate_email(&self) -> Result<(), ErrorInvalidEmail> {
+        let Some(email) = &self.email else {
+            return Ok(());
+        };
+
+        if email.contains('@') {
+            Ok(())
+        } else {
+            Err(ErrorInvalidEmail)
+        }
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/discriminator.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/discriminator.rs
@@ -1,0 +1,14 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A discriminator object for serialization/deserialization when payloads may be one of several schemas.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Discriminator {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub property_name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mapping: Option<BTreeMap<String, String>>,
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/encoding.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/encoding.rs
@@ -1,0 +1,25 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{Header, ObjectOrReference};
+
+/// A single encoding definition applied to a single schema property.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct Encoding {
+    #[serde(skip_serializing_if = "Option::is_none", rename = "contentType")]
+    pub content_type: Option<String>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, ObjectOrReference<Header>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explode: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none", rename = "allowReserved")]
+    pub allow_reserved: Option<bool>,
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/error.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/error.rs
@@ -1,0 +1,31 @@
+use semver::{Error as SemverError, Version};
+use snafu::Snafu;
+
+use super::{reference::ErrorRef, schema::ErrorSchema};
+
+/// Spec errors.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ErrorSpec {
+    /// Reference error.
+    #[snafu(display("Reference error"))]
+    Ref { source: ErrorRef },
+
+    /// Schema error.
+    #[snafu(display("Schema error"))]
+    Schema { source: ErrorSchema },
+
+    /// Semver error.
+    #[snafu(display("Semver error"))]
+    Semver { source: SemverError },
+
+    /// Unsupported spec file version.
+    #[snafu(display("Unsupported spec file version ({})", version))]
+    UnsupportedSpecFileVersion { version: Version },
+}
+
+impl From<SemverError> for ErrorSpec {
+    fn from(source: SemverError) -> Self {
+        ErrorSpec::Semver { source }
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/example.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/example.rs
@@ -1,0 +1,56 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{ErrorRef, FromRef, OpenApiV32Spec, Ref, RefType, spec_extensions};
+
+/// Multi-purpose example objects.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct Example {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+
+    #[serde(rename = "externalValue", skip_serializing_if = "Option::is_none")]
+    pub external_value: Option<String>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl Example {
+    /// Returns JSON-encoded bytes of this example's value.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        match self.value {
+            Some(ref val) => serde_json::to_string(val).unwrap().as_bytes().to_owned(),
+            None => vec![],
+        }
+    }
+}
+
+impl FromRef for Example {
+    fn from_ref(spec: &OpenApiV32Spec, path: &str) -> Result<Self, ErrorRef> {
+        let refpath = path.parse::<Ref>()?;
+
+        match refpath.kind {
+            RefType::Example => spec
+                .components
+                .as_ref()
+                .and_then(|cs| cs.examples.get(&refpath.name))
+                .ok_or_else(|| ErrorRef::Unresolvable {
+                    path: path.to_owned(),
+                })
+                .and_then(|oor| oor.resolve(spec)),
+
+            typ => Err(ErrorRef::MismatchedType {
+                expected: typ,
+                actual: RefType::Example,
+            }),
+        }
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/external_doc.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/external_doc.rs
@@ -1,0 +1,18 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use super::spec_extensions;
+
+/// Allows referencing an external resource for extended documentation.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ExternalDoc {
+    pub url: Url,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/flows.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/flows.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use super::spec_extensions;
+
+/// Allows configuration of the supported OAuth Flows.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Flows {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub implicit: Option<ImplicitFlow>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<PasswordFlow>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_credentials: Option<ClientCredentialsFlow>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_code: Option<AuthorizationCodeFlow>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_authorization: Option<DeviceAuthorizationFlow>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImplicitFlow {
+    pub authorization_url: Url,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<Url>,
+
+    #[serde(default)]
+    pub scopes: BTreeMap<String, String>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasswordFlow {
+    pub token_url: Url,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<Url>,
+
+    #[serde(default)]
+    pub scopes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientCredentialsFlow {
+    pub token_url: Url,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<Url>,
+
+    #[serde(default)]
+    pub scopes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationCodeFlow {
+    pub authorization_url: Url,
+
+    pub token_url: Url,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<Url>,
+
+    #[serde(default)]
+    pub scopes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceAuthorizationFlow {
+    pub device_authorization_url: Url,
+
+    pub token_url: Url,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<Url>,
+
+    #[serde(default)]
+    pub scopes: BTreeMap<String, String>,
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/header.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/header.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ErrorRef, Example, FromRef, MediaType, ObjectOrReference, ObjectSchema, OpenApiV32Spec,
+    ParameterStyle, Ref, RefType, spec_extensions,
+};
+
+/// Describes a single header for HTTP responses.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Header {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style: Option<ParameterStyle>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explode: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<ObjectOrReference<ObjectSchema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub example: Option<serde_json::Value>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub examples: BTreeMap<String, ObjectOrReference<Example>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<BTreeMap<String, MediaType>>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl FromRef for Header {
+    fn from_ref(spec: &OpenApiV32Spec, path: &str) -> Result<Self, ErrorRef> {
+        let refpath = path.parse::<Ref>()?;
+
+        match refpath.kind {
+            RefType::Header => spec
+                .components
+                .as_ref()
+                .and_then(|cs| cs.headers.get(&refpath.name))
+                .ok_or_else(|| ErrorRef::Unresolvable {
+                    path: path.to_owned(),
+                })
+                .and_then(|oor| oor.resolve(spec)),
+
+            typ => Err(ErrorRef::MismatchedType {
+                expected: typ,
+                actual: RefType::Header,
+            }),
+        }
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/info.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/info.rs
@@ -1,0 +1,32 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use super::{Contact, License, spec_extensions};
+
+/// General information about the API.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Info {
+    pub title: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(rename = "termsOfService", skip_serializing_if = "Option::is_none")]
+    pub terms_of_service: Option<Url>,
+
+    pub version: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact: Option<Contact>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<License>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/license.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/license.rs
@@ -1,0 +1,21 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use super::spec_extensions;
+
+/// License information for the exposed API.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct License {
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identifier: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<Url>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/link.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/link.rs
@@ -1,0 +1,46 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{Server, spec_extensions};
+
+/// The Link object represents a possible design-time link for a response.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Link {
+    /// A relative or absolute reference to an OAS operation.
+    Ref {
+        #[serde(rename = "operationRef")]
+        operation_ref: String,
+
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        parameters: BTreeMap<String, String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        server: Option<Server>,
+
+        #[serde(flatten, with = "spec_extensions")]
+        extensions: BTreeMap<String, serde_json::Value>,
+    },
+
+    /// The name of an existing, resolvable OAS operation.
+    Id {
+        #[serde(rename = "operationId")]
+        operation_id: String,
+
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        parameters: BTreeMap<String, String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        server: Option<Server>,
+
+        #[serde(flatten, with = "spec_extensions")]
+        extensions: BTreeMap<String, serde_json::Value>,
+    },
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/media_type.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/media_type.rs
@@ -1,0 +1,51 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    Encoding, ErrorSpec, Example, MediaTypeExamples, ObjectOrReference, ObjectSchema,
+    OpenApiV32Spec, spec_extensions,
+};
+
+/// Each Media Type Object provides schema and examples for the media type identified by its key.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct MediaType {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<ObjectOrReference<ObjectSchema>>,
+
+    #[serde(rename = "itemSchema", skip_serializing_if = "Option::is_none")]
+    pub item_schema: Option<ObjectOrReference<ObjectSchema>>,
+
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub examples: Option<MediaTypeExamples>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub encoding: BTreeMap<String, Encoding>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl MediaType {
+    /// Resolves and returns the JSON schema definition for this media type.
+    pub fn schema(&self, spec: &OpenApiV32Spec) -> Result<Option<ObjectSchema>, ErrorSpec> {
+        let Some(schema) = self.schema.as_ref() else {
+            return Ok(None);
+        };
+
+        let schema = schema
+            .resolve(spec)
+            .map_err(|e| ErrorSpec::Ref { source: e })?;
+
+        Ok(Some(schema))
+    }
+
+    /// Resolves and returns the provided examples for this media type.
+    pub fn examples(&self, spec: &OpenApiV32Spec) -> BTreeMap<String, Example> {
+        self.examples
+            .as_ref()
+            .map(|examples| examples.resolve_all(spec))
+            .unwrap_or_default()
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/media_type_examples.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/media_type_examples.rs
@@ -1,0 +1,61 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{Example, ObjectOrReference, OpenApiV32Spec};
+
+/// Examples for a media type.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum MediaTypeExamples {
+    /// Examples of the media type.
+    Examples {
+        examples: BTreeMap<String, ObjectOrReference<Example>>,
+    },
+
+    /// Example of the media type.
+    Example { example: serde_json::Value },
+}
+
+impl Default for MediaTypeExamples {
+    fn default() -> Self {
+        MediaTypeExamples::Examples {
+            examples: BTreeMap::new(),
+        }
+    }
+}
+
+impl MediaTypeExamples {
+    /// Returns true if no examples are provided.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            MediaTypeExamples::Example { .. } => false,
+            MediaTypeExamples::Examples { examples } => examples.is_empty(),
+        }
+    }
+
+    /// Resolves references and returns a map of provided examples keyed by name.
+    pub fn resolve_all(&self, spec: &OpenApiV32Spec) -> BTreeMap<String, Example> {
+        match self {
+            Self::Example { example } => {
+                let example = Example {
+                    description: None,
+                    summary: None,
+                    value: Some(example.clone()),
+                    external_value: None,
+                    extensions: BTreeMap::default(),
+                };
+
+                let mut map = BTreeMap::new();
+                map.insert("default".to_owned(), example);
+
+                map
+            }
+
+            Self::Examples { examples } => examples
+                .iter()
+                .filter_map(|(name, oor)| oor.resolve(spec).map(|obj| (name.clone(), obj)).ok())
+                .collect(),
+        }
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/mod.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/mod.rs
@@ -1,1 +1,68 @@
-//! OpenAPI 3.2.x spec types (placeholder for future implementation).
+//! Structures used in parsing and navigating OpenAPI 3.2 specifications.
+//!
+//! High-level structures include [`OpenApiV32Spec`], [`Components`] & [`Schema`].
+
+mod callback;
+mod components;
+mod contact;
+mod discriminator;
+mod encoding;
+mod error;
+mod example;
+mod external_doc;
+mod flows;
+mod header;
+mod info;
+mod license;
+mod link;
+mod media_type;
+mod media_type_examples;
+mod openapi_spec;
+mod operation;
+mod parameter;
+mod path_item;
+mod reference;
+mod request_body;
+mod response;
+mod schema;
+mod security_requirement;
+mod security_scheme;
+mod server;
+mod spec_extensions;
+mod tag;
+
+pub use self::{
+    callback::Callback,
+    components::Components,
+    contact::{Contact, ErrorInvalidEmail},
+    discriminator::Discriminator,
+    encoding::Encoding,
+    error::ErrorSpec,
+    example::Example,
+    external_doc::ExternalDoc,
+    flows::{
+        AuthorizationCodeFlow, ClientCredentialsFlow, DeviceAuthorizationFlow, Flows, ImplicitFlow,
+        PasswordFlow,
+    },
+    header::Header,
+    info::Info,
+    license::License,
+    link::Link,
+    media_type::MediaType,
+    media_type_examples::MediaTypeExamples,
+    openapi_spec::OpenApiV32Spec,
+    operation::Operation,
+    parameter::{Parameter, ParameterIn, ParameterStyle},
+    path_item::PathItem,
+    reference::{ErrorRef, FromRef, ObjectOrReference, Ref, RefType},
+    request_body::RequestBody,
+    response::Response,
+    schema::{
+        BooleanSchema, ErrorSchema, ObjectSchema, Schema, Type as SchemaType,
+        TypeSet as SchemaTypeSet,
+    },
+    security_requirement::SecurityRequirement,
+    security_scheme::SecurityScheme,
+    server::{Server, ServerVariable},
+    tag::Tag,
+};

--- a/crates/openapi-nexus-spec/src/oas32/spec/openapi_spec.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/openapi_spec.rs
@@ -1,0 +1,124 @@
+//! OpenAPI 3.2 root specification document.
+
+use std::{collections::BTreeMap, iter::Iterator};
+
+use http::Method;
+use serde::{Deserialize, Serialize};
+
+use super::spec_extensions;
+use super::{
+    Components, ErrorSpec, ExternalDoc, Info, Operation, PathItem, SecurityRequirement, Server, Tag,
+};
+
+const OPENAPI_SUPPORTED_VERSION_RANGE: &str = "~3.2";
+
+/// A complete OpenAPI 3.2 specification.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct OpenApiV32Spec {
+    /// This string MUST be the [semantic version number](https://semver.org/spec/v2.0.0.html)
+    /// of the
+    /// [OpenAPI Specification version](https://spec.openapis.org/oas/v3.2.0#versions)
+    /// that the OpenAPI document uses.
+    pub openapi: String,
+
+    /// Provides metadata about the API.
+    pub info: Info,
+
+    /// An array of Server Objects, which provide connectivity information to a target server.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub servers: Vec<Server>,
+
+    /// Holds the relative paths to the individual endpoints and their operations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paths: Option<BTreeMap<String, PathItem>>,
+
+    /// An element to hold various schemas for the specification.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub components: Option<Components>,
+
+    /// A declaration of which security mechanisms can be used across the API.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub security: Vec<SecurityRequirement>,
+
+    /// A list of tags used by the specification with additional metadata.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<Tag>,
+
+    /// The incoming webhooks that MAY be received as part of this API.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub webhooks: BTreeMap<String, PathItem>,
+
+    /// Additional external documentation.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "externalDocs")]
+    pub external_docs: Option<ExternalDoc>,
+
+    /// Specification extensions.
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl OpenApiV32Spec {
+    /// Validates spec version field.
+    pub fn validate_version(&self) -> Result<semver::Version, ErrorSpec> {
+        let spec_version = &self.openapi;
+        let sem_ver = semver::Version::parse(spec_version)?;
+        let required_version = semver::VersionReq::parse(OPENAPI_SUPPORTED_VERSION_RANGE).unwrap();
+
+        if required_version.matches(&sem_ver) {
+            Ok(sem_ver)
+        } else {
+            Err(ErrorSpec::UnsupportedSpecFileVersion { version: sem_ver })
+        }
+    }
+
+    /// Returns a reference to the operation with given `operation_id`, or `None` if not found.
+    pub fn operation_by_id(&self, operation_id: &str) -> Option<&Operation> {
+        self.operations()
+            .find(|(_, _, op)| {
+                op.operation_id
+                    .as_deref()
+                    .is_some_and(|id| id == operation_id)
+            })
+            .map(|(_, _, op)| op)
+    }
+
+    /// Returns a reference to the operation with given `method` and `path`, or `None` if not found.
+    pub fn operation(&self, method: &Method, path: &str) -> Option<&Operation> {
+        let resource = self.paths.as_ref()?.get(path)?;
+
+        match *method {
+            Method::GET => resource.get.as_ref(),
+            Method::POST => resource.post.as_ref(),
+            Method::PUT => resource.put.as_ref(),
+            Method::PATCH => resource.patch.as_ref(),
+            Method::DELETE => resource.delete.as_ref(),
+            Method::HEAD => resource.head.as_ref(),
+            Method::OPTIONS => resource.options.as_ref(),
+            Method::TRACE => resource.trace.as_ref(),
+            _ => None,
+        }
+    }
+
+    /// Returns an iterator over all the operations defined in this spec.
+    pub fn operations(&self) -> impl Iterator<Item = (String, Method, &Operation)> {
+        let paths = &self.paths;
+
+        let ops = paths
+            .iter()
+            .flatten()
+            .flat_map(|(path, item)| {
+                item.methods()
+                    .into_iter()
+                    .map(move |(method, op)| (path.to_owned(), method, op))
+            })
+            .collect::<Vec<_>>();
+
+        ops.into_iter()
+    }
+
+    /// Returns a reference to the primary (first) server definition.
+    pub fn primary_server(&self) -> Option<&Server> {
+        self.servers.first()
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/operation.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/operation.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    Callback, ErrorSpec, ExternalDoc, ObjectOrReference, OpenApiV32Spec, Parameter, RequestBody,
+    Response, SecurityRequirement, Server, spec_extensions,
+};
+
+/// Describes a single API operation on a path.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct Operation {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<ExternalDoc>,
+
+    #[serde(rename = "operationId", skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<ObjectOrReference<Parameter>>,
+
+    #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
+    pub request_body: Option<ObjectOrReference<RequestBody>>,
+
+    pub responses: Option<BTreeMap<String, ObjectOrReference<Response>>>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub callbacks: BTreeMap<String, Callback>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub security: Vec<SecurityRequirement>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub servers: Vec<Server>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl Operation {
+    /// Resolves and returns this operation's request body.
+    pub fn request_body(&self, spec: &OpenApiV32Spec) -> Result<Option<RequestBody>, ErrorSpec> {
+        let Some(req_body) = self.request_body.as_ref() else {
+            return Ok(None);
+        };
+
+        let req_body = req_body
+            .resolve(spec)
+            .map_err(|e| ErrorSpec::Ref { source: e })?;
+
+        Ok(Some(req_body))
+    }
+
+    /// Resolves and returns map of this operation's responses, keyed by status code.
+    pub fn responses(&self, spec: &OpenApiV32Spec) -> BTreeMap<String, Response> {
+        self.responses
+            .iter()
+            .flatten()
+            .filter_map(|(name, oor)| oor.resolve(spec).map(|obj| (name.clone(), obj)).ok())
+            .collect()
+    }
+
+    /// Resolves and returns list of this operation's parameters.
+    pub fn parameters(&self, spec: &OpenApiV32Spec) -> Result<Vec<Parameter>, ErrorSpec> {
+        let params = self
+            .parameters
+            .iter()
+            .filter_map(|oor| oor.resolve(spec).ok())
+            .collect();
+
+        Ok(params)
+    }
+
+    /// Finds, resolves, and returns one of this operation's parameters by name.
+    pub fn parameter(
+        &self,
+        search: &str,
+        spec: &OpenApiV32Spec,
+    ) -> Result<Option<Parameter>, ErrorSpec> {
+        let param = self
+            .parameters(spec)?
+            .iter()
+            .find(|param| param.name == search)
+            .cloned();
+
+        Ok(param)
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/parameter.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/parameter.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ErrorRef, Example, FromRef, MediaType, ObjectOrReference, ObjectSchema, OpenApiV32Spec, Ref,
+    RefType, spec_extensions,
+};
+
+/// Parameter location.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ParameterIn {
+    Path,
+    Query,
+    Header,
+    Cookie,
+    Querystring,
+}
+
+/// Parameter style.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ParameterStyle {
+    Matrix,
+    Label,
+    Form,
+    Simple,
+    SpaceDelimited,
+    PipeDelimited,
+    DeepObject,
+}
+
+/// Describes a single operation parameter.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Parameter {
+    pub name: String,
+
+    #[serde(rename = "in")]
+    pub location: ParameterIn,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_empty_value: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style: Option<ParameterStyle>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explode: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_reserved: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<ObjectOrReference<ObjectSchema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub example: Option<serde_json::Value>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub examples: BTreeMap<String, ObjectOrReference<Example>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<BTreeMap<String, MediaType>>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl FromRef for Parameter {
+    fn from_ref(spec: &OpenApiV32Spec, path: &str) -> Result<Self, ErrorRef> {
+        let refpath = path.parse::<Ref>()?;
+
+        match refpath.kind {
+            RefType::Parameter => spec
+                .components
+                .as_ref()
+                .and_then(|cs| cs.parameters.get(&refpath.name))
+                .ok_or_else(|| ErrorRef::Unresolvable {
+                    path: path.to_owned(),
+                })
+                .and_then(|oor| oor.resolve(spec)),
+
+            typ => Err(ErrorRef::MismatchedType {
+                expected: typ,
+                actual: RefType::Parameter,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Parameter;
+
+    #[test]
+    fn deserialization() {
+        let spec = r#"{
+            "name": "foo",
+            "in": "query",
+            "description": "bar",
+            "required": false,
+            "schema": {
+                "type": "string"
+            }
+        }"#;
+
+        let parameter = serde_json::from_str::<Parameter>(spec).unwrap();
+        assert_eq!(parameter.name, "foo");
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/path_item.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/path_item.rs
@@ -1,0 +1,85 @@
+use std::collections::BTreeMap;
+
+use http::Method;
+use serde::{Deserialize, Serialize};
+
+use super::{ObjectOrReference, Operation, Parameter, Server, spec_extensions};
+
+/// Describes the operations available on a single path.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct PathItem {
+    #[serde(skip_serializing_if = "Option::is_none", rename = "$ref")]
+    pub reference: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub get: Option<Operation>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub put: Option<Operation>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post: Option<Operation>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delete: Option<Operation>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Operation>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head: Option<Operation>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch: Option<Operation>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace: Option<Operation>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query: Option<Operation>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub servers: Vec<Server>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<ObjectOrReference<Parameter>>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl PathItem {
+    /// Returns iterator over this path's provided operations, keyed by method.
+    pub fn methods(&self) -> impl IntoIterator<Item = (Method, &Operation)> {
+        let mut methods = vec![];
+
+        macro_rules! push_method {
+            ($field:ident, $method:ident) => {{
+                if let Some(ref op) = self.$field {
+                    methods.push((Method::$method, op))
+                }
+            }};
+        }
+
+        push_method!(get, GET);
+        push_method!(put, PUT);
+        push_method!(post, POST);
+        push_method!(delete, DELETE);
+        push_method!(options, OPTIONS);
+        push_method!(head, HEAD);
+        push_method!(patch, PATCH);
+        push_method!(trace, TRACE);
+
+        if let Some(ref op) = self.query {
+            methods.push((Method::from_bytes(b"QUERY").unwrap(), op));
+        }
+
+        methods
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/reference.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/reference.rs
@@ -1,0 +1,208 @@
+use std::{str::FromStr, sync::OnceLock};
+
+use derive_more::Display;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+use super::OpenApiV32Spec;
+
+fn re_ref() -> &'static Regex {
+    static RE_REF: OnceLock<Regex> = OnceLock::new();
+    RE_REF.get_or_init(|| {
+        Regex::new("^(?P<source>[^#]*)#/components/(?P<type>[^/]+)/(?P<name>.+)$").unwrap()
+    })
+}
+
+/// Container for a type of OpenAPI object, or a reference to one.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ObjectOrReference<T> {
+    /// Object reference.
+    ///
+    /// See <https://spec.openapis.org/oas/v3.2.0#reference-object>.
+    Ref {
+        /// Path, file reference, or URL pointing to object.
+        #[serde(rename = "$ref")]
+        ref_path: String,
+
+        /// Summary override.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        summary: Option<String>,
+
+        /// Description override.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
+
+    /// Inline object.
+    Object(T),
+}
+
+impl<T> ObjectOrReference<T>
+where
+    T: FromRef,
+{
+    /// Resolves the object (if needed) from the given `spec` and returns it.
+    pub fn resolve(&self, spec: &OpenApiV32Spec) -> Result<T, ErrorRef> {
+        match self {
+            Self::Object(component) => Ok(component.clone()),
+            Self::Ref { ref_path, .. } => T::from_ref(spec, ref_path),
+        }
+    }
+}
+
+/// Object reference error.
+#[derive(Debug, Clone, PartialEq, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ErrorRef {
+    /// Referenced object has unknown type.
+    #[snafu(display("Invalid type: {}", type_name))]
+    UnknownType { type_name: String },
+
+    /// Referenced object was not of expected type.
+    #[snafu(display("Mismatched type: cannot reference a {} as a {}", expected, actual))]
+    MismatchedType { expected: RefType, actual: RefType },
+
+    /// Reference path points outside the given spec file.
+    #[snafu(display("Unresolvable path: {}", path))]
+    Unresolvable { path: String },
+}
+
+/// Component type of a reference.
+#[derive(Debug, Clone, Copy, PartialEq, Display)]
+pub enum RefType {
+    /// Schema component type.
+    Schema,
+
+    /// Response component type.
+    Response,
+
+    /// Parameter component type.
+    Parameter,
+
+    /// Example component type.
+    Example,
+
+    /// Request body component type.
+    RequestBody,
+
+    /// Header component type.
+    Header,
+
+    /// Security scheme component type.
+    SecurityScheme,
+
+    /// Link component type.
+    Link,
+
+    /// Callback component type.
+    Callback,
+}
+
+impl FromStr for RefType {
+    type Err = ErrorRef;
+
+    fn from_str(typ: &str) -> Result<Self, Self::Err> {
+        Ok(match typ {
+            "schemas" => Self::Schema,
+            "responses" => Self::Response,
+            "parameters" => Self::Parameter,
+            "examples" => Self::Example,
+            "requestBodies" => Self::RequestBody,
+            "headers" => Self::Header,
+            "securitySchemes" => Self::SecurityScheme,
+            "links" => Self::Link,
+            "callbacks" => Self::Callback,
+            typ => {
+                return Err(ErrorRef::UnknownType {
+                    type_name: typ.to_owned(),
+                });
+            }
+        })
+    }
+}
+
+/// Parsed reference path.
+#[derive(Debug, Clone)]
+pub struct Ref {
+    /// Source file of the object being references.
+    pub source: String,
+
+    /// Type of object being referenced.
+    pub kind: RefType,
+
+    /// Name of object being referenced.
+    pub name: String,
+}
+
+impl FromStr for Ref {
+    type Err = ErrorRef;
+
+    fn from_str(path: &str) -> Result<Self, Self::Err> {
+        let parts = re_ref()
+            .captures(path)
+            .ok_or_else(|| ErrorRef::Unresolvable {
+                path: path.to_owned(),
+            })?;
+
+        Ok(Self {
+            source: parts["source"].to_owned(),
+            kind: parts["type"].parse()?,
+            name: parts["name"].to_owned(),
+        })
+    }
+}
+
+/// Find an object from a reference path (`$ref`).
+///
+/// Implemented for object types which can be shared via a spec's `components` object.
+pub trait FromRef: Clone {
+    /// Finds an object in `spec` using the given `path`.
+    fn from_ref(spec: &OpenApiV32Spec, path: &str) -> Result<Self, ErrorRef>;
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::ObjectOrReference;
+
+    #[test]
+    fn ref_serialization_omits_empty_overrides() {
+        let reference = ObjectOrReference::<()>::Ref {
+            ref_path: "#/components/examples/RustMascot".to_owned(),
+            summary: None,
+            description: None,
+        };
+
+        let serialized = serde_json::to_value(reference).expect("serializing ref");
+
+        assert_eq!(
+            serialized,
+            json!({
+                "$ref": "#/components/examples/RustMascot",
+            })
+        );
+    }
+
+    #[test]
+    fn ref_serialization_includes_present_overrides() {
+        let reference = ObjectOrReference::<()>::Ref {
+            ref_path: "#/components/examples/RustMascot".to_owned(),
+            summary: Some("Rust mascot override".to_owned()),
+            description: Some("Let Ferris do the talking.".to_owned()),
+        };
+
+        let serialized = serde_json::to_value(reference).expect("serializing ref");
+
+        assert_eq!(
+            serialized,
+            json!({
+                "$ref": "#/components/examples/RustMascot",
+                "summary": "Rust mascot override",
+                "description": "Let Ferris do the talking.",
+            })
+        );
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/request_body.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/request_body.rs
@@ -1,0 +1,39 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{ErrorRef, FromRef, MediaType, OpenApiV32Spec, Ref, RefType};
+
+/// Describes a single request body.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct RequestBody {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    pub content: BTreeMap<String, MediaType>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+}
+
+impl FromRef for RequestBody {
+    fn from_ref(spec: &OpenApiV32Spec, path: &str) -> Result<Self, ErrorRef> {
+        let refpath = path.parse::<Ref>()?;
+
+        match refpath.kind {
+            RefType::RequestBody => spec
+                .components
+                .as_ref()
+                .and_then(|cs| cs.request_bodies.get(&refpath.name))
+                .ok_or_else(|| ErrorRef::Unresolvable {
+                    path: path.to_owned(),
+                })
+                .and_then(|oor| oor.resolve(spec)),
+
+            typ => Err(ErrorRef::MismatchedType {
+                expected: typ,
+                actual: RefType::RequestBody,
+            }),
+        }
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/response.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/response.rs
@@ -1,0 +1,54 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ErrorRef, FromRef, Header, Link, MediaType, ObjectOrReference, OpenApiV32Spec, Ref, RefType,
+    spec_extensions,
+};
+
+/// Describes a single response from an API Operation.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct Response {
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, ObjectOrReference<Header>>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub content: BTreeMap<String, MediaType>,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub links: BTreeMap<String, ObjectOrReference<Link>>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl FromRef for Response {
+    fn from_ref(spec: &OpenApiV32Spec, path: &str) -> Result<Self, ErrorRef> {
+        let refpath = path.parse::<Ref>()?;
+
+        match refpath.kind {
+            RefType::Response => spec
+                .components
+                .as_ref()
+                .and_then(|cs| cs.responses.get(&refpath.name))
+                .ok_or_else(|| ErrorRef::Unresolvable {
+                    path: path.to_owned(),
+                })
+                .and_then(|oor| oor.resolve(spec)),
+
+            typ => Err(ErrorRef::MismatchedType {
+                expected: typ,
+                actual: RefType::Response,
+            }),
+        }
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/schema.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/schema.rs
@@ -1,0 +1,283 @@
+//! Schema specification for OpenAPI 3.1
+
+use std::{collections::BTreeMap, fmt};
+
+use serde::{Deserialize, Deserializer, Serialize};
+use snafu::Snafu;
+
+use super::{
+    ErrorRef, FromRef, ObjectOrReference, OpenApiV32Spec, Ref, RefType,
+    discriminator::Discriminator, spec_extensions,
+};
+
+/// Schema errors.
+#[derive(Debug, Clone, PartialEq, Snafu)]
+#[snafu(visibility(pub))]
+pub enum ErrorSchema {
+    #[snafu(display("Missing type field"))]
+    NoType,
+
+    #[snafu(display("Unknown type: {}", type_name))]
+    UnknownType { type_name: String },
+
+    #[snafu(display("Required property list specified for a non-object schema"))]
+    RequiredSpecifiedOnNonObject,
+}
+
+/// Single schema type.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Type {
+    Boolean,
+    Integer,
+    Number,
+    String,
+    Array,
+    Object,
+    Null,
+}
+
+/// Set of schema types.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum TypeSet {
+    Single(Type),
+    Multiple(Vec<Type>),
+}
+
+impl TypeSet {
+    /// Returns `true` if this type-set contains the given type.
+    pub fn contains(&self, type_: Type) -> bool {
+        match self {
+            TypeSet::Single(single_type) => *single_type == type_,
+            TypeSet::Multiple(type_set) => type_set.contains(&type_),
+        }
+    }
+
+    /// Returns `true` if this type-set is `object` or `[object, 'null']`.
+    pub fn is_object_or_nullable_object(&self) -> bool {
+        match self {
+            TypeSet::Single(Type::Object) => true,
+            TypeSet::Multiple(set) if set == &[Type::Object] => true,
+            TypeSet::Multiple(set) if set == &[Type::Object, Type::Null] => true,
+            TypeSet::Multiple(set) if set == &[Type::Null, Type::Object] => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if this type-set is `array` or `[array, 'null']`.
+    pub fn is_array_or_nullable_array(&self) -> bool {
+        match self {
+            TypeSet::Single(Type::Array) => true,
+            TypeSet::Multiple(set) if set == &[Type::Array] => true,
+            TypeSet::Multiple(set) if set == &[Type::Array, Type::Null] => true,
+            TypeSet::Multiple(set) if set == &[Type::Null, Type::Array] => true,
+            _ => false,
+        }
+    }
+}
+
+/// A schema object allows the definition of input and output data types.
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+pub struct ObjectSchema {
+    #[serde(rename = "allOf", default, skip_serializing_if = "Vec::is_empty")]
+    pub all_of: Vec<ObjectOrReference<ObjectSchema>>,
+
+    #[serde(rename = "anyOf", default, skip_serializing_if = "Vec::is_empty")]
+    pub any_of: Vec<ObjectOrReference<ObjectSchema>>,
+
+    #[serde(rename = "oneOf", default, skip_serializing_if = "Vec::is_empty")]
+    pub one_of: Vec<ObjectOrReference<ObjectSchema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Box<Schema>>,
+
+    #[serde(rename = "prefixItems", default, skip_serializing_if = "Vec::is_empty")]
+    pub prefix_items: Vec<ObjectOrReference<ObjectSchema>>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub properties: BTreeMap<String, ObjectOrReference<ObjectSchema>>,
+
+    #[serde(
+        rename = "additionalProperties",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_properties: Option<Schema>,
+
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub schema_type: Option<TypeSet>,
+
+    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
+    pub enum_values: Vec<serde_json::Value>,
+
+    #[serde(rename = "const", skip_serializing_if = "Option::is_none")]
+    pub const_value: Option<serde_json::Value>,
+
+    #[serde(rename = "multipleOf", skip_serializing_if = "Option::is_none")]
+    pub multiple_of: Option<serde_json::Number>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<serde_json::Number>,
+
+    #[serde(rename = "exclusiveMaximum", skip_serializing_if = "Option::is_none")]
+    pub exclusive_maximum: Option<serde_json::Number>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<serde_json::Number>,
+
+    #[serde(rename = "exclusiveMinimum", skip_serializing_if = "Option::is_none")]
+    pub exclusive_minimum: Option<serde_json::Number>,
+
+    #[serde(rename = "maxLength", skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<u64>,
+
+    #[serde(rename = "minLength", skip_serializing_if = "Option::is_none")]
+    pub min_length: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+
+    #[serde(rename = "maxItems", skip_serializing_if = "Option::is_none")]
+    pub max_items: Option<u64>,
+
+    #[serde(rename = "minItems", skip_serializing_if = "Option::is_none")]
+    pub min_items: Option<u64>,
+
+    #[serde(rename = "uniqueItems", skip_serializing_if = "Option::is_none")]
+    pub unique_items: Option<bool>,
+
+    #[serde(rename = "maxProperties", skip_serializing_if = "Option::is_none")]
+    pub max_properties: Option<u64>,
+
+    #[serde(rename = "minProperties", skip_serializing_if = "Option::is_none")]
+    pub min_properties: Option<u64>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<bool>,
+
+    #[serde(rename = "readOnly", skip_serializing_if = "Option::is_none")]
+    pub read_only: Option<bool>,
+
+    #[serde(rename = "writeOnly", skip_serializing_if = "Option::is_none")]
+    pub write_only: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<serde_json::Value>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<Discriminator>,
+
+    #[serde(
+        default,
+        deserialize_with = "distinguish_missing_and_null",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub example: Option<serde_json::Value>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+impl ObjectSchema {
+    /// Returns true if Null appears in set of schema types, or None if unspecified.
+    pub fn is_nullable(&self) -> Option<bool> {
+        Some(match self.schema_type.as_ref()? {
+            TypeSet::Single(type_) => *type_ == Type::Null,
+            TypeSet::Multiple(set) => set.contains(&Type::Null),
+        })
+    }
+}
+
+impl FromRef for ObjectSchema {
+    fn from_ref(spec: &OpenApiV32Spec, path: &str) -> Result<Self, ErrorRef> {
+        let refpath = path.parse::<Ref>()?;
+
+        match refpath.kind {
+            RefType::Schema => spec
+                .components
+                .as_ref()
+                .and_then(|cs| cs.schemas.get(&refpath.name))
+                .ok_or_else(|| ErrorRef::Unresolvable {
+                    path: path.to_owned(),
+                })
+                .and_then(|oor| oor.resolve(spec)),
+
+            typ => Err(ErrorRef::MismatchedType {
+                expected: typ,
+                actual: RefType::Schema,
+            }),
+        }
+    }
+}
+
+/// A boolean JSON schema.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct BooleanSchema(pub bool);
+
+/// A JSON schema document.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Schema {
+    Boolean(BooleanSchema),
+    Object(Box<ObjectOrReference<ObjectSchema>>),
+}
+
+/// Considers any value that is present as `Some`, including `null`.
+fn distinguish_missing_and_null<'de, T, D>(de: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de> + fmt::Debug,
+    D: Deserializer<'de>,
+{
+    T::deserialize(de).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ObjectSchema, Type};
+
+    #[test]
+    fn type_set_contains() {
+        let spec = r#"{"type": "integer"}"#;
+        let schema = serde_json::from_str::<ObjectSchema>(spec).unwrap();
+        let schema_type = schema.schema_type.unwrap();
+        assert!(schema_type.contains(Type::Integer));
+
+        let spec = r#"{"type": ["integer", "null"]}"#;
+        let schema = serde_json::from_str::<ObjectSchema>(spec).unwrap();
+        let schema_type = schema.schema_type.unwrap();
+        assert!(schema_type.contains(Type::Integer));
+
+        let spec = r#"{"type": ["object", "null"]}"#;
+        let schema = serde_json::from_str::<ObjectSchema>(spec).unwrap();
+        let schema_type = schema.schema_type.unwrap();
+        assert!(schema_type.contains(Type::Object));
+        assert!(schema_type.is_object_or_nullable_object());
+    }
+
+    #[test]
+    fn example_can_be_explicit_null() {
+        let spec = r#"{"type": ["string", "null"]}"#;
+        let schema = serde_json::from_str::<ObjectSchema>(spec).unwrap();
+        assert_eq!(schema.example, None);
+
+        let spec = r#"{"type": ["string", "null"], "example": null}"#;
+        let schema = serde_json::from_str::<ObjectSchema>(spec).unwrap();
+        assert_eq!(schema.example, Some(serde_json::Value::Null));
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/security_requirement.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/security_requirement.rs
@@ -1,0 +1,7 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Lists the required security schemes to execute this operation.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct SecurityRequirement(pub BTreeMap<String, Vec<String>>);

--- a/crates/openapi-nexus-spec/src/oas32/spec/security_scheme.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/security_scheme.rs
@@ -1,0 +1,154 @@
+use serde::{Deserialize, Serialize};
+
+use super::{ErrorRef, Flows, FromRef, OpenApiV32Spec, Ref, RefType};
+
+/// Defines a security scheme that can be used by the operations.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum SecurityScheme {
+    #[serde(rename = "apiKey")]
+    ApiKey {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+
+        name: String,
+
+        #[serde(rename = "in")]
+        location: String,
+    },
+
+    #[serde(rename = "http")]
+    Http {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+
+        scheme: String,
+
+        #[serde(rename = "bearerFormat")]
+        bearer_format: Option<String>,
+    },
+
+    #[serde(rename = "oauth2")]
+    OAuth2 {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+
+        flows: Flows,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        deprecated: Option<bool>,
+    },
+
+    #[serde(rename = "openIdConnect")]
+    OpenIdConnect {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+
+        #[serde(rename = "openIdConnectUrl")]
+        open_id_connect_url: String,
+    },
+
+    #[serde(rename = "mutualTLS")]
+    MutualTls {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
+}
+
+impl FromRef for SecurityScheme {
+    fn from_ref(spec: &OpenApiV32Spec, path: &str) -> Result<Self, ErrorRef> {
+        let refpath = path.parse::<Ref>()?;
+
+        match refpath.kind {
+            RefType::SecurityScheme => spec
+                .components
+                .as_ref()
+                .and_then(|cs| cs.security_schemes.get(&refpath.name))
+                .ok_or_else(|| ErrorRef::Unresolvable {
+                    path: path.to_owned(),
+                })
+                .and_then(|oor| oor.resolve(spec)),
+            typ => Err(ErrorRef::MismatchedType {
+                expected: typ,
+                actual: RefType::SecurityScheme,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::SecurityScheme;
+
+    #[test]
+    fn test_http_basic_deser() {
+        const HTTP_BASIC_SAMPLE: &str = r#"{"type": "http", "scheme": "basic"}"#;
+        let obj: SecurityScheme = serde_json::from_str(HTTP_BASIC_SAMPLE).unwrap();
+
+        assert!(matches!(
+            obj,
+            SecurityScheme::Http {
+                description: None,
+                scheme,
+                bearer_format: None,
+            } if scheme == "basic"
+        ));
+    }
+
+    #[test]
+    fn test_security_scheme_oauth_deser() {
+        const IMPLICIT_OAUTH2_SAMPLE: &str = r#"{
+          "type": "oauth2",
+          "flows": {
+            "implicit": {
+              "authorizationUrl": "https://example.com/api/oauth/dialog",
+              "scopes": {
+                "write:pets": "modify pets in your account",
+                "read:pets": "read your pets"
+              }
+            },
+            "authorizationCode": {
+              "authorizationUrl": "https://example.com/api/oauth/dialog",
+              "tokenUrl": "https://example.com/api/oauth/token",
+              "scopes": {
+                "write:pets": "modify pets in your account",
+                "read:pets": "read your pets"
+              }
+            }
+          }
+        }"#;
+
+        let obj: SecurityScheme = serde_json::from_str(IMPLICIT_OAUTH2_SAMPLE).unwrap();
+        match obj {
+            SecurityScheme::OAuth2 {
+                description: _,
+                flows,
+                ..
+            } => {
+                assert!(flows.implicit.is_some());
+                let implicit = flows.implicit.unwrap();
+                assert_eq!(
+                    implicit.authorization_url,
+                    Url::parse("https://example.com/api/oauth/dialog").unwrap()
+                );
+                assert!(implicit.scopes.contains_key("write:pets"));
+                assert!(implicit.scopes.contains_key("read:pets"));
+
+                assert!(flows.authorization_code.is_some());
+                let auth_code = flows.authorization_code.unwrap();
+                assert_eq!(
+                    auth_code.authorization_url,
+                    Url::parse("https://example.com/api/oauth/dialog").unwrap()
+                );
+                assert_eq!(
+                    auth_code.token_url,
+                    Url::parse("https://example.com/api/oauth/token").unwrap()
+                );
+            }
+            _ => panic!("wrong security scheme type"),
+        }
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/server.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/server.rs
@@ -1,0 +1,76 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::spec_extensions;
+
+/// An object representing a Server.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Server {
+    pub url: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub variables: BTreeMap<String, ServerVariable>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+/// An object representing a Server Variable for server URL template substitution.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ServerVariable {
+    pub default: String,
+
+    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
+    pub substitutions_enum: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{Server, ServerVariable};
+
+    #[test]
+    fn server_extensions_round_trip() {
+        let payload = r#"{
+            "url": "https://example.com",
+            "x-test": "alpha"
+        }"#;
+
+        let server: Server = serde_json::from_str(payload).expect("server parses");
+        assert_eq!(server.extensions.get("test"), Some(&json!("alpha")));
+
+        let value = serde_json::to_value(server).expect("server serializes");
+        assert_eq!(value.get("x-test"), Some(&json!("alpha")));
+    }
+
+    #[test]
+    fn server_variable_extensions_round_trip() {
+        let payload = r#"{
+            "default": "example",
+            "x-meta": {"enabled": true}
+        }"#;
+
+        let variable: ServerVariable = serde_json::from_str(payload).expect("variable parses");
+        assert_eq!(
+            variable.extensions.get("meta"),
+            Some(&json!({"enabled": true}))
+        );
+
+        let value = serde_json::to_value(variable).expect("variable serializes");
+        assert_eq!(value.get("x-meta"), Some(&json!({"enabled": true})));
+    }
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/spec_extensions.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/spec_extensions.rs
@@ -1,0 +1,59 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+};
+
+use serde::{Deserializer, Serializer, de};
+
+/// Deserializes fields of a map beginning with `x-`.
+pub(crate) fn deserialize<'de, D>(
+    deserializer: D,
+) -> Result<BTreeMap<String, serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ExtraFieldsVisitor;
+
+    impl<'de> de::Visitor<'de> for ExtraFieldsVisitor {
+        type Value = BTreeMap<String, serde_json::Value>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("extensions")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: de::MapAccess<'de>,
+        {
+            let mut map = HashMap::<String, serde_json::Value>::new();
+
+            while let Some((key, value)) = access.next_entry()? {
+                map.insert(key, value);
+            }
+
+            Ok(map
+                .into_iter()
+                .filter_map(|(key, value)| {
+                    key.strip_prefix("x-").map(|key| (key.to_owned(), value))
+                })
+                .collect())
+        }
+    }
+
+    deserializer.deserialize_map(ExtraFieldsVisitor)
+}
+
+/// Serializes fields of a map prefixed with `x-`.
+pub(crate) fn serialize<S>(
+    extensions: &BTreeMap<String, serde_json::Value>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.collect_map(
+        extensions
+            .iter()
+            .map(|(key, value)| (format!("x-{key}"), value)),
+    )
+}

--- a/crates/openapi-nexus-spec/src/oas32/spec/tag.rs
+++ b/crates/openapi-nexus-spec/src/oas32/spec/tag.rs
@@ -1,0 +1,20 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::spec_extensions;
+
+/// Adds metadata to a single tag that is used by the Operation Object.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Tag {
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(flatten, with = "spec_extensions")]
+    pub extensions: BTreeMap<String, serde_json::Value>,
+}


### PR DESCRIPTION
## Summary

- **openapi-nexus-spec**: 29 new `oas32` type files (copied from `oas31` with 3.2 field deltas applied): `itemSchema` on MediaType for SSE/streaming, QUERY method on PathItem, optional `discriminator.propertyName`, `DeviceAuthorizationFlow` for OAuth2, `server.name`, `tag.summary`, `response.summary`, `oauth2.deprecated`, `example.externalValue`, `components.mediaTypes`, `ParameterIn::Querystring`
- **openapi-nexus-parser**: `V32` variant in `ParsedSpec`, version detection via `classify_version`, JSON/YAML parse arms for `OpenApiV32Spec`
- **openapi-nexus-ir**: `v32` lowering module with QUERY method support, `Querystring` → `Query` param mapping, `itemSchema` → `item_content` on `IrResponse` for streaming endpoints. `TaggedEnumPattern::detect_from_schema_v32` added for oas32 type compatibility.

## Design decisions

- **Full copy architecture**: follows the existing pattern where each OAS version has independent type trees because `FromRef` impls are hardcoded to a concrete root spec type
- **`item_content` on `IrResponse`**: when non-empty, signals to generators that the response is a streaming endpoint. Generator-side streaming codegen is out of scope for this PR but the IR carries the information.
- **Deferred fields**: `additional_operations`, `prefix_encoding`, `item_encoding`, `data_value`/`serialized_value` on Example, `parent`/`kind` on Tag, `default_mapping` on Discriminator, `$self`, `ParameterStyle::Cookie`, `oauth2_metadata_url`

## Test plan

- [x] All 719 existing tests pass unchanged
- [x] New v32 lowering tests: minimal spec, object schema, string enum, nullable type, operation, array alias, ref schema
- [x] New QUERY method test (`test_lower_query_method`)
- [x] New itemSchema streaming test (`test_lower_item_schema_streaming`)
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --all -- --check` clean