### PR TITLE
chore: bump version to 0.1.0, update docs and licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0]
+
+### Added
+
+- Rust code generators: `rust-reqwest`, `rust-ureq`, `rust-aioduct` (three HTTP backends with shared model emission)
+- Python code generators: `python-httpx`, `python-requests`
+- Java OkHttp code generator: `java-okhttp`
+- Kotlin OkHttp code generator: `kotlin-okhttp`
+- OpenAPI 3.0 spec parsing and IR lowering
+- OpenAPI 3.2 spec parsing and IR lowering
+- Configurable extra derives per type-kind for Rust generators (`extra_derives` config)
+- AbortSignal support in TypeScript fetch runtime (`RequestOpts`)
+- Compile-check CI gates for all 6 target languages (TypeScript, Go, Rust, Python, Java, Kotlin)
+
+### Changed
+
+- Consolidated 15 workspace crates into a single crate with modules (`src/` replaces `crates/`)
+- Replaced minijinja templates with sigil-stitch code emission across all generators
+- Converted remaining `CodeBlock::builder()` sites to `sigil_quote!()` macro (sigil-stitch 0.2.1 → 0.4.3)
+- Bumped MSRV to 1.90 (Rust edition 2024)
+- Bumped aioduct dependency 0.1.3 → 0.1.6 (added required `rustls-ring` feature)
+- Flattened Justfile layout, aligned CI with sibling projects
+- TypeScript: replaced `any` with `unknown` across generated code and runtime
+- TypeScript: named re-exports instead of barrel `export *`
+- TypeScript: collapsed nullable+optional fields to two states
+- TypeScript: unified file headers, dropped `tslint:disable`
+- Go: rewrote generator on IR + sigil-stitch (no more minijinja)
+
+### Fixed
+
+- TypeScript: use strict equality (`===`) in required-param guards
+- TypeScript: derive Content-Type from `requestBody.content` instead of hardcoding JSON
+- TypeScript: use dot access for statically-known `requestParameters` keys
+- TypeScript: unified `runtime.ts` indentation to 2-space
+
 ## [0.0.5]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fixture-generator-additional-properties"
-version = "0.0.5"
+version = "0.1.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-enum-repr"
-version = "0.0.5"
+version = "0.1.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-petstore"
-version = "0.0.5"
+version = "0.1.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1003,7 +1003,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openapi-nexus"
-version = "0.0.5"
+version = "0.1.0"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.5"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.90"
 description = "OpenAPI 3.1 to code generator"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,15 +1,191 @@
-Apache License, Version 2.0
 
-Copyright 2025 Adam Cavendish
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   1. Definitions.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025-2026 Adam Cavendish
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2025 Adam Cavendish
+Copyright © 2025-2026 Adam Cavendish
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal

--- a/README.md
+++ b/README.md
@@ -1,19 +1,26 @@
 # OpenAPI Nexus
 
