### PR TITLE
feat(python): generate discriminator-aware from_dict/to_dict helpers

### DIFF
--- a/src/generators/python/httpx/emit_models.rs
+++ b/src/generators/python/httpx/emit_models.rs
@@ -7,7 +7,7 @@
 use crate::codegen::traits::file_writer::FileInfo;
 use crate::ir::types::{
     IrEnum, IrEnumValueType, IrIntersection, IrObject, IrPrimitive, IrProperty, IrSchema,
-    IrSchemaKind, IrSpec, IrTaggedUnion, IrTypeExpr, IrUnion, TaggingStyle,
+    IrSchemaKind, IrSpec, IrTaggedUnion, IrTaggedVariant, IrTypeExpr, IrUnion, TaggingStyle,
 };
 use heck::{ToPascalCase, ToSnakeCase};
 use sigil_stitch::code_block::CodeBlock;
@@ -41,7 +41,7 @@ fn emit_model_body(schema: &IrSchema, ir: &IrSpec) -> Option<String> {
         IrSchemaKind::Alias(expr) => emit_alias(schema, expr),
         IrSchemaKind::Union(u) => emit_union(schema, u),
         IrSchemaKind::Intersection(i) => emit_intersection(schema, i, ir),
-        IrSchemaKind::TaggedUnion(tu) => emit_tagged_union(schema, tu),
+        IrSchemaKind::TaggedUnion(tu) => emit_tagged_union(schema, tu, ir),
     }?;
     file_spec.render(100).ok()
 }
@@ -441,8 +441,9 @@ fn emit_intersection_as_dataclass(
 // TaggedUnion -> type X = A | B | C
 // ---------------------------------------------------------------------------
 
-fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<FileSpec> {
+fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion, ir: &IrSpec) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
+    let snake_name = schema.name.to_snake_case();
 
     let members: Vec<TypeName> = tu
         .variants
@@ -489,7 +490,145 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<FileSpec> 
     }
     file = file.add_raw(&doc_block);
     file = file.add_code(type_alias);
+
+    if !tu.variants.is_empty() {
+        let helpers = build_tagged_union_helpers(&name, &snake_name, tu, ir);
+        file = file.add_raw(&helpers);
+    }
+
     file.build().ok()
+}
+
+fn build_tagged_union_helpers(
+    pascal_name: &str,
+    snake_name: &str,
+    tu: &IrTaggedUnion,
+    ir: &IrSpec,
+) -> String {
+    let mut out = String::new();
+    let tag_field = &tu.discriminator_field;
+
+    // Only generate helpers for variants that resolve to Object schemas
+    let resolved_variants: Vec<(&IrTaggedVariant, String)> = tu
+        .variants
+        .iter()
+        .filter_map(|v| {
+            if let IrTypeExpr::Named(ref_name) = &v.content_type
+                && is_object_schema(ref_name, ir)
+            {
+                return Some((v, ref_name.to_pascal_case()));
+            }
+            None
+        })
+        .collect();
+
+    if resolved_variants.is_empty() {
+        return out;
+    }
+
+    // from_dict
+    out.push('\n');
+    out.push_str(&format!(
+        "def {snake_name}_from_dict(data: dict[str, object]) -> {pascal_name}:\n"
+    ));
+    match &tu.tagging {
+        TaggingStyle::Internal => {
+            out.push_str(&format!("    _tag = data[\"{tag_field}\"]\n"));
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                out.push_str(&format!(
+                    "    {kw} _tag == \"{}\":\n        return {py_class}.from_dict(data)\n",
+                    variant.discriminator_value
+                ));
+            }
+        }
+        TaggingStyle::Adjacent { content_field } => {
+            out.push_str(&format!("    _tag = data[\"{tag_field}\"]\n"));
+            out.push_str(&format!(
+                "    _content = data[\"{content_field}\"]  # type: ignore[assignment]\n"
+            ));
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                out.push_str(&format!(
+                    "    {kw} _tag == \"{}\":\n        return {py_class}.from_dict(_content)  # type: ignore[arg-type]\n",
+                    variant.discriminator_value
+                ));
+            }
+        }
+        TaggingStyle::External => {
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                out.push_str(&format!(
+                    "    {kw} \"{}\" in data:\n        return {py_class}.from_dict(data[\"{}\"])  # type: ignore[arg-type]\n",
+                    variant.discriminator_value, variant.discriminator_value
+                ));
+            }
+        }
+    }
+    out.push_str(&format!(
+        "    raise ValueError(f\"Unknown discriminator value for {pascal_name}: {{data}}\")\n"
+    ));
+
+    // to_dict
+    out.push('\n');
+    out.push_str(&format!(
+        "def {snake_name}_to_dict(obj: {pascal_name}) -> dict[str, object]:\n"
+    ));
+    let last_idx = resolved_variants.len() - 1;
+    match &tu.tagging {
+        TaggingStyle::Internal => {
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                let ignore = if i == last_idx {
+                    "  # type: ignore[reportUnnecessaryIsInstance]"
+                } else {
+                    ""
+                };
+                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
+                out.push_str("        result = obj.to_dict()\n");
+                out.push_str(&format!(
+                    "        result[\"{tag_field}\"] = \"{}\"\n",
+                    variant.discriminator_value
+                ));
+                out.push_str("        return result\n");
+            }
+        }
+        TaggingStyle::Adjacent { content_field } => {
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                let ignore = if i == last_idx {
+                    "  # type: ignore[reportUnnecessaryIsInstance]"
+                } else {
+                    ""
+                };
+                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
+                out.push_str(&format!(
+                    "        return {{\"{tag_field}\": \"{}\", \"{content_field}\": obj.to_dict()}}\n",
+                    variant.discriminator_value
+                ));
+            }
+        }
+        TaggingStyle::External => {
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                let ignore = if i == last_idx {
+                    "  # type: ignore[reportUnnecessaryIsInstance]"
+                } else {
+                    ""
+                };
+                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
+                out.push_str(&format!(
+                    "        return {{\"{}\": obj.to_dict()}}\n",
+                    variant.discriminator_value
+                ));
+            }
+        }
+    }
+    out.push_str(&format!(
+        "    raise ValueError(f\"Unknown variant for {pascal_name}: {{type(obj)}}\")\n"
+    ));
+
+    out
 }
 
 // ---------------------------------------------------------------------------

