### PR TITLE
fix(rust): address post-0.1.0 customer feedback

### DIFF
--- a/src/generators/rust/aioduct/codegen.rs
+++ b/src/generators/rust/aioduct/codegen.rs
@@ -101,8 +101,26 @@ fn cargo_toml_file(crate_name: &str, info: &IrInfo, config: &RustGeneratorConfig
         .lines()
         .next()
         .unwrap_or("Generated Rust SDK.");
-    let mut content = format!(
-        r#"[package]
+    let workspace = config.workspace_mode.unwrap_or(false);
+    let mut content = if workspace {
+        format!(
+            r#"[package]
+name = "{crate_name}"
+version.workspace = true
+edition.workspace = true
+description = "{description}"
+
+[dependencies]
+aioduct = {{ version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }}
+serde = {{ version = "1", features = ["derive"] }}
+serde_json = "1"
+serde_repr = "0.1"
+tokio = {{ version = "1", features = ["full"] }}
+"#,
+        )
+    } else {
+        format!(
+            r#"[package]
 name = "{crate_name}"
 version = "0.1.0"
 edition = "2024"
@@ -115,7 +133,8 @@ serde_json = "1"
 serde_repr = "0.1"
 tokio = {{ version = "1", features = ["full"] }}
 "#,
-    );
+        )
+    };
     if let Some(extra) = &config.extra_derives {
         for (name, spec) in extra.all_dependencies() {
             content.push_str(&format!("{name} = {spec}\n"));

--- a/src/generators/rust/common/config.rs
+++ b/src/generators/rust/common/config.rs
@@ -55,6 +55,8 @@ pub struct RustGeneratorConfig {
     pub crate_name: Option<String>,
     #[serde(default)]
     pub extra_derives: Option<ExtraDerivesConfig>,
+    #[serde(default)]
+    pub workspace_mode: Option<bool>,
 }
 
 impl From<toml::value::Table> for RustGeneratorConfig {

--- a/src/generators/rust/common/emit_api.rs
+++ b/src/generators/rust/common/emit_api.rs
@@ -341,7 +341,11 @@ fn emit_operation(
     if let Some(desc) = &op.description {
         b.add("///\n", ());
         for line in desc.lines() {
-            b.add(&format!("/// {line}\n"), ());
+            if line.is_empty() {
+                b.add("///\n", ());
+            } else {
+                b.add(&format!("/// {line}\n"), ());
+            }
         }
     }
 
@@ -356,6 +360,8 @@ fn emit_operation(
     {
         let ty = if is_copy_type(&p.rust_type) {
             p.rust_type.clone()
+        } else if p.rust_type == "String" {
+            "&str".to_string()
         } else {
             format!("&{}", p.rust_type)
         };

--- a/src/generators/rust/common/emit_models.rs
+++ b/src/generators/rust/common/emit_models.rs
@@ -34,10 +34,7 @@ pub fn generate_model_files(
 
     for (_name, schema) in &ir.schemas {
         let Some(file_spec) = emit_model_file(schema, config) else {
-            return Err(format!(
-                "unsupported schema kind for {}: {:?}",
-                schema.name, schema.kind
-            ));
+            continue;
         };
         let stem = schema.name.to_snake_case();
         let filename = format!("{stem}.rs");
@@ -70,7 +67,9 @@ fn emit_model_file(schema: &IrSchema, config: &RustGeneratorConfig) -> Option<Fi
             emit_object(schema, obj, extra.and_then(|e| e.structs.as_ref()))
         }
         IrSchemaKind::Enum(en) => emit_enum(schema, en, extra.and_then(|e| e.enums.as_ref())),
-        IrSchemaKind::Alias(expr) => emit_alias(schema, expr),
+        IrSchemaKind::Alias(expr) => {
+            emit_alias(schema, expr, extra.and_then(|e| e.structs.as_ref()))
+        }
         IrSchemaKind::Union(u) => emit_union(schema, u, extra.and_then(|e| e.unions.as_ref())),
         IrSchemaKind::Intersection(i) => {
             emit_intersection(schema, i, extra.and_then(|e| e.structs.as_ref()))
@@ -254,22 +253,51 @@ fn emit_integer_enum(
 // Alias -> pub type
 // ---------------------------------------------------------------------------
 
-fn emit_alias(schema: &IrSchema, expr: &IrTypeExpr) -> Option<FileSpec> {
+fn emit_alias(
+    schema: &IrSchema,
+    expr: &IrTypeExpr,
+    extra: Option<&ExtraDeriveConfig>,
+) -> Option<FileSpec> {
+    if let IrTypeExpr::Named(n) = expr
+        && n.to_pascal_case() == schema.name.to_pascal_case()
+    {
+        return None;
+    }
+
     let name = schema.name.to_pascal_case();
     let stem = schema.name.to_snake_case();
     let rhs = rust_type_str_model(expr);
-    let rhs_type = TypeName::raw(&rhs);
 
     let mut fsb = FileSpec::builder(&format!("{stem}.rs"));
 
-    let block = sigil_quote!(RustLang {
-        $if(schema.description.is_some()) {
-            $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
-        }
-        pub type $N(name.as_str()) = $T(rhs_type);
-    })
-    .ok()?;
-    fsb = fsb.add_code(block);
+    let has_extra = extra.is_some_and(|cfg| !cfg.derives.is_empty());
+
+    if has_extra {
+        fsb = fsb.add_import(ImportSpec::named("serde", "Deserialize"));
+        fsb = fsb.add_import(ImportSpec::named("serde", "Serialize"));
+
+        let rhs_type = TypeName::raw(&rhs);
+        let block = sigil_quote!(RustLang {
+            $if(schema.description.is_some()) {
+                $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
+            }
+            $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+            #[serde(transparent)]
+            pub struct $N(name.as_str())(pub $T(rhs_type));
+        })
+        .ok()?;
+        fsb = fsb.add_code(block);
+    } else {
+        let rhs_type = TypeName::raw(&rhs);
+        let block = sigil_quote!(RustLang {
+            $if(schema.description.is_some()) {
+                $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
+            }
+            pub type $N(name.as_str()) = $T(rhs_type);
+        })
+        .ok()?;
+        fsb = fsb.add_code(block);
+    }
 
     fsb.build().ok()
 }
@@ -508,7 +536,11 @@ fn build_string_enum_display(name: &str, variants: &[(String, String)]) -> Optio
 fn doc_comment_block(doc: &str) -> String {
     let mut out = String::new();
     for line in doc.lines() {
-        out.push_str(&format!("/// {line}\n"));
+        if line.is_empty() {
+            out.push_str("///\n");
+        } else {
+            out.push_str(&format!("/// {line}\n"));
+        }
     }
     out
 }
@@ -572,6 +604,8 @@ fn rust_primitive(p: &IrPrimitive) -> &'static str {
         IrPrimitive::IntegerWithFormat(format) => match format.as_str() {
             "int32" => "i32",
             "int64" => "i64",
+            "uint32" => "u32",
+            "uint64" => "u64",
             _ => "i64",
         },
         IrPrimitive::Number => "f64",

--- a/src/generators/rust/reqwest/codegen.rs
+++ b/src/generators/rust/reqwest/codegen.rs
@@ -112,8 +112,26 @@ fn cargo_toml_file(crate_name: &str, info: &IrInfo, config: &RustGeneratorConfig
         .lines()
         .next()
         .unwrap_or("Generated Rust SDK.");
-    let mut content = format!(
-        r#"[package]
+    let workspace = config.workspace_mode.unwrap_or(false);
+    let mut content = if workspace {
+        format!(
+            r#"[package]
+name = "{crate_name}"
+version.workspace = true
+edition.workspace = true
+description = "{description}"
+
+[dependencies]
+reqwest = {{ version = "0.12", features = ["json"] }}
+serde = {{ version = "1", features = ["derive"] }}
+serde_json = "1"
+serde_repr = "0.1"
+tokio = {{ version = "1", features = ["full"] }}
+"#,
+        )
+    } else {
+        format!(
+            r#"[package]
 name = "{crate_name}"
 version = "0.1.0"
 edition = "2024"
@@ -126,7 +144,8 @@ serde_json = "1"
 serde_repr = "0.1"
 tokio = {{ version = "1", features = ["full"] }}
 "#,
-    );
+        )
+    };
     if let Some(extra) = &config.extra_derives {
         for (name, spec) in extra.all_dependencies() {
             content.push_str(&format!("{name} = {spec}\n"));

--- a/src/generators/rust/ureq/codegen.rs
+++ b/src/generators/rust/ureq/codegen.rs
@@ -101,8 +101,25 @@ fn cargo_toml_file(crate_name: &str, info: &IrInfo, config: &RustGeneratorConfig
         .lines()
         .next()
         .unwrap_or("Generated Rust SDK.");
-    let mut content = format!(
-        r#"[package]
+    let workspace = config.workspace_mode.unwrap_or(false);
+    let mut content = if workspace {
+        format!(
+            r#"[package]
+name = "{crate_name}"
+version.workspace = true
+edition.workspace = true
+description = "{description}"
+
+[dependencies]
+ureq = {{ version = "3", features = ["json"] }}
+serde = {{ version = "1", features = ["derive"] }}
+serde_json = "1"
+serde_repr = "0.1"
+"#,
+        )
+    } else {
+        format!(
+            r#"[package]
 name = "{crate_name}"
 version = "0.1.0"
 edition = "2024"
@@ -114,7 +131,8 @@ serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
 serde_repr = "0.1"
 "#,
-    );
+        )
+    };
     if let Some(extra) = &config.extra_derives {
         for (name, spec) in extra.all_dependencies() {
             content.push_str(&format!("{name} = {spec}\n"));

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/apis/test_resource.rs.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/apis/test_resource.rs.golden
@@ -43,7 +43,7 @@ impl<'a, R: aioduct::Runtime> TestResourceApi<'a, R> {
     /// DELETE /v1/api/test-resource/{resource_id}
     pub async fn delete_test_resource(
         &self,
-        resource_id: &String,
+        resource_id: &str,
     ) -> Result<DeleteTestResourceResponse, Error> {
         let mut path = "/v1/api/test-resource/{resource_id}".to_string();
         path = path.replace("{resource_id}", &resource_id.to_string());

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/src/apis/items.rs.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/src/apis/items.rs.golden
@@ -22,7 +22,7 @@ impl<'a, R: aioduct::Runtime> ItemsApi<'a, R> {
     /// Create item with body parameter conflict
     pub async fn create_item_with_body_conflict(
         &self,
-        item_id: &String,
+        item_id: &str,
         body: &Option<String>,
         body_2: &crate::models::CreateItemWithBodyConflictRequest,
     ) -> Result<CreateItemWithBodyConflictResponse, Error> {

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/models/adjacently_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/models/adjacently_tagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Adjacently tagged enum
-/// 
+///
 /// The tag and content are separate fields:
 /// `{"ty": "VariantA", "data": {"field1": "...", "field2": 123}}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/models/externally_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/models/externally_tagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Externally tagged enum (default Serde representation)
-/// 
+///
 /// This is the default representation where the variant name is the key
 /// and the content is the value: `{"VariantA": {"field1": "...", "field2": 123}}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/models/internally_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/models/internally_tagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Internally tagged enum
-/// 
+///
 /// The tag is a field inside the object alongside other fields:
 /// `{"ty": "VariantA", "field1": "...", "field2": 123}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/models/mixed_enum.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/models/mixed_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Mixed enum with unit variants (SimpleA, SimpleB) and tuple variants (VariantA(VariantA), VariantB(VariantB))
-/// 
+///
 /// Serializes as externally tagged: `{"SimpleA": null}`, `{"VariantA": {"field1": "...", "field2": 123}}`,
 /// `{"SimpleB": null}`, `{"VariantB": {"field3": true, "field4": 1.23}}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/models/untagged_enum.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/models/untagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Untagged enum
-/// 
+///
 /// No tag is used, variants are distinguished by their structure:
 /// `{"field1": "...", "field2": 123}` or `{"field3": true, "field4": 1.23}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-aioduct/naming-conventions/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/src/apis/default.rs.golden
@@ -22,7 +22,7 @@ impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
     /// Get with query parameters
     pub async fn get_with_query_params(
         &self,
-        snake_case_param: &String,
+        snake_case_param: &str,
         snake_case_number: Option<i64>,
         kebab_case_param: &Option<String>,
         kebab_case_array: &Option<Vec<String>>,

--- a/tests/golden/rust/rust-aioduct/petstore/src/apis/pet.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/apis/pet.rs.golden
@@ -64,7 +64,7 @@ impl<'a, R: aioduct::Runtime> PetApi<'a, R> {
     /// Find pets by status
     pub async fn find_pets_by_status(
         &self,
-        status: &String,
+        status: &str,
     ) -> Result<FindPetsByStatusResponse, Error> {
         let mut path = "/pet/findByStatus".to_string();
         let mut query_parts: Vec<(&str, String)> = Vec::new();

--- a/tests/golden/rust/rust-aioduct/petstore/src/apis/user.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/apis/user.rs.golden
@@ -99,7 +99,7 @@ impl<'a, R: aioduct::Runtime> UserApi<'a, R> {
     /// Get user by user name
     pub async fn get_user_by_name(
         &self,
-        username: &String,
+        username: &str,
     ) -> Result<GetUserByNameResponse, Error> {
         let mut path = "/user/{username}".to_string();
         path = path.replace("{username}", &username.to_string());
@@ -120,7 +120,7 @@ impl<'a, R: aioduct::Runtime> UserApi<'a, R> {
     /// Update user
     pub async fn update_user(
         &self,
-        username: &String,
+        username: &str,
         body: &crate::models::User,
     ) -> Result<UpdateUserResponse, Error> {
         let mut path = "/user/{username}".to_string();
@@ -135,7 +135,7 @@ impl<'a, R: aioduct::Runtime> UserApi<'a, R> {
     /// Delete user
     pub async fn delete_user(
         &self,
-        username: &String,
+        username: &str,
     ) -> Result<DeleteUserResponse, Error> {
         let mut path = "/user/{username}".to_string();
         path = path.replace("{username}", &username.to_string());

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/apis/foo.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/apis/foo.rs.golden
@@ -21,7 +21,7 @@ impl<'a, R: aioduct::Runtime> FooApi<'a, R> {
     /// PATCH /foo/bar
     pub async fn update_foo_bar(
         &self,
-        foo_id: &String,
+        foo_id: &str,
         body: &crate::models::FooRequest,
     ) -> Result<UpdateFooBarResponse, Error> {
         let mut path = "/foo/bar".to_string();

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/apis/default.rs.golden
@@ -43,7 +43,7 @@ impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
     /// Get test
     pub async fn get_test(
         &self,
-        id: &String,
+        id: &str,
     ) -> Result<GetTestResponse, Error> {
         let mut path = "/test/{id}".to_string();
         path = path.replace("{id}", &id.to_string());

--- a/tests/golden/rust/rust-reqwest/delete-with-response-schema/src/apis/test_resource.rs.golden
+++ b/tests/golden/rust/rust-reqwest/delete-with-response-schema/src/apis/test_resource.rs.golden
@@ -43,7 +43,7 @@ impl<'a> TestResourceApi<'a> {
     /// DELETE /v1/api/test-resource/{resource_id}
     pub async fn delete_test_resource(
         &self,
-        resource_id: &String,
+        resource_id: &str,
     ) -> Result<DeleteTestResourceResponse, Error> {
         let mut path = "/v1/api/test-resource/{resource_id}".to_string();
         path = path.replace("{resource_id}", &resource_id.to_string());

--- a/tests/golden/rust/rust-reqwest/duplicate-param-names/src/apis/items.rs.golden
+++ b/tests/golden/rust/rust-reqwest/duplicate-param-names/src/apis/items.rs.golden
@@ -22,7 +22,7 @@ impl<'a> ItemsApi<'a> {
     /// Create item with body parameter conflict
     pub async fn create_item_with_body_conflict(
         &self,
-        item_id: &String,
+        item_id: &str,
         body: &Option<String>,
         body_2: &crate::models::CreateItemWithBodyConflictRequest,
     ) -> Result<CreateItemWithBodyConflictResponse, Error> {

--- a/tests/golden/rust/rust-reqwest/enum-repr/src/models/adjacently_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-reqwest/enum-repr/src/models/adjacently_tagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Adjacently tagged enum
-/// 
+///
 /// The tag and content are separate fields:
 /// `{"ty": "VariantA", "data": {"field1": "...", "field2": 123}}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-reqwest/enum-repr/src/models/externally_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-reqwest/enum-repr/src/models/externally_tagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Externally tagged enum (default Serde representation)
-/// 
+///
 /// This is the default representation where the variant name is the key
 /// and the content is the value: `{"VariantA": {"field1": "...", "field2": 123}}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-reqwest/enum-repr/src/models/internally_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-reqwest/enum-repr/src/models/internally_tagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Internally tagged enum
-/// 
+///
 /// The tag is a field inside the object alongside other fields:
 /// `{"ty": "VariantA", "field1": "...", "field2": 123}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-reqwest/enum-repr/src/models/mixed_enum.rs.golden
+++ b/tests/golden/rust/rust-reqwest/enum-repr/src/models/mixed_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Mixed enum with unit variants (SimpleA, SimpleB) and tuple variants (VariantA(VariantA), VariantB(VariantB))
-/// 
+///
 /// Serializes as externally tagged: `{"SimpleA": null}`, `{"VariantA": {"field1": "...", "field2": 123}}`,
 /// `{"SimpleB": null}`, `{"VariantB": {"field3": true, "field4": 1.23}}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-reqwest/enum-repr/src/models/untagged_enum.rs.golden
+++ b/tests/golden/rust/rust-reqwest/enum-repr/src/models/untagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Untagged enum
-/// 
+///
 /// No tag is used, variants are distinguished by their structure:
 /// `{"field1": "...", "field2": 123}` or `{"field3": true, "field4": 1.23}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-reqwest/naming-conventions/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-reqwest/naming-conventions/src/apis/default.rs.golden
@@ -22,7 +22,7 @@ impl<'a> DefaultApi<'a> {
     /// Get with query parameters
     pub async fn get_with_query_params(
         &self,
-        snake_case_param: &String,
+        snake_case_param: &str,
         snake_case_number: Option<i64>,
         kebab_case_param: &Option<String>,
         kebab_case_array: &Option<Vec<String>>,

--- a/tests/golden/rust/rust-reqwest/petstore/src/apis/pet.rs.golden
+++ b/tests/golden/rust/rust-reqwest/petstore/src/apis/pet.rs.golden
@@ -64,7 +64,7 @@ impl<'a> PetApi<'a> {
     /// Find pets by status
     pub async fn find_pets_by_status(
         &self,
-        status: &String,
+        status: &str,
     ) -> Result<FindPetsByStatusResponse, Error> {
         let mut path = "/pet/findByStatus".to_string();
         let mut query_parts: Vec<(&str, String)> = Vec::new();

--- a/tests/golden/rust/rust-reqwest/petstore/src/apis/user.rs.golden
+++ b/tests/golden/rust/rust-reqwest/petstore/src/apis/user.rs.golden
@@ -99,7 +99,7 @@ impl<'a> UserApi<'a> {
     /// Get user by user name
     pub async fn get_user_by_name(
         &self,
-        username: &String,
+        username: &str,
     ) -> Result<GetUserByNameResponse, Error> {
         let mut path = "/user/{username}".to_string();
         path = path.replace("{username}", &username.to_string());
@@ -120,7 +120,7 @@ impl<'a> UserApi<'a> {
     /// Update user
     pub async fn update_user(
         &self,
-        username: &String,
+        username: &str,
         body: &crate::models::User,
     ) -> Result<UpdateUserResponse, Error> {
         let mut path = "/user/{username}".to_string();
@@ -135,7 +135,7 @@ impl<'a> UserApi<'a> {
     /// Delete user
     pub async fn delete_user(
         &self,
-        username: &String,
+        username: &str,
     ) -> Result<DeleteUserResponse, Error> {
         let mut path = "/user/{username}".to_string();
         path = path.replace("{username}", &username.to_string());

--- a/tests/golden/rust/rust-reqwest/response-body-no-response-body/src/apis/foo.rs.golden
+++ b/tests/golden/rust/rust-reqwest/response-body-no-response-body/src/apis/foo.rs.golden
@@ -21,7 +21,7 @@ impl<'a> FooApi<'a> {
     /// PATCH /foo/bar
     pub async fn update_foo_bar(
         &self,
-        foo_id: &String,
+        foo_id: &str,
         body: &crate::models::FooRequest,
     ) -> Result<UpdateFooBarResponse, Error> {
         let mut path = "/foo/bar".to_string();

--- a/tests/golden/rust/rust-reqwest/type-aliases-intersection-with-nullable-reference/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-intersection-with-nullable-reference/src/apis/default.rs.golden
@@ -43,7 +43,7 @@ impl<'a> DefaultApi<'a> {
     /// Get test
     pub async fn get_test(
         &self,
-        id: &String,
+        id: &str,
     ) -> Result<GetTestResponse, Error> {
         let mut path = "/test/{id}".to_string();
         path = path.replace("{id}", &id.to_string());

--- a/tests/golden/rust/rust-ureq/delete-with-response-schema/src/apis/test_resource.rs.golden
+++ b/tests/golden/rust/rust-ureq/delete-with-response-schema/src/apis/test_resource.rs.golden
@@ -42,7 +42,7 @@ impl<'a> TestResourceApi<'a> {
     /// DELETE /v1/api/test-resource/{resource_id}
     pub fn delete_test_resource(
         &self,
-        resource_id: &String,
+        resource_id: &str,
     ) -> Result<DeleteTestResourceResponse, Error> {
         let mut path = "/v1/api/test-resource/{resource_id}".to_string();
         path = path.replace("{resource_id}", &resource_id.to_string());

--- a/tests/golden/rust/rust-ureq/duplicate-param-names/src/apis/items.rs.golden
+++ b/tests/golden/rust/rust-ureq/duplicate-param-names/src/apis/items.rs.golden
@@ -22,7 +22,7 @@ impl<'a> ItemsApi<'a> {
     /// Create item with body parameter conflict
     pub fn create_item_with_body_conflict(
         &self,
-        item_id: &String,
+        item_id: &str,
         body: &Option<String>,
         body_2: &crate::models::CreateItemWithBodyConflictRequest,
     ) -> Result<CreateItemWithBodyConflictResponse, Error> {

--- a/tests/golden/rust/rust-ureq/enum-repr/src/models/adjacently_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-ureq/enum-repr/src/models/adjacently_tagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Adjacently tagged enum
-/// 
+///
 /// The tag and content are separate fields:
 /// `{"ty": "VariantA", "data": {"field1": "...", "field2": 123}}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-ureq/enum-repr/src/models/externally_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-ureq/enum-repr/src/models/externally_tagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Externally tagged enum (default Serde representation)
-/// 
+///
 /// This is the default representation where the variant name is the key
 /// and the content is the value: `{"VariantA": {"field1": "...", "field2": 123}}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-ureq/enum-repr/src/models/internally_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-ureq/enum-repr/src/models/internally_tagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Internally tagged enum
-/// 
+///
 /// The tag is a field inside the object alongside other fields:
 /// `{"ty": "VariantA", "field1": "...", "field2": 123}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-ureq/enum-repr/src/models/mixed_enum.rs.golden
+++ b/tests/golden/rust/rust-ureq/enum-repr/src/models/mixed_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Mixed enum with unit variants (SimpleA, SimpleB) and tuple variants (VariantA(VariantA), VariantB(VariantB))
-/// 
+///
 /// Serializes as externally tagged: `{"SimpleA": null}`, `{"VariantA": {"field1": "...", "field2": 123}}`,
 /// `{"SimpleB": null}`, `{"VariantB": {"field3": true, "field4": 1.23}}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-ureq/enum-repr/src/models/untagged_enum.rs.golden
+++ b/tests/golden/rust/rust-ureq/enum-repr/src/models/untagged_enum.rs.golden
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Untagged enum
-/// 
+///
 /// No tag is used, variants are distinguished by their structure:
 /// `{"field1": "...", "field2": 123}` or `{"field3": true, "field4": 1.23}`
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/golden/rust/rust-ureq/naming-conventions/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-ureq/naming-conventions/src/apis/default.rs.golden
@@ -22,7 +22,7 @@ impl<'a> DefaultApi<'a> {
     /// Get with query parameters
     pub fn get_with_query_params(
         &self,
-        snake_case_param: &String,
+        snake_case_param: &str,
         snake_case_number: Option<i64>,
         kebab_case_param: &Option<String>,
         kebab_case_array: &Option<Vec<String>>,

--- a/tests/golden/rust/rust-ureq/petstore/src/apis/pet.rs.golden
+++ b/tests/golden/rust/rust-ureq/petstore/src/apis/pet.rs.golden
@@ -62,7 +62,7 @@ impl<'a> PetApi<'a> {
     /// Find pets by status
     pub fn find_pets_by_status(
         &self,
-        status: &String,
+        status: &str,
     ) -> Result<FindPetsByStatusResponse, Error> {
         let path = "/pet/findByStatus".to_string();
         let mut req = self.client.get(&path);

--- a/tests/golden/rust/rust-ureq/petstore/src/apis/user.rs.golden
+++ b/tests/golden/rust/rust-ureq/petstore/src/apis/user.rs.golden
@@ -92,7 +92,7 @@ impl<'a> UserApi<'a> {
     /// Get user by user name
     pub fn get_user_by_name(
         &self,
-        username: &String,
+        username: &str,
     ) -> Result<GetUserByNameResponse, Error> {
         let mut path = "/user/{username}".to_string();
         path = path.replace("{username}", &username.to_string());
@@ -113,7 +113,7 @@ impl<'a> UserApi<'a> {
     /// Update user
     pub fn update_user(
         &self,
-        username: &String,
+        username: &str,
         body: &crate::models::User,
     ) -> Result<UpdateUserResponse, Error> {
         let mut path = "/user/{username}".to_string();
@@ -127,7 +127,7 @@ impl<'a> UserApi<'a> {
     /// Delete user
     pub fn delete_user(
         &self,
-        username: &String,
+        username: &str,
     ) -> Result<DeleteUserResponse, Error> {
         let mut path = "/user/{username}".to_string();
         path = path.replace("{username}", &username.to_string());

--- a/tests/golden/rust/rust-ureq/response-body-no-response-body/src/apis/foo.rs.golden
+++ b/tests/golden/rust/rust-ureq/response-body-no-response-body/src/apis/foo.rs.golden
@@ -21,7 +21,7 @@ impl<'a> FooApi<'a> {
     /// PATCH /foo/bar
     pub fn update_foo_bar(
         &self,
-        foo_id: &String,
+        foo_id: &str,
         body: &crate::models::FooRequest,
     ) -> Result<UpdateFooBarResponse, Error> {
         let mut path = "/foo/bar".to_string();

--- a/tests/golden/rust/rust-ureq/type-aliases-intersection-with-nullable-reference/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-intersection-with-nullable-reference/src/apis/default.rs.golden
@@ -42,7 +42,7 @@ impl<'a> DefaultApi<'a> {
     /// Get test
     pub fn get_test(
         &self,
-        id: &String,
+        id: &str,
     ) -> Result<GetTestResponse, Error> {
         let mut path = "/test/{id}".to_string();
         path = path.replace("{id}", &id.to_string());


### PR DESCRIPTION
## Summary

- Add `uint32`/`uint64` integer format support (maps to `u32`/`u64`)
- Thread extra derives config through `emit_alias`; emit newtype struct with `#[serde(transparent)]` when extra derives are configured
- Skip self-referential aliases (e.g. `pub type String = String`)
- Fix doc comment blank lines to emit `///` without trailing space
- Use `&str` instead of `&String` for String parameters in API methods
- Add `workspace_mode` config option for workspace-compatible `Cargo.toml` (`version.workspace = true`, `edition.workspace = true`)

Tagged enum `utoipa::ToSchema` support is deferred to a separate PR (requires inlining variant fields).

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` / `cargo clippy` clean
- [x] `cargo test` — all golden snapshot tests pass
- [x] `just golden-rust::build` — 141/141 compile checks pass (47 per backend × 3)