### PR TITLE
feat: convert CodeBlock::builder() sites to sigil_quote!()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,9 +1380,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-stitch"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dded794d62a1f3e3c02fbb92397b433c39a9a1cb03877f4f3f10b79c02f1a5cd"
+checksum = "1fa196314ccc321b930e402dcc4998a652fae2322adfddcaf4bca64c064d13a5"
 dependencies = [
  "pretty",
  "serde",
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45683b72d7a10c0e87fe272c7d8984afb5ff2650fbe1ce24cfc19c9359067ab2"
+checksum = "ec9683fc90b7aad315f87f38e5353b04fe750aba38c59b4a8306e06714a4e05a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.148"
 serde_norway = "0.9.42"
 serde_plain = "1.0.2"
-sigil-stitch = "0.4.1"
+sigil-stitch = "0.4.3"
 similar = "2.7.0"
 snafu = "0.8.9"
 toml = "0.9.8"

--- a/src/generators/go/http/sigil_emit.rs
+++ b/src/generators/go/http/sigil_emit.rs
@@ -22,7 +22,7 @@ use crate::ir::types::{
     IrSchemaKind, IrSpec, IrTaggedUnion, IrTypeExpr, IrUnion, TaggingStyle,
 };
 use heck::{ToPascalCase, ToSnakeCase};
-use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::{CodeBlock, sigil_quote};
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::modifiers::TypeKind;
@@ -259,9 +259,10 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<String> {
 
 /// Build a `package models` header block.
 fn package_header() -> CodeBlock {
-    let mut b = CodeBlock::builder();
-    b.add(&format!("package {MODELS_PACKAGE}"), ());
-    b.build().expect("package header builds")
+    sigil_quote!(GoLang {
+        package $L(MODELS_PACKAGE)
+    })
+    .expect("package header builds")
 }
 
 /// Render a simple type-alias file: package + optional doc + `type X = Y`.

--- a/src/generators/go/http/sigil_emit_api.rs
+++ b/src/generators/go/http/sigil_emit_api.rs
@@ -25,6 +25,7 @@ use crate::ir::types::{
 };
 use heck::{ToLowerCamelCase, ToPascalCase, ToSnakeCase};
 use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::sigil_quote;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -208,9 +209,10 @@ fn collect_stringify_imports(t: &IrTypeExpr, pkgs: &mut BTreeSet<String>) {
 
 /// Build a `package apis` header block.
 fn package_header() -> CodeBlock {
-    let mut b = CodeBlock::builder();
-    b.add(&format!("package {APIS_PACKAGE}"), ());
-    b.build().expect("package header builds")
+    sigil_quote!(GoLang {
+        package $L(APIS_PACKAGE)
+    })
+    .expect("package header builds")
 }
 
 /// Build the API struct: `type {Name}API struct { client *runtime.Client }`
@@ -235,8 +237,10 @@ fn build_constructor(struct_name: &str, module_path: &str) -> FunSpec {
     let runtime_client_ty = TypeName::importable(&format!("{module_path}/runtime"), "Client");
     let func_name = format!("New{struct_name}");
 
-    let mut body = CodeBlock::builder();
-    body.add(&format!("return &{struct_name}{{client: client}}"), ());
+    let body = sigil_quote!(GoLang {
+        $L(format!("return &{struct_name}{{client: client}}"))
+    })
+    .expect("constructor body builds");
 
     FunSpec::builder(&func_name)
         .doc(&format!(
@@ -247,7 +251,7 @@ fn build_constructor(struct_name: &str, module_path: &str) -> FunSpec {
                 .expect("param builds"),
         )
         .returns(TypeName::pointer(TypeName::primitive(struct_name)))
-        .body(body.build().expect("constructor body builds"))
+        .body(body)
         .build()
         .expect("constructor FunSpec builds")
 }
@@ -661,21 +665,16 @@ fn emit_decode_into(field: &str, go_ty: &str) -> CodeBlock {
             format!("resp.{field} = &payload"),
         )
     };
-    let mut cb = CodeBlock::builder();
-    cb.add("%>", ());
-    cb.add(&format!("var payload {elem_ty}"), ());
-    cb.add_line();
-    cb.begin_control_flow(
-        "if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil",
-        (),
-    );
-    cb.add("return nil, fmt.Errorf(\"decode response: %%w\", err)", ());
-    cb.add_line();
-    cb.end_control_flow();
-    cb.add(&assignment, ());
-    cb.add_line();
-    cb.add("%<", ());
-    cb.build().expect("decode body builds")
+    sigil_quote!(GoLang {
+        $>
+        $L(format!("var payload {elem_ty}"))
+        $L("if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil") {
+            $L("return nil, fmt.Errorf(\"decode response: %w\", err)")
+        }
+        $L(assignment)
+        $<
+    })
+    .expect("decode body builds")
 }
 
 fn deref_if_pointer(var: &str, is_pointer: bool) -> String {

--- a/src/generators/rust/common/emit_models.rs
+++ b/src/generators/rust/common/emit_models.rs
@@ -16,8 +16,7 @@ use crate::ir::types::{
     IrTaggedUnion, IrTypeExpr, IrUnion, TaggingStyle,
 };
 use heck::{ToPascalCase, ToSnakeCase};
-use sigil_stitch::code_block::{CodeBlock, StringLitArg};
-use sigil_stitch::prelude::sigil_quote;
+use sigil_stitch::prelude::{CodeBlock, sigil_quote};
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::import_spec::ImportSpec;
 use sigil_stitch::type_name::TypeName;
@@ -111,62 +110,35 @@ fn emit_object(
     fsb = fsb.add_import(ImportSpec::named("serde", "Deserialize"));
     fsb = fsb.add_import(ImportSpec::named("serde", "Serialize"));
 
-    let mut body = CodeBlock::builder();
-
-    if let Some(doc) = &schema.description {
-        emit_doc_comment(&mut body, doc);
-    }
-    body.add(
-        &derive_attr("Debug, Clone, Serialize, Deserialize", extra),
-        (),
-    );
-    body.add_line();
-    body.add(&format!("pub struct {name}"), ());
-    body.begin_control_flow("", ());
-
-    for (json_name, prop) in &obj.properties {
-        if let Some(desc) = &prop.description {
-            emit_doc_comment(&mut body, desc);
+    let body = sigil_quote!(RustLang {
+        $if(schema.description.is_some()) {
+            $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
         }
-        let raw_field_name = json_name.to_snake_case();
-        let field_name = escape_rust_keyword(&raw_field_name);
-        let needs_rename = field_name != *json_name;
-        let is_optional = !prop.required || prop.nullable;
-
-        if needs_rename {
-            body.add(&format!("#[serde(rename = \"{json_name}\")]"), ());
-            body.add_line();
+        $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+        pub struct $N(name.as_str()) {
+            $for((json_name, prop) in obj.properties.iter()) {
+                $if(prop.description.is_some()) {
+                    $L(doc_comment_block(prop.description.as_deref().unwrap()).trim_end())
+                }
+                $if(escape_rust_keyword(&json_name.to_snake_case()) != *json_name) {
+                    $L(format!("#[serde(rename = \"{json_name}\")]"))
+                }
+                $if(!prop.required || prop.nullable) {
+                    #[serde(skip_serializing_if = "Option::is_none", default)]
+                    $L(format!("pub {}: Option<{}>,", escape_rust_keyword(&json_name.to_snake_case()), rust_type_str_model(&prop.type_expr)))
+                } $else {
+                    $L(format!("pub {}: {},", escape_rust_keyword(&json_name.to_snake_case()), rust_type_str_model(&prop.type_expr)))
+                }
+            }
+            $if(obj.additional_properties.is_some()) {
+                #[serde(flatten)]
+                $L(format!("pub additional_properties: std::collections::HashMap<String, {}>,", rust_type_str_model(obj.additional_properties.as_ref().unwrap())))
+            }
         }
-        if is_optional {
-            body.add(
-                "#[serde(skip_serializing_if = \"Option::is_none\", default)]",
-                (),
-            );
-            body.add_line();
-        }
+    })
+    .ok()?;
 
-        let rust_type = rust_type_str_model(&prop.type_expr);
-        if is_optional {
-            body.add(&format!("pub {field_name}: Option<{rust_type}>,"), ());
-        } else {
-            body.add(&format!("pub {field_name}: {rust_type},"), ());
-        }
-        body.add_line();
-    }
-
-    if let Some(additional) = &obj.additional_properties {
-        body.add("#[serde(flatten)]", ());
-        body.add_line();
-        let val_type = rust_type_str_model(additional);
-        body.add(
-            &format!("pub additional_properties: std::collections::HashMap<String, {val_type}>,"),
-            (),
-        );
-        body.add_line();
-    }
-
-    body.end_control_flow();
-    fsb = fsb.add_code(body.build().expect("object body builds"));
+    fsb = fsb.add_code(body);
     fsb.build().ok()
 }
 
@@ -196,34 +168,29 @@ fn emit_enum(
     fsb = fsb.add_import(ImportSpec::named("serde", "Deserialize"));
     fsb = fsb.add_import(ImportSpec::named("serde", "Serialize"));
 
-    let mut body = CodeBlock::builder();
-
-    if let Some(doc) = &schema.description {
-        emit_doc_comment(&mut body, doc);
-    }
-    body.add(
-        &derive_attr("Debug, Clone, PartialEq, Eq, Serialize, Deserialize", extra),
-        (),
-    );
-    body.add_line();
-    body.add(&format!("pub enum {name}"), ());
-    body.begin_control_flow("", ());
-
     let mut variants: Vec<(String, String)> = Vec::new();
     for v in &en.values {
         let s = v.value.as_str()?;
-        let variant = s.to_pascal_case();
-        if variant != s {
-            body.add(&format!("#[serde(rename = \"{}\")]", escape_str(s)), ());
-            body.add_line();
-        }
-        body.add(&format!("{variant},"), ());
-        body.add_line();
-        variants.push((variant, s.to_string()));
+        variants.push((s.to_pascal_case(), s.to_string()));
     }
 
-    body.end_control_flow();
-    fsb = fsb.add_code(body.build().expect("enum body builds"));
+    let body = sigil_quote!(RustLang {
+        $if(schema.description.is_some()) {
+            $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
+        }
+        $L(derive_attr("Debug, Clone, PartialEq, Eq, Serialize, Deserialize", extra))
+        pub enum $N(name.as_str()) {
+            $for((variant, wire) in variants.iter()) {
+                $if(variant != wire) {
+                    $L(format!("#[serde(rename = \"{}\")]", escape_str(wire)))
+                }
+                $L(format!("{variant},"))
+            }
+        }
+    })
+    .ok()?;
+
+    fsb = fsb.add_code(body);
 
     // Display impl via sigil_quote!
     if let Some(display_block) = build_string_enum_display(&name, &variants) {
@@ -245,37 +212,35 @@ fn emit_integer_enum(
     fsb = fsb.add_import(ImportSpec::named("serde_repr", "Deserialize_repr"));
     fsb = fsb.add_import(ImportSpec::named("serde_repr", "Serialize_repr"));
 
-    let mut body = CodeBlock::builder();
+    let int_variants: Vec<(String, i64)> = en
+        .values
+        .iter()
+        .map(|v| {
+            let n = v.value.as_i64()?;
+            let variant_name = if n < 0 {
+                format!("Neg{}", n.unsigned_abs())
+            } else {
+                format!("N{n}")
+            };
+            Some((variant_name, n))
+        })
+        .collect::<Option<Vec<_>>>()?;
 
-    if let Some(doc) = &schema.description {
-        emit_doc_comment(&mut body, doc);
-    }
-    body.add(
-        &derive_attr(
-            "Debug, Clone, Copy, PartialEq, Eq, Serialize_repr, Deserialize_repr",
-            extra,
-        ),
-        (),
-    );
-    body.add_line();
-    body.add("#[repr(i64)]", ());
-    body.add_line();
-    body.add(&format!("pub enum {name}"), ());
-    body.begin_control_flow("", ());
+    let body = sigil_quote!(RustLang {
+        $if(schema.description.is_some()) {
+            $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
+        }
+        $L(derive_attr("Debug, Clone, Copy, PartialEq, Eq, Serialize_repr, Deserialize_repr", extra))
+        #[repr(i64)]
+        pub enum $N(name.as_str()) {
+            $for((variant_name, n) in int_variants.iter()) {
+                $L(format!("{variant_name} = {n},"))
+            }
+        }
+    })
+    .ok()?;
 
-    for v in &en.values {
-        let n = v.value.as_i64()?;
-        let variant_name = if n < 0 {
-            format!("Neg{}", n.unsigned_abs())
-        } else {
-            format!("N{n}")
-        };
-        body.add(&format!("{variant_name} = {n},"), ());
-        body.add_line();
-    }
-
-    body.end_control_flow();
-    fsb = fsb.add_code(body.build().expect("integer enum body builds"));
+    fsb = fsb.add_code(body);
 
     // Display impl via sigil_quote!
     if let Some(display_block) = build_integer_enum_display(&name) {
@@ -297,18 +262,15 @@ fn emit_alias(schema: &IrSchema, expr: &IrTypeExpr) -> Option<FileSpec> {
 
     let mut fsb = FileSpec::builder(&format!("{stem}.rs"));
 
-    let mut cb = CodeBlock::builder();
-    if let Some(doc) = &schema.description {
-        cb.add("%L", doc_comment_block(doc));
-    }
-
-    let alias = sigil_quote!(RustLang {
+    let block = sigil_quote!(RustLang {
+        $if(schema.description.is_some()) {
+            $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
+        }
         pub type $N(name.as_str()) = $T(rhs_type);
     })
     .ok()?;
-    cb.add_code(alias);
+    fsb = fsb.add_code(block);
 
-    fsb = fsb.add_code(cb.build().ok()?);
     fsb.build().ok()
 }
 
@@ -318,19 +280,16 @@ fn emit_type_alias_file(schema: &IrSchema, rhs_str: &str) -> Option<FileSpec> {
 
     let mut fsb = FileSpec::builder(&format!("{stem}.rs"));
 
-    let mut cb = CodeBlock::builder();
-    if let Some(doc) = &schema.description {
-        cb.add("%L", doc_comment_block(doc));
-    }
-
     let rhs_type = TypeName::raw(rhs_str);
-    let alias = sigil_quote!(RustLang {
+    let block = sigil_quote!(RustLang {
+        $if(schema.description.is_some()) {
+            $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
+        }
         pub type $N(name.as_str()) = $T(rhs_type);
     })
     .ok()?;
-    cb.add_code(alias);
+    fsb = fsb.add_code(block);
 
-    fsb = fsb.add_code(cb.build().ok()?);
     fsb.build().ok()
 }
 
@@ -350,30 +309,32 @@ fn emit_union(
     fsb = fsb.add_import(ImportSpec::named("serde", "Deserialize"));
     fsb = fsb.add_import(ImportSpec::named("serde", "Serialize"));
 
-    let mut body = CodeBlock::builder();
+    let variants: Vec<(String, String)> = union
+        .members
+        .iter()
+        .enumerate()
+        .map(|(i, member)| {
+            let variant_name = union_variant_name(member, i);
+            let rust_type = rust_type_str_model(member);
+            (variant_name, rust_type)
+        })
+        .collect();
 
-    if let Some(doc) = &schema.description {
-        emit_doc_comment(&mut body, doc);
-    }
-    body.add(
-        &derive_attr("Debug, Clone, Serialize, Deserialize", extra),
-        (),
-    );
-    body.add_line();
-    body.add("#[serde(untagged)]", ());
-    body.add_line();
-    body.add(&format!("pub enum {name}"), ());
-    body.begin_control_flow("", ());
+    let body = sigil_quote!(RustLang {
+        $if(schema.description.is_some()) {
+            $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
+        }
+        $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+        #[serde(untagged)]
+        pub enum $N(name.as_str()) {
+            $for((variant_name, rust_type) in variants.iter()) {
+                $L(format!("{variant_name}({rust_type}),"))
+            }
+        }
+    })
+    .ok()?;
 
-    for (i, member) in union.members.iter().enumerate() {
-        let variant_name = union_variant_name(member, i);
-        let rust_type = rust_type_str_model(member);
-        body.add(&format!("{variant_name}({rust_type}),"), ());
-        body.add_line();
-    }
-
-    body.end_control_flow();
-    fsb = fsb.add_code(body.build().expect("union body builds"));
+    fsb = fsb.add_code(body);
     fsb.build().ok()
 }
 
@@ -420,64 +381,43 @@ fn emit_tagged_union(
     fsb = fsb.add_import(ImportSpec::named("serde", "Deserialize"));
     fsb = fsb.add_import(ImportSpec::named("serde", "Serialize"));
 
-    let mut body = CodeBlock::builder();
-
-    if let Some(doc) = &schema.description {
-        emit_doc_comment(&mut body, doc);
-    }
-    body.add(
-        &derive_attr("Debug, Clone, Serialize, Deserialize", extra),
-        (),
-    );
-    body.add_line();
-
-    match &tu.tagging {
+    let serde_tag_attr = match &tu.tagging {
         TaggingStyle::Internal => {
-            body.add(
-                &format!(
-                    "#[serde(tag = \"{}\")]",
-                    escape_str(&tu.discriminator_field)
-                ),
-                (),
-            );
-            body.add_line();
+            format!(
+                "#[serde(tag = \"{}\")]",
+                escape_str(&tu.discriminator_field)
+            )
         }
         TaggingStyle::Adjacent { content_field } => {
-            body.add(
-                &format!(
-                    "#[serde(tag = \"{}\", content = \"{}\")]",
-                    escape_str(&tu.discriminator_field),
-                    escape_str(content_field)
-                ),
-                (),
-            );
-            body.add_line();
+            format!(
+                "#[serde(tag = \"{}\", content = \"{}\")]",
+                escape_str(&tu.discriminator_field),
+                escape_str(content_field)
+            )
         }
-        TaggingStyle::External => {}
-    }
+        TaggingStyle::External => String::new(),
+    };
 
-    body.add(&format!("pub enum {name}"), ());
-    body.begin_control_flow("", ());
-
-    for variant in &tu.variants {
-        let variant_name = variant.discriminator_value.to_pascal_case();
-        if variant_name != variant.discriminator_value {
-            body.add(
-                &format!(
-                    "#[serde(rename = \"{}\")]",
-                    escape_str(&variant.discriminator_value)
-                ),
-                (),
-            );
-            body.add_line();
+    let body = sigil_quote!(RustLang {
+        $if(schema.description.is_some()) {
+            $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
         }
-        let rust_type = rust_type_str_model(&variant.content_type);
-        body.add(&format!("{variant_name}({rust_type}),"), ());
-        body.add_line();
-    }
+        $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+        $if(!serde_tag_attr.is_empty()) {
+            $L(serde_tag_attr.as_str())
+        }
+        pub enum $N(name.as_str()) {
+            $for(variant in tu.variants.iter()) {
+                $if(variant.discriminator_value.to_pascal_case() != variant.discriminator_value) {
+                    $L(format!("#[serde(rename = \"{}\")]", escape_str(&variant.discriminator_value)))
+                }
+                $L(format!("{}({}),", variant.discriminator_value.to_pascal_case(), rust_type_str_model(&variant.content_type)))
+            }
+        }
+    })
+    .ok()?;
 
-    body.end_control_flow();
-    fsb = fsb.add_code(body.build().expect("tagged union body builds"));
+    fsb = fsb.add_code(body);
     fsb.build().ok()
 }
 
@@ -497,34 +437,36 @@ fn emit_intersection(
     fsb = fsb.add_import(ImportSpec::named("serde", "Deserialize"));
     fsb = fsb.add_import(ImportSpec::named("serde", "Serialize"));
 
-    let mut body = CodeBlock::builder();
+    let fields: Vec<(String, String)> = inter
+        .members
+        .iter()
+        .enumerate()
+        .map(|(i, member)| {
+            let raw_name = match member {
+                IrTypeExpr::Named(n) => n.to_snake_case(),
+                _ => format!("member_{i}"),
+            };
+            let field_name = escape_rust_keyword(&raw_name);
+            let rust_type = rust_type_str_model(member);
+            (field_name, rust_type)
+        })
+        .collect();
 
-    if let Some(doc) = &schema.description {
-        emit_doc_comment(&mut body, doc);
-    }
-    body.add(
-        &derive_attr("Debug, Clone, Serialize, Deserialize", extra),
-        (),
-    );
-    body.add_line();
-    body.add(&format!("pub struct {name}"), ());
-    body.begin_control_flow("", ());
+    let body = sigil_quote!(RustLang {
+        $if(schema.description.is_some()) {
+            $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
+        }
+        $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+        pub struct $N(name.as_str()) {
+            $for((field_name, rust_type) in fields.iter()) {
+                #[serde(flatten)]
+                $L(format!("pub {field_name}: {rust_type},"))
+            }
+        }
+    })
+    .ok()?;
 
-    for (i, member) in inter.members.iter().enumerate() {
-        let raw_name = match member {
-            IrTypeExpr::Named(n) => n.to_snake_case(),
-            _ => format!("member_{i}"),
-        };
-        let field_name = escape_rust_keyword(&raw_name);
-        let rust_type = rust_type_str_model(member);
-        body.add("#[serde(flatten)]", ());
-        body.add_line();
-        body.add(&format!("pub {field_name}: {rust_type},"), ());
-        body.add_line();
-    }
-
-    body.end_control_flow();
-    fsb = fsb.add_code(body.build().expect("intersection body builds"));
+    fsb = fsb.add_code(body);
     fsb.build().ok()
 }
 
@@ -544,19 +486,14 @@ fn build_integer_enum_display(name: &str) -> Option<CodeBlock> {
 }
 
 fn build_string_enum_display(name: &str, variants: &[(String, String)]) -> Option<CodeBlock> {
-    let mut match_arms = CodeBlock::builder();
-    for (variant, wire_value) in variants {
-        match_arms.add(
-            &format!("{name}::{variant} => write!(f, %S),\n"),
-            (StringLitArg(wire_value.clone()),),
-        );
-    }
-    let match_body = match_arms.build().ok()?;
-
     sigil_quote!(RustLang {
         impl std::fmt::Display for $N(name) {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                match self { $C(match_body) }
+                match self {
+                    $for((variant, wire_value) in variants.iter()) {
+                        $L(format!("{name}::{variant} => write!(f, {wire_value:?}),"))
+                    }
+                }
             }
         }
     })
@@ -567,15 +504,7 @@ fn build_string_enum_display(name: &str, variants: &[(String, String)]) -> Optio
 // Doc comment helpers
 // ---------------------------------------------------------------------------
 
-/// Emit doc comment lines into a CodeBlockBuilder.
-fn emit_doc_comment(cb: &mut sigil_stitch::code_block::CodeBlockBuilder, doc: &str) {
-    for line in doc.lines() {
-        cb.add(&format!("/// {line}"), ());
-        cb.add_line();
-    }
-}
-
-/// Build a doc-comment string for use with %L interpolation.
+/// Build a doc-comment string for use with $L interpolation.
 fn doc_comment_block(doc: &str) -> String {
     let mut out = String::new();
     for line in doc.lines() {

--- a/src/generators/typescript/fetch/sigil_emit_api.rs
+++ b/src/generators/typescript/fetch/sigil_emit_api.rs
@@ -25,6 +25,7 @@ use crate::ir::types::{
 };
 use heck::{ToLowerCamelCase as _, ToPascalCase as _};
 use sigil_stitch::code_block::{Arg, CodeBlock};
+use sigil_stitch::prelude::sigil_quote;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
 use sigil_stitch::spec::fun_spec::FunSpec;
@@ -371,11 +372,10 @@ fn build_api_class(
 }
 
 fn build_constructor() -> FunSpec {
-    let mut body = CodeBlock::builder();
-    body.add(
-        "super(configuration ?? %T);",
-        vec![Arg::TypeName(rt_value("DefaultConfig"))],
-    );
+    let body = sigil_quote!(TypeScript {
+        super(configuration ?? $T(rt_value("DefaultConfig")));
+    })
+    .expect("CodeBlock builds");
 
     FunSpec::builder("constructor")
         .is_constructor()
@@ -385,7 +385,7 @@ fn build_constructor() -> FunSpec {
                 .build()
                 .expect("ParameterSpec builds"),
         )
-        .body(body.build().expect("CodeBlock builds"))
+        .body(body)
         .build()
         .expect("Constructor FunSpec builds")
 }
@@ -714,25 +714,22 @@ fn build_convenience_method(op: &IrOperation) -> Result<FunSpec, String> {
     ));
 
     let args_list = raw_call_args(op);
-    let mut body = CodeBlock::builder();
-    if is_void_type(&body_ty) {
-        body.add(
-            &format!(
-                "const response = await this.{}({});\nreturn await response.value();",
-                raw_name, args_list
-            ),
-            vec![],
-        );
+    let is_void = is_void_type(&body_ty);
+    let call_expr = format!("this.{raw_name}({args_list})");
+    let body = if is_void {
+        sigil_quote!(TypeScript {
+            const response = await $L(call_expr.clone());
+            return await response.value();
+        })
+        .expect("CodeBlock builds")
     } else {
-        body.add(
-            &format!(
-                "const response = await this.{}({});\nreturn await response.value() as %T;",
-                raw_name, args_list
-            ),
-            vec![Arg::TypeName(body_ty)],
-        );
-    }
-    fb = fb.body(body.build().expect("CodeBlock builds"));
+        sigil_quote!(TypeScript {
+            const response = await $L(call_expr);
+            return await response.value() as $T(body_ty);
+        })
+        .expect("CodeBlock builds")
+    };
+    fb = fb.body(body);
 
     fb.build()
         .map_err(|e| format!("sigil_emit_api: convenience method {method_base}: {e}"))

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/models/string_enum.rs.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/models/string_enum.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for StringEnum {
             StringEnum::Active => write!(f, "active"),
             StringEnum::Inactive => write!(f, "inactive"),
             StringEnum::Pending => write!(f, "pending"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/models/az.rs.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/models/az.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for Az {
             Az::Foo => write!(f, "foo"),
             Az::Bar => write!(f, "bar"),
             Az::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/models/bar_status.rs.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/models/bar_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for BarStatus {
             BarStatus::Foo => write!(f, "foo"),
             BarStatus::Bar => write!(f, "bar"),
             BarStatus::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/models/foo_type.rs.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/models/foo_type.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for FooType {
             FooType::Foo => write!(f, "foo"),
             FooType::Bar => write!(f, "bar"),
             FooType::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-aioduct/petstore/src/models/order_status.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/models/order_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for OrderStatus {
             OrderStatus::Placed => write!(f, "placed"),
             OrderStatus::Approved => write!(f, "approved"),
             OrderStatus::Delivered => write!(f, "delivered"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-aioduct/petstore/src/models/pet_status.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/models/pet_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for PetStatus {
             PetStatus::Available => write!(f, "available"),
             PetStatus::Pending => write!(f, "pending"),
             PetStatus::Sold => write!(f, "sold"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-aioduct/query-param-enum/src/models/foo_status.rs.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/src/models/foo_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for FooStatus {
             FooStatus::Foo => write!(f, "foo"),
             FooStatus::Bar => write!(f, "bar"),
             FooStatus::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-reqwest/comprehensive-schemas/src/models/string_enum.rs.golden
+++ b/tests/golden/rust/rust-reqwest/comprehensive-schemas/src/models/string_enum.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for StringEnum {
             StringEnum::Active => write!(f, "active"),
             StringEnum::Inactive => write!(f, "inactive"),
             StringEnum::Pending => write!(f, "pending"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-reqwest/interface-with-enum-reference/src/models/az.rs.golden
+++ b/tests/golden/rust/rust-reqwest/interface-with-enum-reference/src/models/az.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for Az {
             Az::Foo => write!(f, "foo"),
             Az::Bar => write!(f, "bar"),
             Az::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-reqwest/interface-with-enum-reference/src/models/bar_status.rs.golden
+++ b/tests/golden/rust/rust-reqwest/interface-with-enum-reference/src/models/bar_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for BarStatus {
             BarStatus::Foo => write!(f, "foo"),
             BarStatus::Bar => write!(f, "bar"),
             BarStatus::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-reqwest/interface-with-enum-reference/src/models/foo_type.rs.golden
+++ b/tests/golden/rust/rust-reqwest/interface-with-enum-reference/src/models/foo_type.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for FooType {
             FooType::Foo => write!(f, "foo"),
             FooType::Bar => write!(f, "bar"),
             FooType::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-reqwest/petstore/src/models/order_status.rs.golden
+++ b/tests/golden/rust/rust-reqwest/petstore/src/models/order_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for OrderStatus {
             OrderStatus::Placed => write!(f, "placed"),
             OrderStatus::Approved => write!(f, "approved"),
             OrderStatus::Delivered => write!(f, "delivered"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-reqwest/petstore/src/models/pet_status.rs.golden
+++ b/tests/golden/rust/rust-reqwest/petstore/src/models/pet_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for PetStatus {
             PetStatus::Available => write!(f, "available"),
             PetStatus::Pending => write!(f, "pending"),
             PetStatus::Sold => write!(f, "sold"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-reqwest/query-param-enum/src/models/foo_status.rs.golden
+++ b/tests/golden/rust/rust-reqwest/query-param-enum/src/models/foo_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for FooStatus {
             FooStatus::Foo => write!(f, "foo"),
             FooStatus::Bar => write!(f, "bar"),
             FooStatus::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-ureq/comprehensive-schemas/src/models/string_enum.rs.golden
+++ b/tests/golden/rust/rust-ureq/comprehensive-schemas/src/models/string_enum.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for StringEnum {
             StringEnum::Active => write!(f, "active"),
             StringEnum::Inactive => write!(f, "inactive"),
             StringEnum::Pending => write!(f, "pending"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-ureq/interface-with-enum-reference/src/models/az.rs.golden
+++ b/tests/golden/rust/rust-ureq/interface-with-enum-reference/src/models/az.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for Az {
             Az::Foo => write!(f, "foo"),
             Az::Bar => write!(f, "bar"),
             Az::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-ureq/interface-with-enum-reference/src/models/bar_status.rs.golden
+++ b/tests/golden/rust/rust-ureq/interface-with-enum-reference/src/models/bar_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for BarStatus {
             BarStatus::Foo => write!(f, "foo"),
             BarStatus::Bar => write!(f, "bar"),
             BarStatus::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-ureq/interface-with-enum-reference/src/models/foo_type.rs.golden
+++ b/tests/golden/rust/rust-ureq/interface-with-enum-reference/src/models/foo_type.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for FooType {
             FooType::Foo => write!(f, "foo"),
             FooType::Bar => write!(f, "bar"),
             FooType::Baz => write!(f, "baz"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-ureq/petstore/src/models/order_status.rs.golden
+++ b/tests/golden/rust/rust-ureq/petstore/src/models/order_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for OrderStatus {
             OrderStatus::Placed => write!(f, "placed"),
             OrderStatus::Approved => write!(f, "approved"),
             OrderStatus::Delivered => write!(f, "delivered"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-ureq/petstore/src/models/pet_status.rs.golden
+++ b/tests/golden/rust/rust-ureq/petstore/src/models/pet_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for PetStatus {
             PetStatus::Available => write!(f, "available"),
             PetStatus::Pending => write!(f, "pending"),
             PetStatus::Sold => write!(f, "sold"),
-
         }
     }
 }

--- a/tests/golden/rust/rust-ureq/query-param-enum/src/models/foo_status.rs.golden
+++ b/tests/golden/rust/rust-ureq/query-param-enum/src/models/foo_status.rs.golden
@@ -22,7 +22,6 @@ impl std:: fmt:: Display for FooStatus {
             FooStatus::Foo => write!(f, "foo"),
             FooStatus::Bar => write!(f, "bar"),
             FooStatus::Baz => write!(f, "baz"),
-
         }
     }
 }


### PR DESCRIPTION
## Summary

- Bump sigil-stitch 0.4.1 → 0.4.3 (`$for`, `$let` directives)
- Convert 12 `CodeBlock::builder()` call-sites to `sigil_quote!()` across Go, TypeScript, and Rust generators
- Remove dead `emit_doc_comment()` helper, consolidate `CodeBlock` import into prelude

Net -95 lines. The remaining 18 `CodeBlock::builder()` sites are deeply imperative HTTP method body builders (path interpolation, query params, headers, response parsing) that are better expressed with the builder API.

## Converted sites

| Generator | Function | Directive used |
|-----------|----------|---------------|
| Go `sigil_emit.rs` | `package_header()` | `$L` |
| Go `sigil_emit_api.rs` | `package_header()`, `build_constructor()`, `emit_decode_into()` | `$L` |
| TypeScript `sigil_emit_api.rs` | `build_constructor()`, `build_convenience_method()` | `$T`, `$L` |
| Rust `emit_models.rs` | `emit_alias`, `emit_type_alias_file`, `emit_object` | `$if`, `$for`, `$L`, `$N`, `$T` |
| Rust `emit_models.rs` | `emit_union`, `emit_tagged_union`, `emit_intersection` | `$if`, `$for`, `$L`, `$N` |
| Rust `emit_models.rs` | `build_string_enum_display`, `build_integer_enum_display` | `$for`, `$L`, `$N` |
| Rust `emit_models.rs` | `emit_enum`, `emit_integer_enum` | `$if`, `$for`, `$L`, `$N` |

## Test plan

- [x] `cargo check` passes with no warnings
- [x] All 47 golden tests pass for rust-reqwest, rust-ureq, rust-aioduct
- [x] All golden tests pass for Go, TypeScript, Java, Kotlin, Python
- [x] `extra_derives` tests pass for all 3 Rust backends