### PR TITLE
feat(rust): configurable extra derives per type-kind

### DIFF
--- a/crates/generators/openapi-nexus-rust-aioduct/src/codegen/rust_aioduct_code_generator.rs
+++ b/crates/generators/openapi-nexus-rust-aioduct/src/codegen/rust_aioduct_code_generator.rs
@@ -42,19 +42,30 @@ impl RustAioductCodeGenerator {
         let mut files = Vec::new();
 
         files.extend(
-            emit_models::generate_model_files(ir, &header).map_err(|msg| {
+            emit_models::generate_model_files(ir, &header, &self.config).map_err(|msg| {
                 Box::<dyn Error + Send + Sync>::from(format!("emit_models: {msg}"))
             })?,
         );
 
+        let response_extra = self
+            .config
+            .extra_derives
+            .as_ref()
+            .and_then(|e| e.response_structs.as_ref());
         files.extend(
-            emit_api::generate_api_files(ir, &header, &backend_config, &emit_method_body)
-                .map_err(|msg| Box::<dyn Error + Send + Sync>::from(format!("emit_api: {msg}")))?,
+            emit_api::generate_api_files(
+                ir,
+                &header,
+                &backend_config,
+                response_extra,
+                &emit_method_body,
+            )
+            .map_err(|msg| Box::<dyn Error + Send + Sync>::from(format!("emit_api: {msg}")))?,
         );
 
         files.extend(runtime_files(&header));
 
-        files.push(cargo_toml_file(&crate_name, &ir.info));
+        files.push(cargo_toml_file(&crate_name, &ir.info, &self.config));
         files.push(project_files::lib_rs_file(&header));
         files.push(project_files::readme_file(&ir.info));
 
@@ -82,7 +93,7 @@ impl FileWriter for RustAioductCodeGenerator {
     }
 }
 
-fn cargo_toml_file(crate_name: &str, info: &IrInfo) -> FileInfo {
+fn cargo_toml_file(crate_name: &str, info: &IrInfo, config: &RustGeneratorConfig) -> FileInfo {
     let description = info
         .description
         .as_deref()
@@ -90,7 +101,7 @@ fn cargo_toml_file(crate_name: &str, info: &IrInfo) -> FileInfo {
         .lines()
         .next()
         .unwrap_or("Generated Rust SDK.");
-    let content = format!(
+    let mut content = format!(
         r#"[package]
 name = "{crate_name}"
 version = "0.1.0"
@@ -105,5 +116,10 @@ serde_repr = "0.1"
 tokio = {{ version = "1", features = ["full"] }}
 "#,
     );
+    if let Some(extra) = &config.extra_derives {
+        for (name, spec) in extra.all_dependencies() {
+            content.push_str(&format!("{name} = {spec}\n"));
+        }
+    }
     FileInfo::project("Cargo.toml".to_string(), content)
 }

--- a/crates/generators/openapi-nexus-rust-aioduct/tests/extra_derives_tests.rs
+++ b/crates/generators/openapi-nexus-rust-aioduct/tests/extra_derives_tests.rs
@@ -1,0 +1,224 @@
+//! Integration tests for extra_derives config in rust-aioduct generator.
+
+use openapi_nexus_rust_aioduct::RustAioductCodeGenerator;
+use openapi_nexus_test_utils::{generate_files, read_fixture};
+
+fn build_config(toml_str: &str) -> toml::value::Table {
+    toml::from_str::<toml::value::Table>(toml_str).unwrap()
+}
+
+fn generate_petstore(config: toml::value::Table) -> std::collections::HashMap<String, String> {
+    let generator = RustAioductCodeGenerator::new(config);
+    let spec = read_fixture("valid/petstore.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+fn generate_union(config: toml::value::Table) -> std::collections::HashMap<String, String> {
+    let generator = RustAioductCodeGenerator::new(config);
+    let spec = read_fixture("valid/type-aliases/union-with-interfaces.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+#[test]
+fn no_extra_derives_default_output() {
+    let files = generate_petstore(toml::value::Table::new());
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "struct should have default derives, got:\n{pet}"
+    );
+    assert!(
+        !pet.contains("PartialEq"),
+        "struct should not have PartialEq by default"
+    );
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug)]"),
+        "response struct should have only Debug derive"
+    );
+}
+
+#[test]
+fn extra_derives_on_structs() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = ["PartialEq", "Hash"]
+        "#,
+    ));
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]"),
+        "struct should have extra derives appended, got:\n{pet}"
+    );
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug)]"),
+        "response struct should not be affected by structs config"
+    );
+}
+
+#[test]
+fn extra_derives_on_enums() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.enums]
+        derives = ["Hash"]
+        "#,
+    ));
+
+    let status = files
+        .get("src/models/pet_status.rs")
+        .expect("pet_status.rs should exist");
+    assert!(
+        status.contains("#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]"),
+        "string enum should have Hash appended, got:\n{status}"
+    );
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "struct should be unaffected by enums config"
+    );
+}
+
+#[test]
+fn extra_derives_on_unions() {
+    let files = generate_union(build_config(
+        r#"
+        [extra_derives.unions]
+        derives = ["PartialEq"]
+        "#,
+    ));
+
+    let has_union_derive = files.values().any(|content| {
+        content.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]")
+            && content.contains("#[serde(untagged)]")
+    });
+    assert!(has_union_derive, "union should have PartialEq appended");
+
+    let struct_files: Vec<_> = files
+        .iter()
+        .filter(|(k, v)| {
+            k.starts_with("src/models/") && *k != "src/models/mod.rs" && v.contains("pub struct")
+        })
+        .collect();
+    for (path, content) in &struct_files {
+        assert!(
+            !content.contains("PartialEq"),
+            "struct in {path} should not be affected by unions config"
+        );
+    }
+}
+
+#[test]
+fn extra_derives_on_response_structs() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.response_structs]
+        derives = ["Clone", "PartialEq"]
+        "#,
+    ));
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug, Clone, PartialEq)]"),
+        "response struct should have extra derives, got:\n{api}"
+    );
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "model struct should be unaffected by response_structs config"
+    );
+}
+
+#[test]
+fn extra_derives_cargo_toml_deps() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = ["utoipa::ToSchema"]
+        [extra_derives.structs.dependencies]
+        utoipa = '{ version = "5", features = ["openapi_extensions"] }'
+        "#,
+    ));
+
+    let cargo = files.get("Cargo.toml").expect("Cargo.toml should exist");
+    assert!(
+        cargo.contains("aioduct"),
+        "Cargo.toml should still have aioduct dep"
+    );
+    assert!(
+        cargo.contains(r#"utoipa = { version = "5", features = ["openapi_extensions"] }"#),
+        "Cargo.toml should contain extra dependency, got:\n{cargo}"
+    );
+}
+
+#[test]
+fn extra_derives_all_kinds_together() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = ["PartialEq"]
+        [extra_derives.structs.dependencies]
+        fake-crate = '"1.0"'
+        [extra_derives.enums]
+        derives = ["Hash"]
+        [extra_derives.response_structs]
+        derives = ["Clone"]
+        "#,
+    ));
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]"),
+        "struct should have PartialEq, got:\n{pet}"
+    );
+
+    let status = files
+        .get("src/models/pet_status.rs")
+        .expect("pet_status.rs should exist");
+    assert!(
+        status.contains("Hash"),
+        "enum should have Hash, got:\n{status}"
+    );
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug, Clone)]"),
+        "response struct should have Clone, got:\n{api}"
+    );
+
+    let cargo = files.get("Cargo.toml").expect("Cargo.toml should exist");
+    assert!(
+        cargo.contains(r#"fake-crate = "1.0""#),
+        "Cargo.toml should have extra dep, got:\n{cargo}"
+    );
+}
+
+#[test]
+fn extra_derives_empty_derives_list() {
+    let with_empty = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = []
+        "#,
+    ));
+    let without = generate_petstore(toml::value::Table::new());
+
+    let pet_with = with_empty
+        .get("src/models/pet.rs")
+        .expect("pet.rs should exist");
+    let pet_without = without
+        .get("src/models/pet.rs")
+        .expect("pet.rs should exist");
+    assert_eq!(
+        pet_with, pet_without,
+        "empty derives list should produce identical output"
+    );
+}

