### PR TITLE
fix(rust-aioduct): bump aioduct 0.1.3 → 0.1.6

### DIFF
--- a/src/generators/rust/aioduct/codegen.rs
+++ b/src/generators/rust/aioduct/codegen.rs
@@ -109,7 +109,7 @@ edition = "2024"
 description = "{description}"
 
 [dependencies]
-aioduct = {{ version = "0.1.3", features = ["tokio", "rustls", "json"] }}
+aioduct = {{ version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }}
 serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "API demonstrating OpenAPI additionalProperties with multiple levels of structs (RootLevel -> MiddleLevel -> LeafValue), each with HashMap fields."
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Comprehensive test for all OpenAPI v3.1.2 schema types"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for DELETE operations with JSON response schemas and type alias request bodies"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test API with duplicate parameter names across different locations"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This API demonstrates all 4 kinds of enum representation types: Externally Tagged, Internally Tagged, Adjacently Tagged, and Untagged"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for interfaces that reference enum types"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test API with multiple operations having similar request body schema names"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture to verify language property naming conventions"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This is a sample Pet Store Server based on the OpenAPI 3.1 specification"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for query parameters that reference enum schemas"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for object with all optional properties including arrays, references, and inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects with snake_case to camelCase conversion (main case from user issue)"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of referenced model types with recursive FromJSON calls"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects that contain a reference property"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects where each object has nested inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for three levels of nested inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for empty array handling"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for inline object containing an array of inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for inline objects (not arrays) with snake_case to camelCase conversion"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for object with mix of simple types, arrays, references, and inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for nested object reference with recursive FromJSON calls"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional array of inline objects with snake_case to camelCase conversion"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional array of referenced model types"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional nested object reference"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for arrays with primitive items (should not be affected by recursive parsing)"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers non-JSON request body media types to pin Content-Type emission."
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This is a test API specification that includes various server configurations"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for complex union types"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variants are inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for internally tagged (adjacently tagged) discriminator unions."
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture with multiple discriminated unions to verify Kind types"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variants are references to component schemas."
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for allOf intersection types"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for allOf intersection types with nullable reference properties"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types that reference other union types"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for simple type aliases (not unions or intersections)"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types with both interfaces and primitives"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types that include the any type"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types (oneOf) with inline object schemas that should generate named interfaces"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for oneOf/anyOf union types with interface members"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types with primitive members"
 
 [dependencies]
-aioduct = { version = "0.1.3", features = ["tokio", "rustls", "json"] }
+aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"


### PR DESCRIPTION
## Summary

- Bump `aioduct` dependency from 0.1.3 to 0.1.6
- Add required `rustls-ring` feature (rustls now requires an explicit crypto provider)
- Regenerate all 47 golden Cargo.toml files

No API changes needed — all existing method signatures (`Client::new`, `RequestBuilder::header_str`, `.json()`, `.send()`, `.bearer_auth()`) are unchanged in 0.1.6.

## Test plan

- [x] `cargo test --test golden_tests_rust_aioduct` — 47/47 pass
- [x] `just golden-rust::build-aioduct` — 47/47 compile with aioduct 0.1.6