### PR TITLE
chore(ci): bump actions/setup-python to v6, replace deprecated peaceiris/actions-mdbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: peaceiris/actions-mdbook@v2
-        with:
-          mdbook-version: 'latest'
+      - uses: taiki-e/install-action@mdbook
       - uses: taiki-e/install-action@just
       - run: cargo install mdbook-mermaid-mmdr
       - run: just book
@@ -164,7 +162,7 @@ jobs:
         if: matrix.generator == 'go-http'
         with:
           go-version: 'stable'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: contains(matrix.generator, 'python-')
         with:
           python-version: '3.12'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,9 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: peaceiris/actions-mdbook@v2
-        with:
-          mdbook-version: 'latest'
+      - uses: taiki-e/install-action@mdbook
       - uses: taiki-e/install-action@just
       - run: cargo install mdbook-mermaid-mmdr
       - run: just book


### PR DESCRIPTION
## Summary

- Bump `actions/setup-python` from v5 to v6 (Node.js 20 deprecation)
- Replace `peaceiris/actions-mdbook@v2` (Node.js 20) with `taiki-e/install-action@mdbook` in both ci.yml and pages.yml

## Test plan

- [x] CI should pass without Node.js 20 deprecation warnings