--- a/src/generators/python/requests/emit_models.rs
+++ b/src/generators/python/requests/emit_models.rs
@@ -7,7 +7,7 @@
 use crate::codegen::traits::file_writer::FileInfo;
 use crate::ir::types::{
     IrEnum, IrEnumValueType, IrIntersection, IrObject, IrPrimitive, IrProperty, IrSchema,
-    IrSchemaKind, IrSpec, IrTaggedUnion, IrTypeExpr, IrUnion, TaggingStyle,
+    IrSchemaKind, IrSpec, IrTaggedUnion, IrTaggedVariant, IrTypeExpr, IrUnion, TaggingStyle,
 };
 use heck::{ToPascalCase, ToSnakeCase};
 use sigil_stitch::code_block::CodeBlock;
@@ -41,7 +41,7 @@ fn emit_model_body(schema: &IrSchema, ir: &IrSpec) -> Option<String> {
         IrSchemaKind::Alias(expr) => emit_alias(schema, expr),
         IrSchemaKind::Union(u) => emit_union(schema, u),
         IrSchemaKind::Intersection(i) => emit_intersection(schema, i, ir),
-        IrSchemaKind::TaggedUnion(tu) => emit_tagged_union(schema, tu),
+        IrSchemaKind::TaggedUnion(tu) => emit_tagged_union(schema, tu, ir),
     }?;
     file_spec.render(100).ok()
 }
@@ -441,8 +441,9 @@ fn emit_intersection_as_dataclass(
 // TaggedUnion -> type X = A | B | C
 // ---------------------------------------------------------------------------
 
-fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<FileSpec> {
+fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion, ir: &IrSpec) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
+    let snake_name = schema.name.to_snake_case();
 
     let members: Vec<TypeName> = tu
         .variants
@@ -489,7 +490,144 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<FileSpec> 
     }
     file = file.add_raw(&doc_block);
     file = file.add_code(type_alias);
+
+    if !tu.variants.is_empty() {
+        let helpers = build_tagged_union_helpers(&name, &snake_name, tu, ir);
+        file = file.add_raw(&helpers);
+    }
+
     file.build().ok()
