### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1]
+
+### Added
+
+- Python: discriminator-aware `_from_dict()` / `_to_dict()` helpers for tagged unions (internal, adjacent, external)
+- Rust: struct variants for internally/adjacently tagged enums (fields inlined into enum)
+
+### Changed
+
+- Rust: upgrade sigil-stitch 0.4.3 → 0.4.4 (fixes Display impl spacing)
+- Rust: generated code now includes `// @generated` marker and `#![allow(clippy::all)]`
+- Rust: dead standalone struct files no longer emitted for exclusively-inlined variants
+- Rust: function signatures use `&[T]` instead of `&Vec<T>`
+- Rust: query params URL-encoded via `url::form_urlencoded` (reqwest/aioduct)
+
+### Fixed
+
+- Rust: punctuation spacing in generated `Display` impls (`std:: fmt::` → `std::fmt::`)
+- Rust: flaky golden tests from temp dir name collisions under parallelism
+- Python: pyright strict-mode errors in generated tagged union helpers
+
 ## [0.1.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fixture-generator-additional-properties"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-enum-repr"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-petstore"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1003,7 +1003,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openapi-nexus"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.90"
-description = "OpenAPI 3.1 to code generator"
+description = "OpenAPI 3.x multi-language code generator"
 authors = ["Adam Basfop Cavendish <GetbetterABC@yeah.net>"]
 repository = "https://github.com/adamcavendish/openapi-nexus"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump workspace version 0.1.0 → 0.1.1
- Update package description to "OpenAPI 3.x multi-language code generator"
- Add CHANGELOG section for 0.1.1 covering all changes since 0.1.0
