### PR TITLE
feat(rust): emit struct variants for internally/adjacently tagged enums

### DIFF
--- a/src/generators/rust/common/emit_models.rs
+++ b/src/generators/rust/common/emit_models.rs
@@ -33,7 +33,7 @@ pub fn generate_model_files(
     let mut mod_entries = Vec::new();
 
     for (_name, schema) in &ir.schemas {
-        let Some(file_spec) = emit_model_file(schema, config) else {
+        let Some(file_spec) = emit_model_file(schema, config, ir) else {
             continue;
         };
         let stem = schema.name.to_snake_case();
@@ -60,7 +60,11 @@ pub fn generate_model_files(
     Ok(files)
 }
 
-fn emit_model_file(schema: &IrSchema, config: &RustGeneratorConfig) -> Option<FileSpec> {
+fn emit_model_file(
+    schema: &IrSchema,
+    config: &RustGeneratorConfig,
+    ir: &IrSpec,
+) -> Option<FileSpec> {
     let extra = config.extra_derives.as_ref();
     match &schema.kind {
         IrSchemaKind::Object(obj) => {
@@ -75,7 +79,7 @@ fn emit_model_file(schema: &IrSchema, config: &RustGeneratorConfig) -> Option<Fi
             emit_intersection(schema, i, extra.and_then(|e| e.structs.as_ref()))
         }
         IrSchemaKind::TaggedUnion(tu) => {
-            emit_tagged_union(schema, tu, extra.and_then(|e| e.unions.as_ref()))
+            emit_tagged_union(schema, tu, extra.and_then(|e| e.unions.as_ref()), ir)
         }
     }
 }
@@ -397,6 +401,7 @@ fn emit_tagged_union(
     schema: &IrSchema,
     tu: &IrTaggedUnion,
     extra: Option<&ExtraDeriveConfig>,
+    ir: &IrSpec,
 ) -> Option<FileSpec> {
     if tu.variants.is_empty() {
         return None;
@@ -426,6 +431,72 @@ fn emit_tagged_union(
         TaggingStyle::External => String::new(),
     };
 
+    let inline_fields = matches!(
+        tu.tagging,
+        TaggingStyle::Internal | TaggingStyle::Adjacent { .. }
+    );
+
+    let mut variant_blocks: Vec<String> = Vec::new();
+    for variant in &tu.variants {
+        let variant_name = variant.discriminator_value.to_pascal_case();
+        let mut block = String::new();
+
+        if variant.discriminator_value.to_pascal_case() != variant.discriminator_value {
+            block.push_str(&format!(
+                "#[serde(rename = \"{}\")]\n",
+                escape_str(&variant.discriminator_value)
+            ));
+        }
+
+        if inline_fields {
+            if let Some(obj) = resolve_object(&variant.content_type, ir) {
+                block.push_str(&format!("{variant_name} {{"));
+                for (json_name, prop) in &obj.properties {
+                    let field_name = escape_rust_keyword(&json_name.to_snake_case());
+                    if field_name != *json_name {
+                        block.push_str(&format!("\n    #[serde(rename = \"{json_name}\")]"));
+                    }
+                    if !prop.required || prop.nullable {
+                        block.push_str(
+                            "\n    #[serde(skip_serializing_if = \"Option::is_none\", default)]",
+                        );
+                        block.push_str(&format!(
+                            "\n    {field_name}: Option<{}>,",
+                            rust_type_str_model(&prop.type_expr)
+                        ));
+                    } else {
+                        block.push_str(&format!(
+                            "\n    {field_name}: {},",
+                            rust_type_str_model(&prop.type_expr)
+                        ));
+                    }
+                }
+                if let Some(ap) = &obj.additional_properties {
+                    block.push_str("\n    #[serde(flatten)]");
+                    block.push_str(&format!(
+                        "\n    additional_properties: std::collections::HashMap<String, {}>,",
+                        rust_type_str_model(ap)
+                    ));
+                }
+                block.push_str("\n},");
+            } else {
+                block.push_str(&format!(
+                    "{}({}),",
+                    variant_name,
+                    rust_type_str_model(&variant.content_type)
+                ));
+            }
+        } else {
+            block.push_str(&format!(
+                "{}({}),",
+                variant_name,
+                rust_type_str_model(&variant.content_type)
+            ));
+        }
+
+        variant_blocks.push(block);
+    }
+
     let body = sigil_quote!(RustLang {
         $if(schema.description.is_some()) {
             $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
@@ -435,11 +506,8 @@ fn emit_tagged_union(
             $L(serde_tag_attr.as_str())
         }
         pub enum $N(name.as_str()) {
-            $for(variant in tu.variants.iter()) {
-                $if(variant.discriminator_value.to_pascal_case() != variant.discriminator_value) {
-                    $L(format!("#[serde(rename = \"{}\")]", escape_str(&variant.discriminator_value)))
-                }
-                $L(format!("{}({}),", variant.discriminator_value.to_pascal_case(), rust_type_str_model(&variant.content_type)))
+            $for(block in variant_blocks.iter()) {
+                $L(block.as_str())
             }
         }
     })
@@ -543,6 +611,20 @@ fn doc_comment_block(doc: &str) -> String {
         }
     }
     out
+}
+
+// ---------------------------------------------------------------------------
+// Schema resolution helper
+// ---------------------------------------------------------------------------
+
+fn resolve_object<'a>(expr: &IrTypeExpr, ir: &'a IrSpec) -> Option<&'a IrObject> {
+    if let IrTypeExpr::Named(name) = expr
+        && let Some(schema) = ir.schemas.get(name)
+        && let IrSchemaKind::Object(obj) = &schema.kind
+    {
+        return Some(obj);
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/models/adjacently_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/models/adjacently_tagged_enum.rs.golden
@@ -13,7 +13,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "ty", content = "data")]
 pub enum AdjacentlyTaggedEnum {
     #[serde(rename = "ADJACENTLY_TAGGED_ENUM_VARIANT_A")]
-    AdjacentlyTaggedEnumVariantA(super::VariantA),
+    AdjacentlyTaggedEnumVariantA {
+        field1: String,
+        field2: i32,
+    },
     #[serde(rename = "ADJACENTLY_TAGGED_ENUM_VARIANT_B")]
-    AdjacentlyTaggedEnumVariantB(super::VariantB),
+    AdjacentlyTaggedEnumVariantB {
+        field3: bool,
+        field4: f64,
+    },
 }

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/models/internally_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/models/internally_tagged_enum.rs.golden
@@ -13,7 +13,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "ty")]
 pub enum InternallyTaggedEnum {
     #[serde(rename = "INTERNALLY_TAGGED_ENUM_VARIANT_A")]
-    InternallyTaggedEnumVariantA(super::VariantA),
+    InternallyTaggedEnumVariantA {
+        field1: String,
+        field2: i32,
+    },
     #[serde(rename = "INTERNALLY_TAGGED_ENUM_VARIANT_B")]
-    InternallyTaggedEnumVariantB(super::VariantB),
+    InternallyTaggedEnumVariantB {
+        field3: bool,
+        field4: f64,
+    },
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/models/resource.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/models/resource.rs.golden
@@ -11,9 +11,17 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum Resource {
     #[serde(rename = "RESOURCE_UNSPECIFIED")]
-    ResourceUnspecified(super::ResourceUnspecified),
+    ResourceUnspecified {
+        name: String,
+    },
     #[serde(rename = "RESOURCE_QUICK")]
-    ResourceQuick(super::ResourceQuick),
+    ResourceQuick {
+        #[serde(rename = "quickField")]
+        quick_field: String,
+    },
     #[serde(rename = "RESOURCE_CUSTOM")]
-    ResourceCustom(super::ResourceCustom),
+    ResourceCustom {
+        #[serde(rename = "customField")]
+        custom_field: String,
+    },
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/models/container_kind.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/models/container_kind.rs.golden
@@ -12,7 +12,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum ContainerKind {
     #[serde(rename = "CONTAINER_KIND_MANAGED")]
-    ContainerKindManaged(super::ContainerKindManaged),
+    ContainerKindManaged {
+        #[serde(rename = "managedField")]
+        managed_field: String,
+    },
     #[serde(rename = "CONTAINER_KIND_CUSTOM")]
-    ContainerKindCustom(super::ContainerKindCustom),
+    ContainerKindCustom {
+        #[serde(rename = "customField")]
+        custom_field: String,
+    },
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/models/volume_kind.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/models/volume_kind.rs.golden
@@ -12,7 +12,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum VolumeKind {
     #[serde(rename = "VOLUME_KIND_LOCAL")]
-    VolumeKindLocal(super::VolumeKindLocal),
+    VolumeKindLocal {
+        #[serde(rename = "localPath")]
+        local_path: String,
+    },
     #[serde(rename = "VOLUME_KIND_REMOTE")]
-    VolumeKindRemote(super::VolumeKindRemote),
+    VolumeKindRemote {
+        #[serde(rename = "remotePath")]
+        remote_path: String,
+    },
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/models/container_image.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/models/container_image.rs.golden
@@ -10,7 +10,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum ContainerImage {
     #[serde(rename = "CONTAINER_IMAGE_MANAGED")]
-    ContainerImageManaged(super::ContainerImageManaged),
+    ContainerImageManaged {
+        #[serde(rename = "managedField")]
+        managed_field: String,
+    },
     #[serde(rename = "CONTAINER_IMAGE_CUSTOM")]
-    ContainerImageCustom(super::ContainerImageCustom),
+    ContainerImageCustom {
+        #[serde(rename = "customField")]
+        custom_field: String,
+    },
 }

--- a/tests/golden/rust/rust-reqwest/enum-repr/src/models/adjacently_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-reqwest/enum-repr/src/models/adjacently_tagged_enum.rs.golden
@@ -13,7 +13,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "ty", content = "data")]
 pub enum AdjacentlyTaggedEnum {
     #[serde(rename = "ADJACENTLY_TAGGED_ENUM_VARIANT_A")]
-    AdjacentlyTaggedEnumVariantA(super::VariantA),
+    AdjacentlyTaggedEnumVariantA {
+        field1: String,
+        field2: i32,
+    },
     #[serde(rename = "ADJACENTLY_TAGGED_ENUM_VARIANT_B")]
-    AdjacentlyTaggedEnumVariantB(super::VariantB),
+    AdjacentlyTaggedEnumVariantB {
+        field3: bool,
+        field4: f64,
+    },
 }

--- a/tests/golden/rust/rust-reqwest/enum-repr/src/models/internally_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-reqwest/enum-repr/src/models/internally_tagged_enum.rs.golden
@@ -13,7 +13,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "ty")]
 pub enum InternallyTaggedEnum {
     #[serde(rename = "INTERNALLY_TAGGED_ENUM_VARIANT_A")]
-    InternallyTaggedEnumVariantA(super::VariantA),
+    InternallyTaggedEnumVariantA {
+        field1: String,
+        field2: i32,
+    },
     #[serde(rename = "INTERNALLY_TAGGED_ENUM_VARIANT_B")]
-    InternallyTaggedEnumVariantB(super::VariantB),
+    InternallyTaggedEnumVariantB {
+        field3: bool,
+        field4: f64,
+    },
 }

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-internally-tagged/src/models/resource.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-internally-tagged/src/models/resource.rs.golden
@@ -11,9 +11,17 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum Resource {
     #[serde(rename = "RESOURCE_UNSPECIFIED")]
-    ResourceUnspecified(super::ResourceUnspecified),
+    ResourceUnspecified {
+        name: String,
+    },
     #[serde(rename = "RESOURCE_QUICK")]
-    ResourceQuick(super::ResourceQuick),
+    ResourceQuick {
+        #[serde(rename = "quickField")]
+        quick_field: String,
+    },
     #[serde(rename = "RESOURCE_CUSTOM")]
-    ResourceCustom(super::ResourceCustom),
+    ResourceCustom {
+        #[serde(rename = "customField")]
+        custom_field: String,
+    },
 }

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-multiple/src/models/container_kind.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-multiple/src/models/container_kind.rs.golden
@@ -12,7 +12,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum ContainerKind {
     #[serde(rename = "CONTAINER_KIND_MANAGED")]
-    ContainerKindManaged(super::ContainerKindManaged),
+    ContainerKindManaged {
+        #[serde(rename = "managedField")]
+        managed_field: String,
+    },
     #[serde(rename = "CONTAINER_KIND_CUSTOM")]
-    ContainerKindCustom(super::ContainerKindCustom),
+    ContainerKindCustom {
+        #[serde(rename = "customField")]
+        custom_field: String,
+    },
 }

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-multiple/src/models/volume_kind.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-multiple/src/models/volume_kind.rs.golden
@@ -12,7 +12,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum VolumeKind {
     #[serde(rename = "VOLUME_KIND_LOCAL")]
-    VolumeKindLocal(super::VolumeKindLocal),
+    VolumeKindLocal {
+        #[serde(rename = "localPath")]
+        local_path: String,
+    },
     #[serde(rename = "VOLUME_KIND_REMOTE")]
-    VolumeKindRemote(super::VolumeKindRemote),
+    VolumeKindRemote {
+        #[serde(rename = "remotePath")]
+        remote_path: String,
+    },
 }

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-with-refs/src/models/container_image.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-with-refs/src/models/container_image.rs.golden
@@ -10,7 +10,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum ContainerImage {
     #[serde(rename = "CONTAINER_IMAGE_MANAGED")]
-    ContainerImageManaged(super::ContainerImageManaged),
+    ContainerImageManaged {
+        #[serde(rename = "managedField")]
+        managed_field: String,
+    },
     #[serde(rename = "CONTAINER_IMAGE_CUSTOM")]
-    ContainerImageCustom(super::ContainerImageCustom),
+    ContainerImageCustom {
+        #[serde(rename = "customField")]
+        custom_field: String,
+    },
 }

--- a/tests/golden/rust/rust-ureq/enum-repr/src/models/adjacently_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-ureq/enum-repr/src/models/adjacently_tagged_enum.rs.golden
@@ -13,7 +13,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "ty", content = "data")]
 pub enum AdjacentlyTaggedEnum {
     #[serde(rename = "ADJACENTLY_TAGGED_ENUM_VARIANT_A")]
-    AdjacentlyTaggedEnumVariantA(super::VariantA),
+    AdjacentlyTaggedEnumVariantA {
+        field1: String,
+        field2: i32,
+    },
     #[serde(rename = "ADJACENTLY_TAGGED_ENUM_VARIANT_B")]
-    AdjacentlyTaggedEnumVariantB(super::VariantB),
+    AdjacentlyTaggedEnumVariantB {
+        field3: bool,
+        field4: f64,
+    },
 }