+}
+
+fn build_tagged_union_helpers(
+    pascal_name: &str,
+    snake_name: &str,
+    tu: &IrTaggedUnion,
+    ir: &IrSpec,
+) -> String {
+    let mut out = String::new();
+    let tag_field = &tu.discriminator_field;
+
+    let resolved_variants: Vec<(&IrTaggedVariant, String)> = tu
+        .variants
+        .iter()
+        .filter_map(|v| {
+            if let IrTypeExpr::Named(ref_name) = &v.content_type
+                && is_object_schema(ref_name, ir)
+            {
+                return Some((v, ref_name.to_pascal_case()));
+            }
+            None
+        })
+        .collect();
+
+    if resolved_variants.is_empty() {
+        return out;
+    }
+
+    // from_dict
+    out.push('\n');
+    out.push_str(&format!(
+        "def {snake_name}_from_dict(data: dict[str, object]) -> {pascal_name}:\n"
+    ));
+    match &tu.tagging {
+        TaggingStyle::Internal => {
+            out.push_str(&format!("    _tag = data[\"{tag_field}\"]\n"));
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                out.push_str(&format!(
+                    "    {kw} _tag == \"{}\":\n        return {py_class}.from_dict(data)\n",
+                    variant.discriminator_value
+                ));
+            }
+        }
+        TaggingStyle::Adjacent { content_field } => {
+            out.push_str(&format!("    _tag = data[\"{tag_field}\"]\n"));
+            out.push_str(&format!(
+                "    _content = data[\"{content_field}\"]  # type: ignore[assignment]\n"
+            ));
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                out.push_str(&format!(
+                    "    {kw} _tag == \"{}\":\n        return {py_class}.from_dict(_content)  # type: ignore[arg-type]\n",
+                    variant.discriminator_value
+                ));
+            }
+        }
+        TaggingStyle::External => {
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                out.push_str(&format!(
+                    "    {kw} \"{}\" in data:\n        return {py_class}.from_dict(data[\"{}\"])  # type: ignore[arg-type]\n",
+                    variant.discriminator_value, variant.discriminator_value
+                ));
+            }
+        }
+    }
+    out.push_str(&format!(
+        "    raise ValueError(f\"Unknown discriminator value for {pascal_name}: {{data}}\")\n"
+    ));
+
+    // to_dict
+    out.push('\n');
+    out.push_str(&format!(
+        "def {snake_name}_to_dict(obj: {pascal_name}) -> dict[str, object]:\n"
+    ));
+    let last_idx = resolved_variants.len() - 1;
+    match &tu.tagging {
+        TaggingStyle::Internal => {
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                let ignore = if i == last_idx {
+                    "  # type: ignore[reportUnnecessaryIsInstance]"
+                } else {
+                    ""
+                };
+                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
+                out.push_str("        result = obj.to_dict()\n");
+                out.push_str(&format!(
+                    "        result[\"{tag_field}\"] = \"{}\"\n",
+                    variant.discriminator_value
+                ));
+                out.push_str("        return result\n");
+            }
+        }
+        TaggingStyle::Adjacent { content_field } => {
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                let ignore = if i == last_idx {
+                    "  # type: ignore[reportUnnecessaryIsInstance]"
+                } else {
+                    ""
+                };
+                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
+                out.push_str(&format!(
+                    "        return {{\"{tag_field}\": \"{}\", \"{content_field}\": obj.to_dict()}}\n",
+                    variant.discriminator_value
+                ));
+            }
+        }
+        TaggingStyle::External => {
+            for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
+                let kw = if i == 0 { "if" } else { "elif" };
+                let ignore = if i == last_idx {
+                    "  # type: ignore[reportUnnecessaryIsInstance]"
+                } else {
+                    ""
+                };
+                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
+                out.push_str(&format!(
+                    "        return {{\"{}\": obj.to_dict()}}\n",
+                    variant.discriminator_value
+                ));
+            }
+        }
+    }
+    out.push_str(&format!(
+        "    raise ValueError(f\"Unknown variant for {pascal_name}: {{type(obj)}}\")\n"
+    ));
+
+    out
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
@@ -16,3 +16,20 @@ from .variant_b import VariantB
 # Discriminator: ty / content: data (adjacent).
 
 type AdjacentlyTaggedEnum = VariantA | VariantB
+
+
+def adjacently_tagged_enum_from_dict(data: dict[str, object]) -> AdjacentlyTaggedEnum:
+    _tag = data["ty"]
+    _content = data["data"]  # type: ignore[assignment]
+    if _tag == "ADJACENTLY_TAGGED_ENUM_VARIANT_A":
+        return VariantA.from_dict(_content)  # type: ignore[arg-type]
+    elif _tag == "ADJACENTLY_TAGGED_ENUM_VARIANT_B":
+        return VariantB.from_dict(_content)  # type: ignore[arg-type]
+    raise ValueError(f"Unknown discriminator value for AdjacentlyTaggedEnum: {data}")
+
+def adjacently_tagged_enum_to_dict(obj: AdjacentlyTaggedEnum) -> dict[str, object]:
+    if isinstance(obj, VariantA):
+        return {"ty": "ADJACENTLY_TAGGED_ENUM_VARIANT_A", "data": obj.to_dict()}
+    elif isinstance(obj, VariantB):  # type: ignore[reportUnnecessaryIsInstance]
+        return {"ty": "ADJACENTLY_TAGGED_ENUM_VARIANT_B", "data": obj.to_dict()}
+    raise ValueError(f"Unknown variant for AdjacentlyTaggedEnum: {type(obj)}")

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
@@ -16,3 +16,18 @@ from .variant_b import VariantB
 # Discriminator: variant key (external).
 
 type ExternallyTaggedEnum = VariantA | VariantB
+
+
+def externally_tagged_enum_from_dict(data: dict[str, object]) -> ExternallyTaggedEnum:
+    if "EXTERNALLY_TAGGED_ENUM_VARIANT_A" in data:
+        return VariantA.from_dict(data["EXTERNALLY_TAGGED_ENUM_VARIANT_A"])  # type: ignore[arg-type]
+    elif "EXTERNALLY_TAGGED_ENUM_VARIANT_B" in data:
+        return VariantB.from_dict(data["EXTERNALLY_TAGGED_ENUM_VARIANT_B"])  # type: ignore[arg-type]
+    raise ValueError(f"Unknown discriminator value for ExternallyTaggedEnum: {data}")
+
+def externally_tagged_enum_to_dict(obj: ExternallyTaggedEnum) -> dict[str, object]:
+    if isinstance(obj, VariantA):
+        return {"EXTERNALLY_TAGGED_ENUM_VARIANT_A": obj.to_dict()}
+    elif isinstance(obj, VariantB):  # type: ignore[reportUnnecessaryIsInstance]
+        return {"EXTERNALLY_TAGGED_ENUM_VARIANT_B": obj.to_dict()}
+    raise ValueError(f"Unknown variant for ExternallyTaggedEnum: {type(obj)}")

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
@@ -16,3 +16,23 @@ from .variant_b import VariantB
 # Discriminator: ty (internal).
 
 type InternallyTaggedEnum = VariantA | VariantB