-> OpenAPI 3.1 to multi-language code generator
+> OpenAPI 3.0 / 3.1 / 3.2 to multi-language code generator
 
 [![CI](https://github.com/adamcavendish/openapi-nexus/actions/workflows/ci.yml/badge.svg)](https://github.com/adamcavendish/openapi-nexus/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![Rust](https://img.shields.io/badge/rust-1.90+-orange.svg)](https://www.rust-lang.org/)
 
-OpenAPI Nexus transforms OpenAPI 3.1 specifications into type-safe client libraries. Generated output is deterministic, compile-checked in CI, and tested byte-for-byte via golden tests.
+OpenAPI Nexus transforms OpenAPI specifications into type-safe client libraries. Generated output is deterministic, compile-checked in CI, and tested byte-for-byte via golden tests.
 
 ## Language Support
 
-| Language | Generator | Status |
-|----------|-----------|--------|
-| TypeScript (fetch) | `typescript-fetch` | Stable |
-| Go (net/http) | `go-http` | Stable |
+| Language | Generator | HTTP Client | Status |
+|----------|-----------|-------------|--------|
+| TypeScript | `typescript-fetch` | fetch | Beta |
+| Go | `go-http` | net/http | Beta |
+| Rust | `rust-reqwest` | reqwest | Beta |
+| Rust | `rust-ureq` | ureq | Beta |
+| Rust | `rust-aioduct` | aioduct | Beta |
+| Python | `python-httpx` | httpx | Beta |
+| Python | `python-requests` | requests | Beta |
+| Java | `java-okhttp` | OkHttp | Beta |
+| Kotlin | `kotlin-okhttp` | OkHttp | Beta |
 
 ## Quick Start
 
@@ -22,7 +29,7 @@ OpenAPI Nexus transforms OpenAPI 3.1 specifications into type-safe client librar
 Download a binary from the [releases page](https://github.com/adamcavendish/openapi-nexus/releases), or build from source:
 
 ```bash
-cargo install --path crates/openapi-nexus
+cargo install openapi-nexus
 ```
 
 Requires Rust 1.90+.
@@ -36,8 +43,17 @@ openapi-nexus generate -i spec.yaml -o output -g typescript-fetch
 # Go client
 openapi-nexus generate -i spec.yaml -o output -g go-http
 
-# Both at once
-openapi-nexus generate -i spec.yaml -o output -g typescript-fetch,go-http
+# Rust client (reqwest)
+openapi-nexus generate -i spec.yaml -o output -g rust-reqwest
+
+# Python client (httpx)
+openapi-nexus generate -i spec.yaml -o output -g python-httpx
+
+# Java client
+openapi-nexus generate -i spec.yaml -o output -g java-okhttp
+
+# Multiple generators at once
+openapi-nexus generate -i spec.yaml -o output -g typescript-fetch,go-http,rust-reqwest
 ```
 
 ## Configuration
@@ -56,6 +72,12 @@ Generator-specific options go in the config file:
 ```toml
 [generators.go-http]
 module_path = "github.com/myorg/myproject/sdk"
+
+[generators.rust-reqwest.extra_derives.structs]
+derives = ["PartialEq"]
+
+[generators.rust-reqwest.extra_derives.enums]
+derives = ["Hash"]
 ```
 
 ## How It Works
@@ -64,7 +86,7 @@ module_path = "github.com/myorg/myproject/sdk"
 OpenAPI YAML/JSON → parse → lower to IR → CodeGenerator::generate(&IrSpec) → write
 ```
 
-Parsing auto-detects OAS version. Lowering produces a version-agnostic `IrSpec`. Each generator receives the pre-lowered IR and uses [sigil-stitch](https://github.com/adamcavendish/sigil-stitch) for type-safe code emission.
+Parsing auto-detects OAS version (3.0, 3.1, 3.2). Lowering produces a version-agnostic `IrSpec`. Each generator receives the pre-lowered IR and uses [sigil-stitch](https://github.com/adamcavendish/sigil-stitch) for type-safe code emission.
 
 ## Documentation
 
@@ -82,8 +104,8 @@ cargo clippy --all-targets --all-features -- -D warnings
 # Update golden files after intentional output changes
 UPDATE_GOLDEN=1 cargo test
 
-# Compile-check generated output
-just golden::build-all
+# Compile-check generated output for all languages
+just golden-build-all
 ```
 
 ## License

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,6 +1,6 @@
 [book]
 title = "openapi-nexus"
-description = "OpenAPI 3.1 to multi-language code generator"
+description = "OpenAPI 3.0 / 3.1 / 3.2 to multi-language code generator"
 authors = ["Adam Cavendish"]
 language = "en"
 src = "src"

--- a/docs/src/adding_a_generator.md
+++ b/docs/src/adding_a_generator.md
@@ -2,53 +2,42 @@
 
 This guide walks through adding a new language generator to openapi-nexus.
 
-## 1. Create the crate
+## 1. Add a GeneratorType variant
 
-Create a new crate under `crates/generators/`:
-
-```bash
-cargo new --lib crates/generators/openapi-nexus-<lang>
-```
-
-Add it to the workspace `members` list in the root `Cargo.toml`:
-
-```toml
-members = [
-    # ...
-    "crates/generators/openapi-nexus-<lang>",
-]
-```
-
-Add workspace dependencies:
-
-```toml
-# In the new crate's Cargo.toml
-[dependencies]
-openapi-nexus-core.workspace = true
-openapi-nexus-ir.workspace = true
-sigil-stitch.workspace = true
-```
-
-## 2. Add a GeneratorType variant
-
-In `crates/openapi-nexus-core/src/generator_type.rs`, add a new variant:
+In `src/codegen/generator_type.rs`, add a new variant:
 
 ```rust
 pub enum GeneratorType {
     TypeScriptFetch,
     GoHttp,
+    // ...
     MyLang,  // <-- new
 }
 ```
 
 Implement the `Display` and `FromStr` traits to map the CLI name (e.g., `"my-lang"`) to the variant.
 
+Also add the corresponding `Language` variant in `src/codegen/language.rs` if the target language doesn't exist yet.
+
+## 2. Create the generator module
+
+Create a new directory under `src/generators/`:
+
+```
+src/generators/my_lang/
+├── mod.rs              Module root, exports the generator struct
+├── sigil_emit.rs       Model emission (IR schemas → target-language types)
+└── sigil_emit_api.rs   API emission (IR operations → client methods)
+```
+
+Add the module to `src/generators/mod.rs`.
+
 ## 3. Implement CodeGenerator
 
 ```rust
-use openapi_nexus_core::traits::code_generator::CodeGenerator;
-use openapi_nexus_core::traits::file_writer::FileWriter;
-use openapi_nexus_ir::types::IrSpec;
+use crate::codegen::traits::code_generator::CodeGenerator;
+use crate::codegen::traits::file_writer::{FileInfo, FileWriter};
+use crate::ir::types::IrSpec;
 
 pub struct MyLangCodeGenerator { /* config fields */ }
 
@@ -73,23 +62,25 @@ impl FileWriter for MyLangCodeGenerator {}
 
 ## 5. Register in the orchestrator
 
-In `crates/openapi-nexus/src/openapi_code_generator.rs`, inside `OpenApiCodeGenerator::new()`:
+In `src/generators/registry.rs`, add the generator to the registry:
 
 ```rust
-registry.register_generator(Box::new(
-    MyLangCodeGenerator::new(/* config */)
-));
+GeneratorType::MyLang => {
+    Box::new(MyLangCodeGenerator::new(/* config */))
+}
 ```
 
 ## 6. Add golden tests
 
-1. Create `crates/generators/openapi-nexus-<lang>/tests/golden_tests_<lang>.rs`
-2. Use the `run_golden_test` harness from `openapi-nexus-test-utils`
-3. Create golden files: `tests/golden/<lang>/<generator-id>/`
-4. Generate initial goldens with `UPDATE_GOLDEN=1 cargo test --test golden_tests_<lang>`
+1. Create `tests/golden_tests_my_lang.rs`
+2. Use the `run_golden_test` harness from `openapi_nexus::codegen::test_utils`
+3. Create golden files: `tests/golden/my_lang/my-lang/<fixture>/`
+4. Generate initial goldens with `UPDATE_GOLDEN=1 cargo test --test golden_tests_my_lang`
 
 See the [Golden Testing](golden_testing.md) chapter for details.
 
 ## 7. Add to CI
 
-In `.github/workflows/ci.yml`, add a new entry to the golden-build matrix with the appropriate language toolchain setup and `just golden::build-<lang>` command.
+In `.github/workflows/ci.yml`, add a new entry to the golden-build matrix with the appropriate language toolchain setup and compile-check command.
+
+Add a Justfile submodule at `just/golden-my-lang.just` with `update` and `build` recipes.

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -6,13 +6,13 @@
 flowchart TD
     A["OpenAPI YAML / JSON"] --> B
 
-    B["openapi-nexus-parser
+    B["Parser
     Parses YAML/JSON into ParsedSpec
-    Auto-detects OAS 3.0 vs 3.1"]
+    Auto-detects OAS 3.0 / 3.1 / 3.2"]
 
     B --> C
 
-    C["openapi-nexus-ir
+    C["IR Lowering
     Lowers ParsedSpec into IrSpec
     Version-agnostic IR"]
 
@@ -28,36 +28,36 @@ flowchart TD
     Writes files to disk"]
 ```
 
-Lowering happens once in the orchestrator (`OpenApiCodeGenerator`). Generators never touch raw OpenAPI types.
+Lowering happens once in the orchestrator (`src/generators/orchestrator.rs`). Generators never touch raw OpenAPI types.
 
-## Workspace Crates
+## Module Layout
 
-### Core pipeline
+openapi-nexus is a single crate. All modules live under `src/`:
 
-| Crate | Purpose |
-|-------|---------|
-| `openapi-nexus` | CLI binary, orchestrator (`OpenApiCodeGenerator`, `GeneratorRegistry`) |
-| `openapi-nexus-parser` | Parses YAML/JSON into `ParsedSpec` |
-| `openapi-nexus-spec` | Raw OpenAPI types (`OpenApiV30Spec`, `OpenApiV31Spec`) |
-| `openapi-nexus-ir` | Lowers parsed spec to `IrSpec` via `lower::lower()` |
-| `openapi-nexus-core` | Shared traits (`CodeGenerator`, `FileWriter`, `CombinedGenerator`), enums (`GeneratorType`, `Language`) |
-| `openapi-nexus-config` | Configuration loading (CLI > env > TOML > defaults) |
-
-### Generators
-
-| Crate | Language | Emission |
-|-------|----------|----------|
-| `openapi-nexus-typescript-fetch` | TypeScript | `sigil-stitch` |
-| `openapi-nexus-go-http` | Go | `sigil-stitch` |
-
-Both generators live under `crates/generators/`.
-
-### Test infrastructure
-
-| Crate | Purpose |
-|-------|---------|
-| `openapi-nexus-test-utils` | Shared golden-test harness (`run_golden_test`, `generate_files`) |
-| `fixture-generators/*` | Generate type-checked OAS fixtures from Rust + utoipa |
+```
+src/
+├── cli/              CLI argument parsing and entry point
+├── codegen/          CodeGenerator/FileWriter traits, GeneratorType, Language enums
+├── config/           Configuration loading (CLI > env > TOML > defaults)
+├── ir/               IrSpec types and lowering passes
+│   └── lower/        v30.rs, v31.rs, v32.rs
+├── spec/             Raw OAS types (v30, v31, v32)
+├── parser/           YAML/JSON parsing, OAS version auto-detection
+└── generators/       One submodule per generator
+    ├── typescript/fetch/
+    ├── go/http/
+    ├── rust/common/         Shared model + API emission for Rust backends
+    ├── rust/reqwest/
+    ├── rust/ureq/
+    ├── rust/aioduct/
+    ├── python/common/       Shared model + API emission for Python backends
+    ├── python/httpx/
+    ├── python/requests/
+    ├── java/okhttp/
+    ├── kotlin/okhttp/
+    ├── orchestrator.rs      Orchestrates parse → lower → generate → write
+    └── registry.rs          Maps GeneratorType to constructor
+```
 
 ## The CodeGenerator Trait
 
@@ -73,11 +73,11 @@ pub trait CodeGenerator {
 
 ## Code Emission
 
-Both generators use [sigil-stitch](https://github.com/adamcavendish/sigil-stitch), a type-safe code generation framework. sigil-stitch provides:
+All generators use [sigil-stitch](https://github.com/adamcavendish/sigil-stitch), a type-safe code generation framework. sigil-stitch provides:
 
-- Language-specific type systems (TypeScript, Go)
+- Language-specific type systems (TypeScript, Go, Rust, Python, Java, Kotlin)
 - Import tracking and deduplication
 - Width-aware pretty printing
-- The `sigil_quote!` macro for inline code templates
+- The `sigil_quote!` macro for inline code templates with `$if`, `$for`, `$let` directives
 
 Each generator's `sigil_emit*.rs` files contain the emission logic that transforms IR types into sigil-stitch AST nodes.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -5,7 +5,7 @@
 Download the latest binary from the [releases page](https://github.com/adamcavendish/openapi-nexus/releases), or build from source:
 
 ```bash
-cargo install --path crates/openapi-nexus
+cargo install openapi-nexus
 ```
 
 Requires Rust 1.90+ (edition 2024).
@@ -21,13 +21,20 @@ openapi-nexus generate \
   --generator typescript-fetch
 ```
 
-Generate both TypeScript and Go clients at once:
+Generate clients for multiple languages at once:
 
 ```bash
 openapi-nexus generate \
   --input spec.yaml \
   --output output \
-  --generators typescript-fetch,go-http
+  --generators typescript-fetch,go-http,rust-reqwest,python-httpx
+```
+
+All nine generators:
+
+```bash
+openapi-nexus generate -i spec.yaml -o output \
+  -g typescript-fetch,go-http,rust-reqwest,rust-ureq,rust-aioduct,python-httpx,python-requests,java-okhttp,kotlin-okhttp
 ```
 
 ## Configuration
@@ -56,6 +63,12 @@ Generator-specific options live under `[generators.<name>]` sections:
 ```toml
 [generators.go-http]
 module_path = "github.com/myorg/myproject/sdk"
+
+[generators.rust-reqwest.extra_derives.structs]
+derives = ["PartialEq"]
+
+[generators.rust-reqwest.extra_derives.enums]
+derives = ["Hash"]
 ```
 
 ### CLI Reference

--- a/docs/src/golden_testing.md
+++ b/docs/src/golden_testing.md
@@ -15,12 +15,17 @@ Each generator has a test file that:
 
 ```
 tests/
-├── fixtures/valid/           # Input OpenAPI specs
+├── fixtures/valid/                  Input OpenAPI specs
 ├── golden/
-│   ├── typescript/
-│   │   └── typescript-fetch/ # Expected TS output per fixture
-│   └── go/
-│       └── go-http/          # Expected Go output per fixture
+│   ├── typescript/typescript-fetch/  Expected TypeScript output per fixture
+│   ├── go/go-http/                   Expected Go output per fixture
+│   ├── rust/rust-reqwest/            Expected Rust (reqwest) output
+│   ├── rust/rust-ureq/               Expected Rust (ureq) output
+│   ├── rust/rust-aioduct/            Expected Rust (aioduct) output
+│   ├── python/python-httpx/          Expected Python (httpx) output
+│   ├── python/python-requests/       Expected Python (requests) output
+│   ├── java/java-okhttp/             Expected Java output
+│   └── kotlin/kotlin-okhttp/         Expected Kotlin output
 ```
 
 Each golden directory contains files with a `.golden` suffix:
@@ -40,8 +45,14 @@ tests/golden/go/go-http/petstore/
 
 CI materializes each golden directory into a temp folder (stripping the `.golden` suffix) and runs the target language's compiler:
 
-- TypeScript: `tsc --noEmit` (marker: `tsconfig.json.golden`)
-- Go: `go build ./...` (marker: `go.mod.golden`)
+| Language | Command | Marker file |
+|----------|---------|-------------|
+| TypeScript | `tsc --noEmit` | `tsconfig.json.golden` |
+| Go | `go build ./...` | `go.mod.golden` |
+| Rust | `cargo check` | `Cargo.toml.golden` |
+| Python | `pyright` | `pyproject.toml.golden` |
+| Java | `gradle compileJava` | `build.gradle.golden` |
+| Kotlin | `gradle compileKotlin` | `build.gradle.kts.golden` |
 
 This catches type errors that snapshot comparison alone cannot.
 
@@ -51,14 +62,19 @@ This catches type errors that snapshot comparison alone cannot.
 # Run all snapshot tests
 cargo test
 
-# Run only TypeScript golden tests
-cargo test -p openapi-nexus-typescript-fetch --test golden_tests_typescript_fetch
-
-# Run only Go golden tests
-cargo test -p openapi-nexus-go-http --test golden_tests_go_http
+# Run specific generator's golden tests
+cargo test --test golden_tests_typescript_fetch
+cargo test --test golden_tests_go_http
+cargo test --test golden_tests_rust_reqwest
+cargo test --test golden_tests_rust_ureq
+cargo test --test golden_tests_rust_aioduct
+cargo test --test golden_tests_python_httpx
+cargo test --test golden_tests_python_requests
+cargo test --test golden_tests_java_okhttp
+cargo test --test golden_tests_kotlin_okhttp
 
 # Run a single test by name
-cargo test -p openapi-nexus-go-http --test golden_tests_go_http -- minimal
+cargo test --test golden_tests_go_http -- minimal
 ```
 
 ## Updating Golden Files
@@ -69,19 +85,21 @@ When you intentionally change generator output:
 # Update all
 UPDATE_GOLDEN=1 cargo test
 
-# Update TypeScript only
+# Update one generator
 UPDATE_GOLDEN=1 cargo test --test golden_tests_typescript_fetch
-
-# Update Go only
-UPDATE_GOLDEN=1 cargo test --test golden_tests_go_http
+UPDATE_GOLDEN=1 cargo test --test golden_tests_rust_reqwest
 ```
 
 After updating, verify the compile check passes:
 
 ```bash
-just golden::build-ts    # TypeScript compile check
-just golden::build-go    # Go compile check
-just golden::build-all   # Both
+just golden-typescript::build
+just golden-go::build
+just golden-rust::build
+just golden-python::build
+just golden-java::build
+just golden-kotlin::build
+just golden-build-all           # all languages
 ```
 
 ## Extra File Detection

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,13 +1,20 @@
 # Introduction
 
-openapi-nexus is a modular OpenAPI 3.1 code generator written in Rust. It reads an OpenAPI specification and produces type-safe client libraries for multiple languages.
+openapi-nexus is a modular OpenAPI code generator written in Rust. It reads an OpenAPI specification (3.0, 3.1, or 3.2) and produces type-safe client libraries for multiple languages.
 
 ## Supported Languages
 
-| Language | Generator ID | Status |
-|----------|-------------|--------|
-| TypeScript (fetch) | `typescript-fetch` | Stable |
-| Go (net/http) | `go-http` | Stable |
+| Language | Generator ID | HTTP Client | Status |
+|----------|-------------|-------------|--------|
+| TypeScript | `typescript-fetch` | fetch | Beta |
+| Go | `go-http` | net/http | Beta |
+| Rust | `rust-reqwest` | reqwest | Beta |
+| Rust | `rust-ureq` | ureq | Beta |
+| Rust | `rust-aioduct` | aioduct | Beta |
+| Python | `python-httpx` | httpx | Beta |
+| Python | `python-requests` | requests | Beta |
+| Java | `java-okhttp` | OkHttp | Beta |
+| Kotlin | `kotlin-okhttp` | OkHttp | Beta |
 
 ## How It Works
 
@@ -15,7 +22,7 @@ openapi-nexus follows a compiler-like pipeline:
 
 ```mermaid
 flowchart TD
-    A["OpenAPI YAML / JSON"] --> B["Parse (auto-detect OAS 3.0 / 3.1)"]
+    A["OpenAPI YAML / JSON"] --> B["Parse (auto-detect OAS 3.0 / 3.1 / 3.2)"]
     B --> C["Lower to IR (IrSpec)"]
     C --> D["CodeGenerator::generate(&IrSpec)"]
     D --> E["Vec&lt;FileInfo&gt; → write to disk"]
@@ -26,7 +33,7 @@ Parsing and lowering happen once in the orchestrator. Each generator receives a 
 ## Key Properties
 
 - **Deterministic output.** The same spec always produces the same files. Golden tests enforce byte-for-byte reproducibility.
-- **Compile-checked output.** CI runs `tsc --noEmit` on every generated TypeScript file and `go build ./...` on every generated Go file.
+- **Compile-checked output.** CI runs language-specific compile checks on every generated file: `tsc --noEmit` (TypeScript), `go build` (Go), `cargo check` (Rust), `pyright` (Python), `gradle compileJava` (Java), `gradle compileKotlin` (Kotlin).
 - **Single binary.** The CLI is a self-contained Rust binary with no runtime dependencies.
 
 ## Links


### PR DESCRIPTION
## Summary

- Bump workspace version 0.0.5 → 0.1.0 (first release with breaking changes)
- Add `[0.1.0]` CHANGELOG section covering 66 commits: 7 new generators, OAS 3.0/3.2 support, crate consolidation, sigil-stitch migration
- Update README with 9-generator table, fixed install path (`cargo install --path .`), correct just targets
- Replace LICENSE-APACHE short notice with full standard Apache License 2.0 text
- Update LICENSE-MIT copyright year to 2025-2026
- Rewrite all 5 mdbook docs for single-crate module layout, all 9 generators, OAS 3.0/3.1/3.2, and correct test/just commands

## Test plan

- [x] `cargo check` compiles with new version
- [x] `mdbook build docs` builds without errors
- [x] No code changes, documentation only (plus version bump)