--- a/tests/golden/rust/rust-ureq/enum-repr/src/models/internally_tagged_enum.rs.golden
+++ b/tests/golden/rust/rust-ureq/enum-repr/src/models/internally_tagged_enum.rs.golden
@@ -13,7 +13,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "ty")]
 pub enum InternallyTaggedEnum {
     #[serde(rename = "INTERNALLY_TAGGED_ENUM_VARIANT_A")]
-    InternallyTaggedEnumVariantA(super::VariantA),
+    InternallyTaggedEnumVariantA {
+        field1: String,
+        field2: i32,
+    },
     #[serde(rename = "INTERNALLY_TAGGED_ENUM_VARIANT_B")]
-    InternallyTaggedEnumVariantB(super::VariantB),
+    InternallyTaggedEnumVariantB {
+        field3: bool,
+        field4: f64,
+    },
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-internally-tagged/src/models/resource.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-internally-tagged/src/models/resource.rs.golden
@@ -11,9 +11,17 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum Resource {
     #[serde(rename = "RESOURCE_UNSPECIFIED")]
-    ResourceUnspecified(super::ResourceUnspecified),
+    ResourceUnspecified {
+        name: String,
+    },
     #[serde(rename = "RESOURCE_QUICK")]
-    ResourceQuick(super::ResourceQuick),
+    ResourceQuick {
+        #[serde(rename = "quickField")]
+        quick_field: String,
+    },
     #[serde(rename = "RESOURCE_CUSTOM")]
-    ResourceCustom(super::ResourceCustom),
+    ResourceCustom {
+        #[serde(rename = "customField")]
+        custom_field: String,
+    },
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-multiple/src/models/container_kind.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-multiple/src/models/container_kind.rs.golden
@@ -12,7 +12,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum ContainerKind {
     #[serde(rename = "CONTAINER_KIND_MANAGED")]
-    ContainerKindManaged(super::ContainerKindManaged),
+    ContainerKindManaged {
+        #[serde(rename = "managedField")]
+        managed_field: String,
+    },
     #[serde(rename = "CONTAINER_KIND_CUSTOM")]
-    ContainerKindCustom(super::ContainerKindCustom),
+    ContainerKindCustom {
+        #[serde(rename = "customField")]
+        custom_field: String,
+    },
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-multiple/src/models/volume_kind.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-multiple/src/models/volume_kind.rs.golden
@@ -12,7 +12,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum VolumeKind {
     #[serde(rename = "VOLUME_KIND_LOCAL")]
-    VolumeKindLocal(super::VolumeKindLocal),
+    VolumeKindLocal {
+        #[serde(rename = "localPath")]
+        local_path: String,
+    },
     #[serde(rename = "VOLUME_KIND_REMOTE")]
-    VolumeKindRemote(super::VolumeKindRemote),
+    VolumeKindRemote {
+        #[serde(rename = "remotePath")]
+        remote_path: String,
+    },
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-with-refs/src/models/container_image.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-with-refs/src/models/container_image.rs.golden
@@ -10,7 +10,13 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "kind")]
 pub enum ContainerImage {
     #[serde(rename = "CONTAINER_IMAGE_MANAGED")]
-    ContainerImageManaged(super::ContainerImageManaged),
+    ContainerImageManaged {
+        #[serde(rename = "managedField")]
+        managed_field: String,
+    },
     #[serde(rename = "CONTAINER_IMAGE_CUSTOM")]
-    ContainerImageCustom(super::ContainerImageCustom),
+    ContainerImageCustom {
+        #[serde(rename = "customField")]
+        custom_field: String,
+    },
 }

--- a/tests/tagged_enum_struct_variants.rs
+++ b/tests/tagged_enum_struct_variants.rs
@@ -1,0 +1,403 @@
+//! Tests that internally/adjacently tagged enums emit struct variants
+//! (inlined fields) while externally tagged and untagged enums keep
+//! tuple variants. This is required for utoipa::ToSchema and
+//! schemars::JsonSchema derive compatibility.
+
+use openapi_nexus::generators::rust::reqwest::RustReqwestCodeGenerator;
+use openapi_nexus::test_utils::{generate_files, read_fixture};
+
+fn generate_enum_repr(config: toml::value::Table) -> std::collections::HashMap<String, String> {
+    let generator = RustReqwestCodeGenerator::new(config);
+    let spec = read_fixture("valid/enum-repr/enum-repr.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+fn generate_discriminated_union_internally_tagged(
+    config: toml::value::Table,
+) -> std::collections::HashMap<String, String> {
+    let generator = RustReqwestCodeGenerator::new(config);
+    let spec = read_fixture("valid/type-aliases/discriminated-union-internally-tagged.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+fn generate_discriminated_union_with_refs(
+    config: toml::value::Table,
+) -> std::collections::HashMap<String, String> {
+    let generator = RustReqwestCodeGenerator::new(config);
+    let spec = read_fixture("valid/type-aliases/discriminated-union-with-refs.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+fn generate_discriminated_union_multiple(
+    config: toml::value::Table,
+) -> std::collections::HashMap<String, String> {
+    let generator = RustReqwestCodeGenerator::new(config);
+    let spec = read_fixture("valid/type-aliases/discriminated-union-multiple.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+// ---------------------------------------------------------------------------
+// Internally tagged: struct variants with inlined fields
+// ---------------------------------------------------------------------------
+
+#[test]
+fn internally_tagged_enum_uses_struct_variants() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("src/models/internally_tagged_enum.rs")
+        .expect("internally_tagged_enum.rs should exist");
+
+    assert!(
+        content.contains("#[serde(tag = \"ty\")]"),
+        "should have internal tag attribute, got:\n{content}"
+    );
+
+    assert!(
+        content.contains("InternallyTaggedEnumVariantA {"),
+        "variant A should be a struct variant (opening brace), got:\n{content}"
+    );
+    assert!(
+        content.contains("InternallyTaggedEnumVariantB {"),
+        "variant B should be a struct variant (opening brace), got:\n{content}"
+    );
+
+    assert!(
+        !content.contains("InternallyTaggedEnumVariantA("),
+        "variant A should NOT be a tuple variant, got:\n{content}"
+    );
+    assert!(
+        !content.contains("InternallyTaggedEnumVariantB("),
+        "variant B should NOT be a tuple variant, got:\n{content}"
+    );
+}
+
+#[test]
+fn internally_tagged_struct_variant_fields_inlined() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("src/models/internally_tagged_enum.rs")
+        .expect("internally_tagged_enum.rs should exist");
+
+    assert!(
+        content.contains("field1: String"),
+        "VariantA's field1 should be inlined, got:\n{content}"
+    );
+    assert!(
+        content.contains("field2: i32"),
+        "VariantA's field2 should be inlined, got:\n{content}"
+    );
+    assert!(
+        content.contains("field3: bool"),
+        "VariantB's field3 should be inlined, got:\n{content}"
+    );
+    assert!(
+        content.contains("field4: f64"),
+        "VariantB's field4 should be inlined, got:\n{content}"
+    );
+}
+
+#[test]
+fn internally_tagged_fields_have_no_pub() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("src/models/internally_tagged_enum.rs")
+        .expect("internally_tagged_enum.rs should exist");
+
+    assert!(
+        !content.contains("pub field"),
+        "enum variant fields must not have pub visibility, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adjacently tagged: struct variants with inlined fields
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adjacently_tagged_enum_uses_struct_variants() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("src/models/adjacently_tagged_enum.rs")
+        .expect("adjacently_tagged_enum.rs should exist");
+
+    assert!(
+        content.contains("#[serde(tag = \"ty\", content = \"data\")]"),
+        "should have adjacent tag attribute, got:\n{content}"
+    );
+
+    assert!(
+        content.contains("AdjacentlyTaggedEnumVariantA {"),
+        "variant A should be a struct variant, got:\n{content}"
+    );
+    assert!(
+        content.contains("AdjacentlyTaggedEnumVariantB {"),
+        "variant B should be a struct variant, got:\n{content}"
+    );
+
+    assert!(
+        !content.contains("AdjacentlyTaggedEnumVariantA("),
+        "variant A should NOT be a tuple variant, got:\n{content}"
+    );
+}
+
+#[test]
+fn adjacently_tagged_struct_variant_fields_inlined() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("src/models/adjacently_tagged_enum.rs")
+        .expect("adjacently_tagged_enum.rs should exist");
+
+    assert!(
+        content.contains("field1: String"),
+        "VariantA's field1 should be inlined, got:\n{content}"
+    );
+    assert!(
+        content.contains("field2: i32"),
+        "VariantA's field2 should be inlined, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Externally tagged: tuple variants (unchanged)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn externally_tagged_enum_uses_tuple_variants() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("src/models/externally_tagged_enum.rs")
+        .expect("externally_tagged_enum.rs should exist");
+
+    assert!(
+        content.contains("ExternallyTaggedEnumVariantA(super::VariantA)"),
+        "variant A should be a tuple variant wrapping super::VariantA, got:\n{content}"
+    );
+    assert!(
+        content.contains("ExternallyTaggedEnumVariantB(super::VariantB)"),
+        "variant B should be a tuple variant wrapping super::VariantB, got:\n{content}"
+    );
+
+    assert!(
+        !content.contains("ExternallyTaggedEnumVariantA {"),
+        "variant A should NOT be a struct variant, got:\n{content}"
+    );
+}
+
+#[test]
+fn externally_tagged_enum_has_no_serde_tag() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("src/models/externally_tagged_enum.rs")
+        .expect("externally_tagged_enum.rs should exist");
+
+    assert!(
+        !content.contains("#[serde(tag"),
+        "externally tagged enum should have no serde tag attribute, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Untagged: tuple variants (unchanged)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn untagged_enum_uses_tuple_variants() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("src/models/untagged_enum.rs")
+        .expect("untagged_enum.rs should exist");
+
+    assert!(
+        content.contains("#[serde(untagged)]"),
+        "should have untagged attribute, got:\n{content}"
+    );
+    assert!(
+        content.contains("VariantA(super::VariantA)"),
+        "untagged variant should be a tuple variant, got:\n{content}"
+    );
+    assert!(
+        content.contains("VariantB(super::VariantB)"),
+        "untagged variant should be a tuple variant, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union (internally tagged with refs): struct variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discriminated_union_internally_tagged_uses_struct_variants() {
+    let files = generate_discriminated_union_internally_tagged(toml::value::Table::new());
+    let content = files
+        .get("src/models/resource.rs")
+        .expect("resource.rs should exist");
+
+    assert!(
+        content.contains("#[serde(tag = \"kind\")]"),
+        "should have internal tag attribute, got:\n{content}"
+    );
+
+    assert!(
+        content.contains("ResourceUnspecified {"),
+        "ResourceUnspecified should be a struct variant, got:\n{content}"
+    );
+    assert!(
+        content.contains("ResourceQuick {"),
+        "ResourceQuick should be a struct variant, got:\n{content}"
+    );
+    assert!(
+        content.contains("ResourceCustom {"),
+        "ResourceCustom should be a struct variant, got:\n{content}"
+    );
+
+    assert!(
+        !content.contains("ResourceUnspecified("),
+        "ResourceUnspecified should NOT be a tuple variant, got:\n{content}"
+    );
+}
+
+#[test]
+fn discriminated_union_struct_variant_has_serde_rename_on_fields() {
+    let files = generate_discriminated_union_internally_tagged(toml::value::Table::new());
+    let content = files
+        .get("src/models/resource.rs")
+        .expect("resource.rs should exist");
+
+    assert!(
+        content.contains("#[serde(rename = \"quickField\")]"),
+        "camelCase fields should have serde rename, got:\n{content}"
+    );
+    assert!(
+        content.contains("quick_field: String"),
+        "field should use snake_case name, got:\n{content}"
+    );
+}
+
+#[test]
+fn discriminated_union_with_refs_uses_struct_variants() {
+    let files = generate_discriminated_union_with_refs(toml::value::Table::new());
+    let content = files
+        .get("src/models/container_image.rs")
+        .expect("container_image.rs should exist");
+
+    assert!(
+        content.contains("ContainerImageManaged {"),
+        "ContainerImageManaged should be a struct variant, got:\n{content}"
+    );
+    assert!(
+        content.contains("ContainerImageCustom {"),
+        "ContainerImageCustom should be a struct variant, got:\n{content}"
+    );
+}
+
+#[test]
+fn discriminated_union_multiple_uses_struct_variants() {
+    let files = generate_discriminated_union_multiple(toml::value::Table::new());
+
+    let container = files
+        .get("src/models/container_kind.rs")
+        .expect("container_kind.rs should exist");
+    assert!(
+        container.contains("#[serde(tag = \"kind\")]"),
+        "ContainerKind should be internally tagged, got:\n{container}"
+    );
+    assert!(
+        !container.contains("(super::"),
+        "ContainerKind should not have tuple variants, got:\n{container}"
+    );
+
+    let volume = files
+        .get("src/models/volume_kind.rs")
+        .expect("volume_kind.rs should exist");
+    assert!(
+        volume.contains("#[serde(tag = \"kind\")]"),
+        "VolumeKind should be internally tagged, got:\n{volume}"
+    );
+    assert!(
+        !volume.contains("(super::"),
+        "VolumeKind should not have tuple variants, got:\n{volume}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Extra derives applied to tagged union enums with struct variants
+// ---------------------------------------------------------------------------
+
+fn build_config(toml_str: &str) -> toml::value::Table {
+    toml::from_str::<toml::value::Table>(toml_str).unwrap()
+}
+
+#[test]
+fn extra_derives_on_internally_tagged_enum() {
+    let config = build_config(
+        r#"
+        [extra_derives.unions]
+        derives = ["PartialEq"]
+        "#,
+    );
+    let files = generate_enum_repr(config);
+    let content = files
+        .get("src/models/internally_tagged_enum.rs")
+        .expect("internally_tagged_enum.rs should exist");
+
+    assert!(
+        content.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]"),
+        "internally tagged enum should have extra derive, got:\n{content}"
+    );
+}
+
+#[test]
+fn extra_derives_on_adjacently_tagged_enum() {
+    let config = build_config(
+        r#"
+        [extra_derives.unions]
+        derives = ["PartialEq"]
+        "#,
+    );
+    let files = generate_enum_repr(config);
+    let content = files
+        .get("src/models/adjacently_tagged_enum.rs")
+        .expect("adjacently_tagged_enum.rs should exist");
+
+    assert!(
+        content.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]"),
+        "adjacently tagged enum should have extra derive, got:\n{content}"
+    );
+}
+
+#[test]
+fn extra_derives_on_externally_tagged_enum() {
+    let config = build_config(
+        r#"
+        [extra_derives.unions]
+        derives = ["PartialEq"]
+        "#,
+    );
+    let files = generate_enum_repr(config);
+    let content = files
+        .get("src/models/externally_tagged_enum.rs")
+        .expect("externally_tagged_enum.rs should exist");
+
+    assert!(
+        content.contains("#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]"),
+        "externally tagged enum should also get unions extra derive, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Standalone variant structs are still generated alongside inlined variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn variant_structs_still_generated_for_internally_tagged() {
+    let files = generate_enum_repr(toml::value::Table::new());
+
+    assert!(
+        files.contains_key("src/models/variant_a.rs"),
+        "variant_a.rs should still be generated as standalone struct"
+    );
+    assert!(
+        files.contains_key("src/models/variant_b.rs"),
+        "variant_b.rs should still be generated as standalone struct"
+    );
+}


### PR DESCRIPTION
## Summary

- Internally and adjacently tagged enums now emit struct variants with inlined fields instead of tuple variants wrapping a type reference
- This makes generated code compatible with `utoipa::ToSchema` and `schemars::JsonSchema` derives, which cannot introspect tuple variants in tagged enums
- Externally tagged and untagged enums retain tuple variants (already work with both derive macros)

## Changes

- `src/generators/rust/common/emit_models.rs`: thread `&IrSpec` through emit chain, add `resolve_object` helper, emit struct variants for Internal/Adjacent tagging styles
- 18 golden files updated across 3 backends (reqwest/ureq/aioduct)
- New test file `tests/tagged_enum_struct_variants.rs` with 16 tests covering all tagging styles, field inlining, serde attributes, extra derives, and variant struct coexistence

## Test plan

- [x] `cargo test --test tagged_enum_struct_variants` — 16 tests pass
- [x] `cargo test --test golden_tests_rust_reqwest` — all golden comparisons pass
- [x] `cargo test --test golden_tests_rust_ureq` — all golden comparisons pass
- [x] `cargo test --test golden_tests_rust_aioduct` — all golden comparisons pass
- [x] `just golden-rust::build` — all 141 Rust golden targets compile