### PR TITLE
fix(ci): replace extractions/setup-just with taiki-e/install-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
             cmd: just golden::build-python-requests
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v4
+      - uses: taiki-e/install-action@just
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         if: contains(matrix.generator, 'rust-')
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- `extractions/setup-just@v4` fails with `no release for just matching version specifier` on master, breaking all golden builds
- Replace with `taiki-e/install-action@just`, which is already used for `nextest` in the same workflow

## Test plan
- [ ] CI golden builds pass (especially `go-http` which was failing)