+
+
+def internally_tagged_enum_from_dict(data: dict[str, object]) -> InternallyTaggedEnum:
+    _tag = data["ty"]
+    if _tag == "INTERNALLY_TAGGED_ENUM_VARIANT_A":
+        return VariantA.from_dict(data)
+    elif _tag == "INTERNALLY_TAGGED_ENUM_VARIANT_B":
+        return VariantB.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for InternallyTaggedEnum: {data}")
+
+def internally_tagged_enum_to_dict(obj: InternallyTaggedEnum) -> dict[str, object]:
+    if isinstance(obj, VariantA):
+        result = obj.to_dict()
+        result["ty"] = "INTERNALLY_TAGGED_ENUM_VARIANT_A"
+        return result
+    elif isinstance(obj, VariantB):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["ty"] = "INTERNALLY_TAGGED_ENUM_VARIANT_B"
+        return result
+    raise ValueError(f"Unknown variant for InternallyTaggedEnum: {type(obj)}")

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
@@ -14,3 +14,29 @@ from .resource_unspecified import ResourceUnspecified
 # Discriminator: kind (internal).
 
 type Resource = ResourceUnspecified | ResourceQuick | ResourceCustom
+
+
+def resource_from_dict(data: dict[str, object]) -> Resource:
+    _tag = data["kind"]
+    if _tag == "RESOURCE_UNSPECIFIED":
+        return ResourceUnspecified.from_dict(data)
+    elif _tag == "RESOURCE_QUICK":
+        return ResourceQuick.from_dict(data)
+    elif _tag == "RESOURCE_CUSTOM":
+        return ResourceCustom.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for Resource: {data}")
+
+def resource_to_dict(obj: Resource) -> dict[str, object]:
+    if isinstance(obj, ResourceUnspecified):
+        result = obj.to_dict()
+        result["kind"] = "RESOURCE_UNSPECIFIED"
+        return result
+    elif isinstance(obj, ResourceQuick):
+        result = obj.to_dict()
+        result["kind"] = "RESOURCE_QUICK"
+        return result
+    elif isinstance(obj, ResourceCustom):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["kind"] = "RESOURCE_CUSTOM"
+        return result
+    raise ValueError(f"Unknown variant for Resource: {type(obj)}")

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
@@ -14,3 +14,23 @@ from .container_kind_managed import ContainerKindManaged
 # Discriminator: kind (internal).
 
 type ContainerKind = ContainerKindManaged | ContainerKindCustom
+
+
+def container_kind_from_dict(data: dict[str, object]) -> ContainerKind:
+    _tag = data["kind"]
+    if _tag == "CONTAINER_KIND_MANAGED":
+        return ContainerKindManaged.from_dict(data)
+    elif _tag == "CONTAINER_KIND_CUSTOM":
+        return ContainerKindCustom.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for ContainerKind: {data}")
+
+def container_kind_to_dict(obj: ContainerKind) -> dict[str, object]:
+    if isinstance(obj, ContainerKindManaged):
+        result = obj.to_dict()
+        result["kind"] = "CONTAINER_KIND_MANAGED"
+        return result
+    elif isinstance(obj, ContainerKindCustom):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["kind"] = "CONTAINER_KIND_CUSTOM"
+        return result
+    raise ValueError(f"Unknown variant for ContainerKind: {type(obj)}")

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
@@ -14,3 +14,23 @@ from .volume_kind_remote import VolumeKindRemote
 # Discriminator: kind (internal).
 
 type VolumeKind = VolumeKindLocal | VolumeKindRemote
+
+
+def volume_kind_from_dict(data: dict[str, object]) -> VolumeKind:
+    _tag = data["kind"]
+    if _tag == "VOLUME_KIND_LOCAL":
+        return VolumeKindLocal.from_dict(data)
+    elif _tag == "VOLUME_KIND_REMOTE":
+        return VolumeKindRemote.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for VolumeKind: {data}")
+
+def volume_kind_to_dict(obj: VolumeKind) -> dict[str, object]:
+    if isinstance(obj, VolumeKindLocal):
+        result = obj.to_dict()
+        result["kind"] = "VOLUME_KIND_LOCAL"
+        return result
+    elif isinstance(obj, VolumeKindRemote):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["kind"] = "VOLUME_KIND_REMOTE"
+        return result
+    raise ValueError(f"Unknown variant for VolumeKind: {type(obj)}")

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
@@ -12,3 +12,23 @@ from .container_image_managed import ContainerImageManaged
 # Discriminator: kind (internal).
 
 type ContainerImage = ContainerImageManaged | ContainerImageCustom