--- a/crates/generators/openapi-nexus-rust-common/src/config.rs
+++ b/crates/generators/openapi-nexus-rust-common/src/config.rs
@@ -1,13 +1,60 @@
 //! Base configuration shared across all Rust generators.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use tracing::error;
+
+/// Extra derives for a single type-kind (structs, enums, unions, or response structs).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ExtraDeriveConfig {
+    #[serde(default)]
+    pub derives: Vec<String>,
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, String>,
+}
+
+/// Per-type-kind extra derive configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ExtraDerivesConfig {
+    #[serde(default)]
+    pub structs: Option<ExtraDeriveConfig>,
+    #[serde(default)]
+    pub enums: Option<ExtraDeriveConfig>,
+    #[serde(default)]
+    pub unions: Option<ExtraDeriveConfig>,
+    #[serde(default)]
+    pub response_structs: Option<ExtraDeriveConfig>,
+}
+
+impl ExtraDerivesConfig {
+    /// Collect all unique crate dependencies across every type-kind.
+    pub fn all_dependencies(&self) -> BTreeMap<String, String> {
+        let mut deps = BTreeMap::new();
+        for cfg in [
+            &self.structs,
+            &self.enums,
+            &self.unions,
+            &self.response_structs,
+        ]
+        .into_iter()
+        .flatten()
+        {
+            for (k, v) in &cfg.dependencies {
+                deps.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+        deps
+    }
+}
 
 /// Base configuration for Rust generators.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RustGeneratorConfig {
     #[serde(default)]
     pub crate_name: Option<String>,
+    #[serde(default)]
+    pub extra_derives: Option<ExtraDerivesConfig>,
 }
 
 impl From<toml::value::Table> for RustGeneratorConfig {
@@ -23,5 +70,139 @@ impl From<toml::value::Table> for RustGeneratorConfig {
                 Self::default()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(toml_str: &str) -> toml::value::Table {
+        toml::from_str::<toml::value::Table>(toml_str).unwrap()
+    }
+
+    #[test]
+    fn default_config_has_no_extra_derives() {
+        let config = RustGeneratorConfig::default();
+        assert!(config.crate_name.is_none());
+        assert!(config.extra_derives.is_none());
+    }
+
+    #[test]
+    fn deserialize_empty_table() {
+        let config = RustGeneratorConfig::from(toml::value::Table::new());
+        assert!(config.crate_name.is_none());
+        assert!(config.extra_derives.is_none());
+    }
+
+    #[test]
+    fn deserialize_crate_name_only() {
+        let config = RustGeneratorConfig::from(table(r#"crate_name = "my-sdk""#));
+        assert_eq!(config.crate_name.as_deref(), Some("my-sdk"));
+        assert!(config.extra_derives.is_none());
+    }
+
+    #[test]
+    fn deserialize_extra_derives_structs() {
+        let config = RustGeneratorConfig::from(table(
+            r#"
+            [extra_derives.structs]
+            derives = ["PartialEq", "Hash"]
+            "#,
+        ));
+        let extra = config.extra_derives.unwrap();
+        let structs = extra.structs.unwrap();
+        assert_eq!(structs.derives, vec!["PartialEq", "Hash"]);
+        assert!(structs.dependencies.is_empty());
+        assert!(extra.enums.is_none());
+        assert!(extra.unions.is_none());
+        assert!(extra.response_structs.is_none());
+    }
+
+    #[test]
+    fn deserialize_extra_derives_all_kinds() {
+        let config = RustGeneratorConfig::from(table(
+            r#"
+            [extra_derives.structs]
+            derives = ["PartialEq"]
+            [extra_derives.enums]
+            derives = ["Hash"]
+            [extra_derives.unions]
+            derives = ["Clone"]
+            [extra_derives.response_structs]
+            derives = ["PartialEq", "Eq"]
+            "#,
+        ));
+        let extra = config.extra_derives.unwrap();
+        assert_eq!(extra.structs.unwrap().derives, vec!["PartialEq"]);
+        assert_eq!(extra.enums.unwrap().derives, vec!["Hash"]);
+        assert_eq!(extra.unions.unwrap().derives, vec!["Clone"]);
+        assert_eq!(
+            extra.response_structs.unwrap().derives,
+            vec!["PartialEq", "Eq"]
+        );
+    }
+
+    #[test]
+    fn deserialize_extra_derives_with_dependencies() {
+        let config = RustGeneratorConfig::from(table(
+            r#"
+            [extra_derives.structs]
+            derives = ["utoipa::ToSchema"]
+            [extra_derives.structs.dependencies]
+            utoipa = '{ version = "5", features = ["openapi_extensions"] }'
+            "#,
+        ));
+        let structs = config.extra_derives.unwrap().structs.unwrap();
+        assert_eq!(structs.derives, vec!["utoipa::ToSchema"]);
+        assert_eq!(
+            structs.dependencies.get("utoipa").unwrap(),
+            r#"{ version = "5", features = ["openapi_extensions"] }"#
+        );
+    }
+
+    #[test]
+    fn all_dependencies_merges_across_kinds() {
+        let extra = ExtraDerivesConfig {
+            structs: Some(ExtraDeriveConfig {
+                derives: vec!["utoipa::ToSchema".into()],
+                dependencies: BTreeMap::from([
+                    ("utoipa".into(), r#"{ version = "5" }"#.into()),
+                    ("shared".into(), "\"1.0\"".into()),
+                ]),
+            }),
+            enums: Some(ExtraDeriveConfig {
+                derives: vec!["strum::Display".into()],
+                dependencies: BTreeMap::from([
+                    ("strum".into(), r#"{ version = "0.26" }"#.into()),
+                    ("shared".into(), "\"2.0\"".into()),
+                ]),
+            }),
+            unions: None,
+            response_structs: None,
+        };
+        let deps = extra.all_dependencies();
+        assert_eq!(deps.len(), 3);
+        assert_eq!(deps["shared"], "\"1.0\"");
+        assert!(deps.contains_key("utoipa"));
+        assert!(deps.contains_key("strum"));
+    }
+
+    #[test]
+    fn all_dependencies_empty_when_no_extra() {
+        let extra = ExtraDerivesConfig::default();
+        assert!(extra.all_dependencies().is_empty());
+    }
+
+    #[test]
+    fn invalid_config_falls_back_to_default() {
+        let mut t = toml::value::Table::new();
+        t.insert(
+            "extra_derives".into(),
+            toml::Value::String("invalid".into()),
+        );
+        let config = RustGeneratorConfig::from(t);
+        assert!(config.crate_name.is_none());
+        assert!(config.extra_derives.is_none());
     }
 }

--- a/crates/generators/openapi-nexus-rust-common/src/emit_api.rs
+++ b/crates/generators/openapi-nexus-rust-common/src/emit_api.rs
@@ -23,6 +23,7 @@ use sigil_stitch::spec::modifiers::{TypeKind, Visibility};
 use sigil_stitch::spec::type_spec::TypeSpec;
 use sigil_stitch::type_name::TypeName;
 
+use crate::config::ExtraDeriveConfig;
 use crate::emit_models::rust_type_str_qualified;
 
 // ---------------------------------------------------------------------------
@@ -50,6 +51,7 @@ pub fn generate_api_files(
     ir: &IrSpec,
     header: &str,
     config: &RustBackendConfig,
+    response_extra_derives: Option<&ExtraDeriveConfig>,
     body_emitter: &dyn Fn(&OpPlan<'_>) -> CodeBlock,
 ) -> Result<Vec<FileInfo>, String> {
     let by_tag = group_by_tag(&ir.operations);
@@ -60,7 +62,7 @@ pub fn generate_api_files(
         let stem = tag.to_snake_case();
         let filename = format!("{stem}.rs");
         mod_entries.push(stem);
-        let body = emit_api_file(tag, ops, config, body_emitter);
+        let body = emit_api_file(tag, ops, config, response_extra_derives, body_emitter);
         let content = format!("{header}{body}");
         files.push(FileInfo::api(filename, content));
     }
@@ -102,6 +104,7 @@ fn emit_api_file(
     tag: &str,
     ops: &[&IrOperation],
     config: &RustBackendConfig,
+    response_extra_derives: Option<&ExtraDeriveConfig>,
     body_emitter: &dyn Fn(&OpPlan<'_>) -> CodeBlock,
 ) -> String {
     let struct_name = format!("{}Api", tag.to_pascal_case());
@@ -179,7 +182,7 @@ fn emit_api_file(
 
     // Response structs -- add as TypeSpec members
     for plan in &plans {
-        fsb = fsb.add_type(emit_response_struct(plan));
+        fsb = fsb.add_type(emit_response_struct(plan, response_extra_derives));
     }
 
     let file = fsb.build().expect("FileSpec builds");
@@ -379,11 +382,19 @@ fn emit_operation(
     b.build().unwrap()
 }
 
-pub fn emit_response_struct(plan: &OpPlan<'_>) -> TypeSpec {
+pub fn emit_response_struct(plan: &OpPlan<'_>, extra: Option<&ExtraDeriveConfig>) -> TypeSpec {
     let mut tb = TypeSpec::builder(&plan.response_type, TypeKind::Struct);
     tb = tb.visibility(Visibility::Public);
     tb = tb.doc(&format!("Response from `{}`.", plan.method_name));
-    tb = tb.annotate(AnnotationSpec::new("derive").arg("Debug"));
+
+    let mut ann = AnnotationSpec::new("derive");
+    ann = ann.arg("Debug");
+    if let Some(cfg) = extra {
+        for d in &cfg.derives {
+            ann = ann.arg(d);
+        }
+    }
+    tb = tb.annotate(ann);
 
     // status_code field
     {

--- a/crates/generators/openapi-nexus-rust-common/src/emit_models.rs
+++ b/crates/generators/openapi-nexus-rust-common/src/emit_models.rs
@@ -22,13 +22,19 @@ use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::import_spec::ImportSpec;
 use sigil_stitch::type_name::TypeName;
 
+use crate::config::{ExtraDeriveConfig, RustGeneratorConfig};
+
 /// Generate every model file from the IR.
-pub fn generate_model_files(ir: &IrSpec, header: &str) -> Result<Vec<FileInfo>, String> {
+pub fn generate_model_files(
+    ir: &IrSpec,
+    header: &str,
+    config: &RustGeneratorConfig,
+) -> Result<Vec<FileInfo>, String> {
     let mut files = Vec::new();
     let mut mod_entries = Vec::new();
 
     for (_name, schema) in &ir.schemas {
-        let Some(file_spec) = emit_model_file(schema) else {
+        let Some(file_spec) = emit_model_file(schema, config) else {
             return Err(format!(
                 "unsupported schema kind for {}: {:?}",
                 schema.name, schema.kind
@@ -58,14 +64,34 @@ pub fn generate_model_files(ir: &IrSpec, header: &str) -> Result<Vec<FileInfo>, 
     Ok(files)
 }
 
-fn emit_model_file(schema: &IrSchema) -> Option<FileSpec> {
+fn emit_model_file(schema: &IrSchema, config: &RustGeneratorConfig) -> Option<FileSpec> {
+    let extra = config.extra_derives.as_ref();
     match &schema.kind {
-        IrSchemaKind::Object(obj) => emit_object(schema, obj),
-        IrSchemaKind::Enum(en) => emit_enum(schema, en),
+        IrSchemaKind::Object(obj) => {
+            emit_object(schema, obj, extra.and_then(|e| e.structs.as_ref()))
+        }
+        IrSchemaKind::Enum(en) => emit_enum(schema, en, extra.and_then(|e| e.enums.as_ref())),
         IrSchemaKind::Alias(expr) => emit_alias(schema, expr),
-        IrSchemaKind::Union(u) => emit_union(schema, u),
-        IrSchemaKind::Intersection(i) => emit_intersection(schema, i),
-        IrSchemaKind::TaggedUnion(tu) => emit_tagged_union(schema, tu),
+        IrSchemaKind::Union(u) => emit_union(schema, u, extra.and_then(|e| e.unions.as_ref())),
+        IrSchemaKind::Intersection(i) => {
+            emit_intersection(schema, i, extra.and_then(|e| e.structs.as_ref()))
+        }
+        IrSchemaKind::TaggedUnion(tu) => {
+            emit_tagged_union(schema, tu, extra.and_then(|e| e.unions.as_ref()))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Derive attribute helper
+// ---------------------------------------------------------------------------
+
+fn derive_attr(base: &str, extra: Option<&ExtraDeriveConfig>) -> String {
+    match extra {
+        Some(cfg) if !cfg.derives.is_empty() => {
+            format!("#[derive({base}, {})]", cfg.derives.join(", "))
+        }
+        _ => format!("#[derive({base})]"),
     }
 }
 
@@ -73,7 +99,11 @@ fn emit_model_file(schema: &IrSchema) -> Option<FileSpec> {
 // Object -> struct
 // ---------------------------------------------------------------------------
 
-fn emit_object(schema: &IrSchema, obj: &IrObject) -> Option<FileSpec> {
+fn emit_object(
+    schema: &IrSchema,
+    obj: &IrObject,
+    extra: Option<&ExtraDeriveConfig>,
+) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
     let stem = schema.name.to_snake_case();
 
@@ -86,7 +116,10 @@ fn emit_object(schema: &IrSchema, obj: &IrObject) -> Option<FileSpec> {
     if let Some(doc) = &schema.description {
         emit_doc_comment(&mut body, doc);
     }
-    body.add("#[derive(Debug, Clone, Serialize, Deserialize)]", ());
+    body.add(
+        &derive_attr("Debug, Clone, Serialize, Deserialize", extra),
+        (),
+    );
     body.add_line();
     body.add(&format!("pub struct {name}"), ());
     body.begin_control_flow("", ());
@@ -141,7 +174,11 @@ fn emit_object(schema: &IrSchema, obj: &IrObject) -> Option<FileSpec> {
 // Enum
 // ---------------------------------------------------------------------------
 
-fn emit_enum(schema: &IrSchema, en: &IrEnum) -> Option<FileSpec> {
+fn emit_enum(
+    schema: &IrSchema,
+    en: &IrEnum,
+    extra: Option<&ExtraDeriveConfig>,
+) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
 
     match en.value_type {
@@ -149,7 +186,7 @@ fn emit_enum(schema: &IrSchema, en: &IrEnum) -> Option<FileSpec> {
             return emit_type_alias_file(schema, "serde_json::Value");
         }
         IrEnumValueType::Integer => {
-            return emit_integer_enum(schema, en);
+            return emit_integer_enum(schema, en, extra);
         }
         IrEnumValueType::String => {}
     }
@@ -165,7 +202,7 @@ fn emit_enum(schema: &IrSchema, en: &IrEnum) -> Option<FileSpec> {
         emit_doc_comment(&mut body, doc);
     }
     body.add(
-        "#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]",
+        &derive_attr("Debug, Clone, PartialEq, Eq, Serialize, Deserialize", extra),
         (),
     );
     body.add_line();
@@ -196,7 +233,11 @@ fn emit_enum(schema: &IrSchema, en: &IrEnum) -> Option<FileSpec> {
     fsb.build().ok()
 }
 
-fn emit_integer_enum(schema: &IrSchema, en: &IrEnum) -> Option<FileSpec> {
+fn emit_integer_enum(
+    schema: &IrSchema,
+    en: &IrEnum,
+    extra: Option<&ExtraDeriveConfig>,
+) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
     let stem = schema.name.to_snake_case();
 
@@ -210,7 +251,10 @@ fn emit_integer_enum(schema: &IrSchema, en: &IrEnum) -> Option<FileSpec> {
         emit_doc_comment(&mut body, doc);
     }
     body.add(
-        "#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize_repr, Deserialize_repr)]",
+        &derive_attr(
+            "Debug, Clone, Copy, PartialEq, Eq, Serialize_repr, Deserialize_repr",
+            extra,
+        ),
         (),
     );
     body.add_line();
@@ -294,7 +338,11 @@ fn emit_type_alias_file(schema: &IrSchema, rhs_str: &str) -> Option<FileSpec> {
 // Union -> #[serde(untagged)] enum
 // ---------------------------------------------------------------------------
 
-fn emit_union(schema: &IrSchema, union: &IrUnion) -> Option<FileSpec> {
+fn emit_union(
+    schema: &IrSchema,
+    union: &IrUnion,
+    extra: Option<&ExtraDeriveConfig>,
+) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
     let stem = schema.name.to_snake_case();
 
@@ -307,7 +355,10 @@ fn emit_union(schema: &IrSchema, union: &IrUnion) -> Option<FileSpec> {
     if let Some(doc) = &schema.description {
         emit_doc_comment(&mut body, doc);
     }
-    body.add("#[derive(Debug, Clone, Serialize, Deserialize)]", ());
+    body.add(
+        &derive_attr("Debug, Clone, Serialize, Deserialize", extra),
+        (),
+    );
     body.add_line();
     body.add("#[serde(untagged)]", ());
     body.add_line();
@@ -353,7 +404,11 @@ fn primitive_variant_name(p: &IrPrimitive) -> String {
 // TaggedUnion -> serde-tagged enum
 // ---------------------------------------------------------------------------
 
-fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<FileSpec> {
+fn emit_tagged_union(
+    schema: &IrSchema,
+    tu: &IrTaggedUnion,
+    extra: Option<&ExtraDeriveConfig>,
+) -> Option<FileSpec> {
     if tu.variants.is_empty() {
         return None;
     }
@@ -370,7 +425,10 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<FileSpec> 
     if let Some(doc) = &schema.description {
         emit_doc_comment(&mut body, doc);
     }
-    body.add("#[derive(Debug, Clone, Serialize, Deserialize)]", ());
+    body.add(
+        &derive_attr("Debug, Clone, Serialize, Deserialize", extra),
+        (),
+    );
     body.add_line();
 
     match &tu.tagging {
@@ -427,7 +485,11 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<FileSpec> 
 // Intersection -> flattened struct
 // ---------------------------------------------------------------------------
 
-fn emit_intersection(schema: &IrSchema, inter: &IrIntersection) -> Option<FileSpec> {
+fn emit_intersection(
+    schema: &IrSchema,
+    inter: &IrIntersection,
+    extra: Option<&ExtraDeriveConfig>,
+) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
     let stem = schema.name.to_snake_case();
 
@@ -440,7 +502,10 @@ fn emit_intersection(schema: &IrSchema, inter: &IrIntersection) -> Option<FileSp
     if let Some(doc) = &schema.description {
         emit_doc_comment(&mut body, doc);
     }
-    body.add("#[derive(Debug, Clone, Serialize, Deserialize)]", ());
+    body.add(
+        &derive_attr("Debug, Clone, Serialize, Deserialize", extra),
+        (),
+    );
     body.add_line();
     body.add(&format!("pub struct {name}"), ());
     body.begin_control_flow("", ());

--- a/crates/generators/openapi-nexus-rust-reqwest/src/codegen/rust_reqwest_code_generator.rs
+++ b/crates/generators/openapi-nexus-rust-reqwest/src/codegen/rust_reqwest_code_generator.rs
@@ -50,22 +50,33 @@ impl RustReqwestCodeGenerator {
 
         // Models (shared)
         files.extend(
-            emit_models::generate_model_files(ir, &header).map_err(|msg| {
+            emit_models::generate_model_files(ir, &header, &self.config).map_err(|msg| {
                 Box::<dyn Error + Send + Sync>::from(format!("emit_models: {msg}"))
             })?,
         );
 
         // APIs (shared planning + reqwest body emitter)
+        let response_extra = self
+            .config
+            .extra_derives
+            .as_ref()
+            .and_then(|e| e.response_structs.as_ref());
         files.extend(
-            emit_api::generate_api_files(ir, &header, &backend_config, &emit_method_body)
-                .map_err(|msg| Box::<dyn Error + Send + Sync>::from(format!("emit_api: {msg}")))?,
+            emit_api::generate_api_files(
+                ir,
+                &header,
+                &backend_config,
+                response_extra,
+                &emit_method_body,
+            )
+            .map_err(|msg| Box::<dyn Error + Send + Sync>::from(format!("emit_api: {msg}")))?,
         );
 
         // Runtime (reqwest-specific)
         files.extend(runtime_files(&header));
 
         // Project files
-        files.push(cargo_toml_file(&crate_name, &ir.info));
+        files.push(cargo_toml_file(&crate_name, &ir.info, &self.config));
         files.push(project_files::lib_rs_file(&header));
         files.push(project_files::readme_file(&ir.info));
 
@@ -93,7 +104,7 @@ impl FileWriter for RustReqwestCodeGenerator {
     }
 }
 
-fn cargo_toml_file(crate_name: &str, info: &IrInfo) -> FileInfo {
+fn cargo_toml_file(crate_name: &str, info: &IrInfo, config: &RustGeneratorConfig) -> FileInfo {
     let description = info
         .description
         .as_deref()
@@ -101,7 +112,7 @@ fn cargo_toml_file(crate_name: &str, info: &IrInfo) -> FileInfo {
         .lines()
         .next()
         .unwrap_or("Generated Rust SDK.");
-    let content = format!(
+    let mut content = format!(
         r#"[package]
 name = "{crate_name}"
 version = "0.1.0"
@@ -116,5 +127,10 @@ serde_repr = "0.1"
 tokio = {{ version = "1", features = ["full"] }}
 "#,
     );
+    if let Some(extra) = &config.extra_derives {
+        for (name, spec) in extra.all_dependencies() {
+            content.push_str(&format!("{name} = {spec}\n"));
+        }
+    }
     FileInfo::project("Cargo.toml".to_string(), content)
 }

--- a/crates/generators/openapi-nexus-rust-reqwest/tests/extra_derives_tests.rs
+++ b/crates/generators/openapi-nexus-rust-reqwest/tests/extra_derives_tests.rs
@@ -1,0 +1,228 @@
+//! Integration tests for extra_derives config in rust-reqwest generator.
+
+use openapi_nexus_rust_reqwest::RustReqwestCodeGenerator;
+use openapi_nexus_test_utils::{generate_files, read_fixture};
+
+fn build_config(toml_str: &str) -> toml::value::Table {
+    toml::from_str::<toml::value::Table>(toml_str).unwrap()
+}
+
+fn generate_petstore(config: toml::value::Table) -> std::collections::HashMap<String, String> {
+    let generator = RustReqwestCodeGenerator::new(config);
+    let spec = read_fixture("valid/petstore.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+fn generate_union(config: toml::value::Table) -> std::collections::HashMap<String, String> {
+    let generator = RustReqwestCodeGenerator::new(config);
+    let spec = read_fixture("valid/type-aliases/union-with-interfaces.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+#[test]
+fn no_extra_derives_default_output() {
+    let files = generate_petstore(toml::value::Table::new());
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "struct should have default derives, got:\n{pet}"
+    );
+    assert!(
+        !pet.contains("PartialEq"),
+        "struct should not have PartialEq by default"
+    );
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug)]"),
+        "response struct should have only Debug derive"
+    );
+}
+
+#[test]
+fn extra_derives_on_structs() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = ["PartialEq", "Hash"]
+        "#,
+    ));
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]"),
+        "struct should have extra derives appended, got:\n{pet}"
+    );
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug)]"),
+        "response struct should not be affected by structs config"
+    );
+    assert!(
+        !api.contains("PartialEq"),
+        "response struct should not have PartialEq from structs config"
+    );
+}
+
+#[test]
+fn extra_derives_on_enums() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.enums]
+        derives = ["Hash"]
+        "#,
+    ));
+
+    let status = files
+        .get("src/models/pet_status.rs")
+        .expect("pet_status.rs should exist");
+    assert!(
+        status.contains("#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]"),
+        "string enum should have Hash appended, got:\n{status}"
+    );
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "struct should be unaffected by enums config"
+    );
+}
+
+#[test]
+fn extra_derives_on_unions() {
+    let files = generate_union(build_config(
+        r#"
+        [extra_derives.unions]
+        derives = ["PartialEq"]
+        "#,
+    ));
+
+    let has_union_derive = files.values().any(|content| {
+        content.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]")
+            && content.contains("#[serde(untagged)]")
+    });
+    assert!(has_union_derive, "union should have PartialEq appended");
+
+    let struct_files: Vec<_> = files
+        .iter()
+        .filter(|(k, v)| {
+            k.starts_with("src/models/") && *k != "src/models/mod.rs" && v.contains("pub struct")
+        })
+        .collect();
+    for (path, content) in &struct_files {
+        assert!(
+            !content.contains("PartialEq"),
+            "struct in {path} should not be affected by unions config"
+        );
+    }
+}
+
+#[test]
+fn extra_derives_on_response_structs() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.response_structs]
+        derives = ["Clone", "PartialEq"]
+        "#,
+    ));
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug, Clone, PartialEq)]"),
+        "response struct should have extra derives, got:\n{api}"
+    );
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "model struct should be unaffected by response_structs config"
+    );
+}
+
+#[test]
+fn extra_derives_cargo_toml_deps() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = ["utoipa::ToSchema"]
+        [extra_derives.structs.dependencies]
+        utoipa = '{ version = "5", features = ["openapi_extensions"] }'
+        "#,
+    ));
+
+    let cargo = files.get("Cargo.toml").expect("Cargo.toml should exist");
+    assert!(
+        cargo.contains("reqwest"),
+        "Cargo.toml should still have reqwest dep"
+    );
+    assert!(
+        cargo.contains(r#"utoipa = { version = "5", features = ["openapi_extensions"] }"#),
+        "Cargo.toml should contain extra dependency, got:\n{cargo}"
+    );
+}
+
+#[test]
+fn extra_derives_all_kinds_together() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = ["PartialEq"]
+        [extra_derives.structs.dependencies]
+        fake-crate = '"1.0"'
+        [extra_derives.enums]
+        derives = ["Hash"]
+        [extra_derives.response_structs]
+        derives = ["Clone"]
+        "#,
+    ));
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]"),
+        "struct should have PartialEq, got:\n{pet}"
+    );
+
+    let status = files
+        .get("src/models/pet_status.rs")
+        .expect("pet_status.rs should exist");
+    assert!(
+        status.contains("Hash"),
+        "enum should have Hash, got:\n{status}"
+    );
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug, Clone)]"),
+        "response struct should have Clone, got:\n{api}"
+    );
+
+    let cargo = files.get("Cargo.toml").expect("Cargo.toml should exist");
+    assert!(
+        cargo.contains(r#"fake-crate = "1.0""#),
+        "Cargo.toml should have extra dep, got:\n{cargo}"
+    );
+}
+
+#[test]
+fn extra_derives_empty_derives_list() {
+    let with_empty = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = []
+        "#,
+    ));
+    let without = generate_petstore(toml::value::Table::new());
+
+    let pet_with = with_empty
+        .get("src/models/pet.rs")
+        .expect("pet.rs should exist");
+    let pet_without = without
+        .get("src/models/pet.rs")
+        .expect("pet.rs should exist");
+    assert_eq!(
+        pet_with, pet_without,
+        "empty derives list should produce identical output"
+    );
+}

--- a/crates/generators/openapi-nexus-rust-ureq/src/codegen/rust_ureq_code_generator.rs
+++ b/crates/generators/openapi-nexus-rust-ureq/src/codegen/rust_ureq_code_generator.rs
@@ -42,19 +42,30 @@ impl RustUreqCodeGenerator {
         let mut files = Vec::new();
 
         files.extend(
-            emit_models::generate_model_files(ir, &header).map_err(|msg| {
+            emit_models::generate_model_files(ir, &header, &self.config).map_err(|msg| {
                 Box::<dyn Error + Send + Sync>::from(format!("emit_models: {msg}"))
             })?,
         );
 
+        let response_extra = self
+            .config
+            .extra_derives
+            .as_ref()
+            .and_then(|e| e.response_structs.as_ref());
         files.extend(
-            emit_api::generate_api_files(ir, &header, &backend_config, &emit_method_body)
-                .map_err(|msg| Box::<dyn Error + Send + Sync>::from(format!("emit_api: {msg}")))?,
+            emit_api::generate_api_files(
+                ir,
+                &header,
+                &backend_config,
+                response_extra,
+                &emit_method_body,
+            )
+            .map_err(|msg| Box::<dyn Error + Send + Sync>::from(format!("emit_api: {msg}")))?,
         );
 
         files.extend(runtime_files(&header));
 
-        files.push(cargo_toml_file(&crate_name, &ir.info));
+        files.push(cargo_toml_file(&crate_name, &ir.info, &self.config));
         files.push(project_files::lib_rs_file(&header));
         files.push(project_files::readme_file(&ir.info));
 
@@ -82,7 +93,7 @@ impl FileWriter for RustUreqCodeGenerator {
     }
 }
 
-fn cargo_toml_file(crate_name: &str, info: &IrInfo) -> FileInfo {
+fn cargo_toml_file(crate_name: &str, info: &IrInfo, config: &RustGeneratorConfig) -> FileInfo {
     let description = info
         .description
         .as_deref()
@@ -90,7 +101,7 @@ fn cargo_toml_file(crate_name: &str, info: &IrInfo) -> FileInfo {
         .lines()
         .next()
         .unwrap_or("Generated Rust SDK.");
-    let content = format!(
+    let mut content = format!(
         r#"[package]
 name = "{crate_name}"
 version = "0.1.0"
@@ -104,5 +115,10 @@ serde_json = "1"
 serde_repr = "0.1"
 "#,
     );
+    if let Some(extra) = &config.extra_derives {
+        for (name, spec) in extra.all_dependencies() {
+            content.push_str(&format!("{name} = {spec}\n"));
+        }
+    }
     FileInfo::project("Cargo.toml".to_string(), content)
 }

--- a/crates/generators/openapi-nexus-rust-ureq/tests/extra_derives_tests.rs
+++ b/crates/generators/openapi-nexus-rust-ureq/tests/extra_derives_tests.rs
@@ -1,0 +1,224 @@
+//! Integration tests for extra_derives config in rust-ureq generator.
+
+use openapi_nexus_rust_ureq::RustUreqCodeGenerator;
+use openapi_nexus_test_utils::{generate_files, read_fixture};
+
+fn build_config(toml_str: &str) -> toml::value::Table {
+    toml::from_str::<toml::value::Table>(toml_str).unwrap()
+}
+
+fn generate_petstore(config: toml::value::Table) -> std::collections::HashMap<String, String> {
+    let generator = RustUreqCodeGenerator::new(config);
+    let spec = read_fixture("valid/petstore.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+fn generate_union(config: toml::value::Table) -> std::collections::HashMap<String, String> {
+    let generator = RustUreqCodeGenerator::new(config);
+    let spec = read_fixture("valid/type-aliases/union-with-interfaces.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+#[test]
+fn no_extra_derives_default_output() {
+    let files = generate_petstore(toml::value::Table::new());
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "struct should have default derives, got:\n{pet}"
+    );
+    assert!(
+        !pet.contains("PartialEq"),
+        "struct should not have PartialEq by default"
+    );
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug)]"),
+        "response struct should have only Debug derive"
+    );
+}
+
+#[test]
+fn extra_derives_on_structs() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = ["PartialEq", "Hash"]
+        "#,
+    ));
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]"),
+        "struct should have extra derives appended, got:\n{pet}"
+    );
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug)]"),
+        "response struct should not be affected by structs config"
+    );
+}
+
+#[test]
+fn extra_derives_on_enums() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.enums]
+        derives = ["Hash"]
+        "#,
+    ));
+
+    let status = files
+        .get("src/models/pet_status.rs")
+        .expect("pet_status.rs should exist");
+    assert!(
+        status.contains("#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]"),
+        "string enum should have Hash appended, got:\n{status}"
+    );
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "struct should be unaffected by enums config"
+    );
+}
+
+#[test]
+fn extra_derives_on_unions() {
+    let files = generate_union(build_config(
+        r#"
+        [extra_derives.unions]
+        derives = ["PartialEq"]
+        "#,
+    ));
+
+    let has_union_derive = files.values().any(|content| {
+        content.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]")
+            && content.contains("#[serde(untagged)]")
+    });
+    assert!(has_union_derive, "union should have PartialEq appended");
+
+    let struct_files: Vec<_> = files
+        .iter()
+        .filter(|(k, v)| {
+            k.starts_with("src/models/") && *k != "src/models/mod.rs" && v.contains("pub struct")
+        })
+        .collect();
+    for (path, content) in &struct_files {
+        assert!(
+            !content.contains("PartialEq"),
+            "struct in {path} should not be affected by unions config"
+        );
+    }
+}
+
+#[test]
+fn extra_derives_on_response_structs() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.response_structs]
+        derives = ["Clone", "PartialEq"]
+        "#,
+    ));
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug, Clone, PartialEq)]"),
+        "response struct should have extra derives, got:\n{api}"
+    );
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"),
+        "model struct should be unaffected by response_structs config"
+    );
+}
+
+#[test]
+fn extra_derives_cargo_toml_deps() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = ["utoipa::ToSchema"]
+        [extra_derives.structs.dependencies]
+        utoipa = '{ version = "5", features = ["openapi_extensions"] }'
+        "#,
+    ));
+
+    let cargo = files.get("Cargo.toml").expect("Cargo.toml should exist");
+    assert!(
+        cargo.contains("ureq"),
+        "Cargo.toml should still have ureq dep"
+    );
+    assert!(
+        cargo.contains(r#"utoipa = { version = "5", features = ["openapi_extensions"] }"#),
+        "Cargo.toml should contain extra dependency, got:\n{cargo}"
+    );
+}
+
+#[test]
+fn extra_derives_all_kinds_together() {
+    let files = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = ["PartialEq"]
+        [extra_derives.structs.dependencies]
+        fake-crate = '"1.0"'
+        [extra_derives.enums]
+        derives = ["Hash"]
+        [extra_derives.response_structs]
+        derives = ["Clone"]
+        "#,
+    ));
+
+    let pet = files.get("src/models/pet.rs").expect("pet.rs should exist");
+    assert!(
+        pet.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]"),
+        "struct should have PartialEq, got:\n{pet}"
+    );
+
+    let status = files
+        .get("src/models/pet_status.rs")
+        .expect("pet_status.rs should exist");
+    assert!(
+        status.contains("Hash"),
+        "enum should have Hash, got:\n{status}"
+    );
+
+    let api = files.get("src/apis/pet.rs").expect("pet api should exist");
+    assert!(
+        api.contains("#[derive(Debug, Clone)]"),
+        "response struct should have Clone, got:\n{api}"
+    );
+
+    let cargo = files.get("Cargo.toml").expect("Cargo.toml should exist");
+    assert!(
+        cargo.contains(r#"fake-crate = "1.0""#),
+        "Cargo.toml should have extra dep, got:\n{cargo}"
+    );
+}
+
+#[test]
+fn extra_derives_empty_derives_list() {
+    let with_empty = generate_petstore(build_config(
+        r#"
+        [extra_derives.structs]
+        derives = []
+        "#,
+    ));
+    let without = generate_petstore(toml::value::Table::new());
+
+    let pet_with = with_empty
+        .get("src/models/pet.rs")
+        .expect("pet.rs should exist");
+    let pet_without = without
+        .get("src/models/pet.rs")
+        .expect("pet.rs should exist");
+    assert_eq!(
+        pet_with, pet_without,
+        "empty derives list should produce identical output"
+    );
+}


### PR DESCRIPTION
## Summary

- Add per-type-kind `extra_derives` config to Rust generators (structs, enums, unions, response_structs)
- Each type-kind supports a list of extra derive names and a map of crate dependencies
- Extra dependencies are automatically appended to the generated `Cargo.toml`
- Works across all 3 Rust backends (reqwest, ureq, aioduct)

Example config:
```toml
[generators.rust-reqwest.extra_derives.structs]
derives = ["PartialEq", "utoipa::ToSchema"]

[generators.rust-reqwest.extra_derives.structs.dependencies]
utoipa = '{ version = "5", features = ["openapi_extensions"] }'
```

## Test plan

- [x] 9 unit tests for config deserialization and `all_dependencies()` merging
- [x] 8 integration tests per backend (24 total) covering: default output, structs, enums, unions, response structs, Cargo.toml deps, all-kinds-together, empty-derives identity
- [x] All existing golden tests pass unchanged (no extra derives configured = identical output)
- [x] `cargo clippy --workspace -- -D warnings` clean