+
+
+def container_image_from_dict(data: dict[str, object]) -> ContainerImage:
+    _tag = data["kind"]
+    if _tag == "CONTAINER_IMAGE_MANAGED":
+        return ContainerImageManaged.from_dict(data)
+    elif _tag == "CONTAINER_IMAGE_CUSTOM":
+        return ContainerImageCustom.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for ContainerImage: {data}")
+
+def container_image_to_dict(obj: ContainerImage) -> dict[str, object]:
+    if isinstance(obj, ContainerImageManaged):
+        result = obj.to_dict()
+        result["kind"] = "CONTAINER_IMAGE_MANAGED"
+        return result
+    elif isinstance(obj, ContainerImageCustom):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["kind"] = "CONTAINER_IMAGE_CUSTOM"
+        return result
+    raise ValueError(f"Unknown variant for ContainerImage: {type(obj)}")

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
@@ -16,3 +16,20 @@ from .variant_b import VariantB
 # Discriminator: ty / content: data (adjacent).
 
 type AdjacentlyTaggedEnum = VariantA | VariantB
+
+
+def adjacently_tagged_enum_from_dict(data: dict[str, object]) -> AdjacentlyTaggedEnum:
+    _tag = data["ty"]
+    _content = data["data"]  # type: ignore[assignment]
+    if _tag == "ADJACENTLY_TAGGED_ENUM_VARIANT_A":
+        return VariantA.from_dict(_content)  # type: ignore[arg-type]
+    elif _tag == "ADJACENTLY_TAGGED_ENUM_VARIANT_B":
+        return VariantB.from_dict(_content)  # type: ignore[arg-type]
+    raise ValueError(f"Unknown discriminator value for AdjacentlyTaggedEnum: {data}")
+
+def adjacently_tagged_enum_to_dict(obj: AdjacentlyTaggedEnum) -> dict[str, object]:
+    if isinstance(obj, VariantA):
+        return {"ty": "ADJACENTLY_TAGGED_ENUM_VARIANT_A", "data": obj.to_dict()}
+    elif isinstance(obj, VariantB):  # type: ignore[reportUnnecessaryIsInstance]
+        return {"ty": "ADJACENTLY_TAGGED_ENUM_VARIANT_B", "data": obj.to_dict()}
+    raise ValueError(f"Unknown variant for AdjacentlyTaggedEnum: {type(obj)}")

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
@@ -16,3 +16,18 @@ from .variant_b import VariantB
 # Discriminator: variant key (external).
 
 type ExternallyTaggedEnum = VariantA | VariantB
+
+
+def externally_tagged_enum_from_dict(data: dict[str, object]) -> ExternallyTaggedEnum:
+    if "EXTERNALLY_TAGGED_ENUM_VARIANT_A" in data:
+        return VariantA.from_dict(data["EXTERNALLY_TAGGED_ENUM_VARIANT_A"])  # type: ignore[arg-type]
+    elif "EXTERNALLY_TAGGED_ENUM_VARIANT_B" in data:
+        return VariantB.from_dict(data["EXTERNALLY_TAGGED_ENUM_VARIANT_B"])  # type: ignore[arg-type]
+    raise ValueError(f"Unknown discriminator value for ExternallyTaggedEnum: {data}")
+
+def externally_tagged_enum_to_dict(obj: ExternallyTaggedEnum) -> dict[str, object]:
+    if isinstance(obj, VariantA):
+        return {"EXTERNALLY_TAGGED_ENUM_VARIANT_A": obj.to_dict()}
+    elif isinstance(obj, VariantB):  # type: ignore[reportUnnecessaryIsInstance]
+        return {"EXTERNALLY_TAGGED_ENUM_VARIANT_B": obj.to_dict()}
+    raise ValueError(f"Unknown variant for ExternallyTaggedEnum: {type(obj)}")

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
@@ -16,3 +16,23 @@ from .variant_b import VariantB
 # Discriminator: ty (internal).
 
 type InternallyTaggedEnum = VariantA | VariantB
+
+
+def internally_tagged_enum_from_dict(data: dict[str, object]) -> InternallyTaggedEnum:
+    _tag = data["ty"]
+    if _tag == "INTERNALLY_TAGGED_ENUM_VARIANT_A":
+        return VariantA.from_dict(data)
+    elif _tag == "INTERNALLY_TAGGED_ENUM_VARIANT_B":
+        return VariantB.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for InternallyTaggedEnum: {data}")
+
+def internally_tagged_enum_to_dict(obj: InternallyTaggedEnum) -> dict[str, object]:
+    if isinstance(obj, VariantA):
+        result = obj.to_dict()
+        result["ty"] = "INTERNALLY_TAGGED_ENUM_VARIANT_A"
+        return result
+    elif isinstance(obj, VariantB):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["ty"] = "INTERNALLY_TAGGED_ENUM_VARIANT_B"
+        return result
+    raise ValueError(f"Unknown variant for InternallyTaggedEnum: {type(obj)}")

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
@@ -14,3 +14,29 @@ from .resource_unspecified import ResourceUnspecified
 # Discriminator: kind (internal).
 
 type Resource = ResourceUnspecified | ResourceQuick | ResourceCustom
+
+
+def resource_from_dict(data: dict[str, object]) -> Resource:
+    _tag = data["kind"]
+    if _tag == "RESOURCE_UNSPECIFIED":
+        return ResourceUnspecified.from_dict(data)
+    elif _tag == "RESOURCE_QUICK":
+        return ResourceQuick.from_dict(data)
+    elif _tag == "RESOURCE_CUSTOM":
+        return ResourceCustom.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for Resource: {data}")
+
+def resource_to_dict(obj: Resource) -> dict[str, object]:
+    if isinstance(obj, ResourceUnspecified):
+        result = obj.to_dict()
+        result["kind"] = "RESOURCE_UNSPECIFIED"
+        return result
+    elif isinstance(obj, ResourceQuick):
+        result = obj.to_dict()
+        result["kind"] = "RESOURCE_QUICK"
+        return result
+    elif isinstance(obj, ResourceCustom):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["kind"] = "RESOURCE_CUSTOM"
+        return result
+    raise ValueError(f"Unknown variant for Resource: {type(obj)}")

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
@@ -14,3 +14,23 @@ from .container_kind_managed import ContainerKindManaged
 # Discriminator: kind (internal).
 
 type ContainerKind = ContainerKindManaged | ContainerKindCustom
+
+
+def container_kind_from_dict(data: dict[str, object]) -> ContainerKind:
+    _tag = data["kind"]
+    if _tag == "CONTAINER_KIND_MANAGED":
+        return ContainerKindManaged.from_dict(data)
+    elif _tag == "CONTAINER_KIND_CUSTOM":
+        return ContainerKindCustom.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for ContainerKind: {data}")
+
+def container_kind_to_dict(obj: ContainerKind) -> dict[str, object]:
+    if isinstance(obj, ContainerKindManaged):
+        result = obj.to_dict()
+        result["kind"] = "CONTAINER_KIND_MANAGED"
+        return result
+    elif isinstance(obj, ContainerKindCustom):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["kind"] = "CONTAINER_KIND_CUSTOM"
+        return result
+    raise ValueError(f"Unknown variant for ContainerKind: {type(obj)}")

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
@@ -14,3 +14,23 @@ from .volume_kind_remote import VolumeKindRemote
 # Discriminator: kind (internal).
 
 type VolumeKind = VolumeKindLocal | VolumeKindRemote
+
+
+def volume_kind_from_dict(data: dict[str, object]) -> VolumeKind:
+    _tag = data["kind"]
+    if _tag == "VOLUME_KIND_LOCAL":
+        return VolumeKindLocal.from_dict(data)
+    elif _tag == "VOLUME_KIND_REMOTE":
+        return VolumeKindRemote.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for VolumeKind: {data}")
+
+def volume_kind_to_dict(obj: VolumeKind) -> dict[str, object]:
+    if isinstance(obj, VolumeKindLocal):
+        result = obj.to_dict()
+        result["kind"] = "VOLUME_KIND_LOCAL"
+        return result
+    elif isinstance(obj, VolumeKindRemote):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["kind"] = "VOLUME_KIND_REMOTE"
+        return result
+    raise ValueError(f"Unknown variant for VolumeKind: {type(obj)}")

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
@@ -12,3 +12,23 @@ from .container_image_managed import ContainerImageManaged
 # Discriminator: kind (internal).
 
 type ContainerImage = ContainerImageManaged | ContainerImageCustom
+
+
+def container_image_from_dict(data: dict[str, object]) -> ContainerImage:
+    _tag = data["kind"]
+    if _tag == "CONTAINER_IMAGE_MANAGED":
+        return ContainerImageManaged.from_dict(data)
+    elif _tag == "CONTAINER_IMAGE_CUSTOM":
+        return ContainerImageCustom.from_dict(data)
+    raise ValueError(f"Unknown discriminator value for ContainerImage: {data}")
+
+def container_image_to_dict(obj: ContainerImage) -> dict[str, object]:
+    if isinstance(obj, ContainerImageManaged):
+        result = obj.to_dict()
+        result["kind"] = "CONTAINER_IMAGE_MANAGED"
+        return result
+    elif isinstance(obj, ContainerImageCustom):  # type: ignore[reportUnnecessaryIsInstance]
+        result = obj.to_dict()
+        result["kind"] = "CONTAINER_IMAGE_CUSTOM"
+        return result
+    raise ValueError(f"Unknown variant for ContainerImage: {type(obj)}")

--- a/tests/python_tagged_union_helpers.rs
+++ b/tests/python_tagged_union_helpers.rs
@@ -1,0 +1,266 @@
+//! Tests that Python tagged union types generate discriminator-aware
+//! from_dict/to_dict helper functions for all tagging styles.
+
+use openapi_nexus::generators::python::httpx::PythonHttpxCodeGenerator;
+use openapi_nexus::test_utils::{generate_files, read_fixture};
+
+fn generate_enum_repr(config: toml::value::Table) -> std::collections::HashMap<String, String> {
+    let generator = PythonHttpxCodeGenerator::new(config);
+    let spec = read_fixture("valid/enum-repr/enum-repr.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+fn generate_discriminated_union_internally_tagged(
+    config: toml::value::Table,
+) -> std::collections::HashMap<String, String> {
+    let generator = PythonHttpxCodeGenerator::new(config);
+    let spec = read_fixture("valid/type-aliases/discriminated-union-internally-tagged.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+fn generate_discriminated_union_with_refs(
+    config: toml::value::Table,
+) -> std::collections::HashMap<String, String> {
+    let generator = PythonHttpxCodeGenerator::new(config);
+    let spec = read_fixture("valid/type-aliases/discriminated-union-with-refs.yaml");
+    generate_files(&generator, &spec).expect("generation should succeed")
+}
+
+// ---------------------------------------------------------------------------
+// Internally tagged: from_dict dispatches on tag, to_dict injects tag
+// ---------------------------------------------------------------------------
+
+#[test]
+fn internally_tagged_has_from_dict_helper() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("enum_representation_api/models/internally_tagged_enum.py")
+        .expect("internally_tagged_enum.py should exist");
+
+    assert!(
+        content.contains("def internally_tagged_enum_from_dict(data: dict[str, object])"),
+        "should have from_dict helper, got:\n{content}"
+    );
+    assert!(
+        content.contains("_tag = data[\"ty\"]"),
+        "from_dict should read the discriminator field, got:\n{content}"
+    );
+    assert!(
+        content.contains("return VariantA.from_dict(data)"),
+        "from_dict should dispatch to VariantA.from_dict, got:\n{content}"
+    );
+}
+
+#[test]
+fn internally_tagged_has_to_dict_helper() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("enum_representation_api/models/internally_tagged_enum.py")
+        .expect("internally_tagged_enum.py should exist");
+
+    assert!(
+        content.contains("def internally_tagged_enum_to_dict(obj: InternallyTaggedEnum)"),
+        "should have to_dict helper, got:\n{content}"
+    );
+    assert!(
+        content.contains("result[\"ty\"] = \"INTERNALLY_TAGGED_ENUM_VARIANT_A\""),
+        "to_dict should inject discriminator value, got:\n{content}"
+    );
+    assert!(
+        content.contains("result = obj.to_dict()"),
+        "to_dict should call obj.to_dict() first, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adjacently tagged: from_dict reads content field, to_dict wraps in envelope
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adjacently_tagged_from_dict_reads_content_field() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("enum_representation_api/models/adjacently_tagged_enum.py")
+        .expect("adjacently_tagged_enum.py should exist");
+
+    assert!(
+        content.contains("def adjacently_tagged_enum_from_dict(data: dict[str, object])"),
+        "should have from_dict helper, got:\n{content}"
+    );
+    assert!(
+        content.contains("_tag = data[\"ty\"]"),
+        "from_dict should read the tag field, got:\n{content}"
+    );
+    assert!(
+        content.contains("_content = data[\"data\"]"),
+        "from_dict should read the content field, got:\n{content}"
+    );
+    assert!(
+        content.contains("return VariantA.from_dict(_content)"),
+        "from_dict should pass content to variant's from_dict, got:\n{content}"
+    );
+}
+
+#[test]
+fn adjacently_tagged_to_dict_produces_envelope() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("enum_representation_api/models/adjacently_tagged_enum.py")
+        .expect("adjacently_tagged_enum.py should exist");
+
+    assert!(
+        content.contains("def adjacently_tagged_enum_to_dict(obj: AdjacentlyTaggedEnum)"),
+        "should have to_dict helper, got:\n{content}"
+    );
+    assert!(
+        content.contains("{\"ty\": \"ADJACENTLY_TAGGED_ENUM_VARIANT_A\", \"data\": obj.to_dict()}"),
+        "to_dict should produce tag+content envelope, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Externally tagged: from_dict checks key presence, to_dict wraps in key
+// ---------------------------------------------------------------------------
+
+#[test]
+fn externally_tagged_from_dict_checks_key() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("enum_representation_api/models/externally_tagged_enum.py")
+        .expect("externally_tagged_enum.py should exist");
+
+    assert!(
+        content.contains("def externally_tagged_enum_from_dict(data: dict[str, object])"),
+        "should have from_dict helper, got:\n{content}"
+    );
+    assert!(
+        content.contains("\"EXTERNALLY_TAGGED_ENUM_VARIANT_A\" in data"),
+        "from_dict should check key presence, got:\n{content}"
+    );
+    assert!(
+        content.contains("VariantA.from_dict(data[\"EXTERNALLY_TAGGED_ENUM_VARIANT_A\"])"),
+        "from_dict should pass inner value to variant's from_dict, got:\n{content}"
+    );
+}
+
+#[test]
+fn externally_tagged_to_dict_wraps_in_key() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("enum_representation_api/models/externally_tagged_enum.py")
+        .expect("externally_tagged_enum.py should exist");
+
+    assert!(
+        content.contains("def externally_tagged_enum_to_dict(obj: ExternallyTaggedEnum)"),
+        "should have to_dict helper, got:\n{content}"
+    );
+    assert!(
+        content.contains("{\"EXTERNALLY_TAGGED_ENUM_VARIANT_A\": obj.to_dict()}"),
+        "to_dict should wrap in variant key, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union fixture: internally tagged with serde rename on fields
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discriminated_union_resource_has_helpers() {
+    let files = generate_discriminated_union_internally_tagged(toml::value::Table::new());
+    let content = files
+        .get("discriminated_union_internally_tagged_test/models/resource.py")
+        .expect("resource.py should exist");
+
+    assert!(
+        content.contains("def resource_from_dict(data: dict[str, object]) -> Resource:"),
+        "should have from_dict helper, got:\n{content}"
+    );
+    assert!(
+        content.contains("_tag = data[\"kind\"]"),
+        "from_dict should read 'kind' discriminator, got:\n{content}"
+    );
+    assert!(
+        content.contains("_tag == \"RESOURCE_QUICK\""),
+        "from_dict should check RESOURCE_QUICK, got:\n{content}"
+    );
+    assert!(
+        content.contains("def resource_to_dict(obj: Resource) -> dict[str, object]:"),
+        "should have to_dict helper, got:\n{content}"
+    );
+    assert!(
+        content.contains("result[\"kind\"] = \"RESOURCE_QUICK\""),
+        "to_dict should inject kind=RESOURCE_QUICK, got:\n{content}"
+    );
+}
+
+#[test]
+fn discriminated_union_with_refs_has_helpers() {
+    let files = generate_discriminated_union_with_refs(toml::value::Table::new());
+    let content = files
+        .get("discriminated_union_with_references_test/models/container_image.py")
+        .expect("container_image.py should exist");
+
+    assert!(
+        content.contains("def container_image_from_dict("),
+        "should have from_dict helper, got:\n{content}"
+    );
+    assert!(
+        content.contains("def container_image_to_dict("),
+        "should have to_dict helper, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn from_dict_raises_on_unknown_discriminator() {
+    let files = generate_discriminated_union_internally_tagged(toml::value::Table::new());
+    let content = files
+        .get("discriminated_union_internally_tagged_test/models/resource.py")
+        .expect("resource.py should exist");
+
+    assert!(
+        content.contains("raise ValueError("),
+        "from_dict should raise ValueError on unknown discriminator, got:\n{content}"
+    );
+}
+
+#[test]
+fn to_dict_raises_on_unknown_variant() {
+    let files = generate_discriminated_union_internally_tagged(toml::value::Table::new());
+    let content = files
+        .get("discriminated_union_internally_tagged_test/models/resource.py")
+        .expect("resource.py should exist");
+
+    assert!(
+        content.contains("raise ValueError(f\"Unknown variant for Resource:"),
+        "to_dict should raise ValueError on unknown variant type, got:\n{content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Variant dataclasses remain unchanged (no discriminator field injected)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn variant_dataclass_unchanged_no_discriminator_field() {
+    let files = generate_enum_repr(toml::value::Table::new());
+    let content = files
+        .get("enum_representation_api/models/variant_a.py")
+        .expect("variant_a.py should exist");
+
+    assert!(
+        !content.contains("ty:") && !content.contains("\"ty\""),
+        "variant dataclass should NOT have discriminator field 'ty', got:\n{content}"
+    );
+    assert!(
+        content.contains("field1: str"),
+        "variant should still have its own fields, got:\n{content}"
+    );
+    assert!(
+        content.contains("field2: int"),
+        "variant should still have its own fields, got:\n{content}"
+    );
+}


### PR DESCRIPTION
## Summary

- Tagged union files now emit `{name}_from_dict()` and `{name}_to_dict()` helper functions that handle discriminator dispatch and injection
- Fixes a data-loss bug where round-tripping through the generated SDK would silently drop the discriminator field for internally-tagged unions
- All three tagging styles supported: internal (tag alongside fields), adjacent (tag + content envelope), external (wrapping key)
- Variant dataclasses remain unchanged since they can be shared across multiple union contexts with different tags

## Changes

- `src/generators/python/httpx/emit_models.rs` — add `build_tagged_union_helpers` function, thread `ir` into `emit_tagged_union`
- `src/generators/python/requests/emit_models.rs` — same changes (identical file)
- 14 golden files updated across both Python backends
- New test file `tests/python_tagged_union_helpers.rs` with 11 integration tests

## Test plan

- [x] `cargo test --test python_tagged_union_helpers` — 11 tests pass
- [x] `cargo test --test golden_tests_python_httpx` — all golden comparisons pass
- [x] `cargo test --test golden_tests_python_requests` — all golden comparisons pass
- [x] `cargo fmt && cargo clippy` — clean