### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2]
+
+### Added
+
+- Rust: `workspace_deps` config with 3 modes (`explicit`, `workspace_version`, `full`) for generated Cargo.toml dependencies
+- Rust: `per_type` extra derives for targeting specific schemas by name
+- Rust: `package_name` accepted as alias for `crate_name` in generator config
+
+### Fixed
+
+- Rust: bogus `string.rs` no longer generated for schemas named "string" (was producing `pub type String = String;` that shadows std)
+- Rust: multi-line operation summaries now correctly prefix every line with `///` (YAML `|-` block scalars)
+- Rust: `#[serde(untagged)]` enums excluded from blanket `extra_derives.unions` (incompatible with utoipa::ToSchema)
+
 ## [0.1.1]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fixture-generator-additional-properties"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-enum-repr"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-petstore"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1003,7 +1003,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openapi-nexus"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.90"
 description = "OpenAPI 3.x multi-language code generator"


### PR DESCRIPTION
## Summary

- Bump workspace version 0.1.1 → 0.1.2
- Add CHANGELOG entry for 0.1.2 covering PR #85 fixes:
  - `workspace_deps` config (3 modes)
  - `per_type` extra derives
  - `package_name` alias for `crate_name`
  - Suppress bogus `string.rs` primitive alias
  - Fix multi-line summary doc comments
  - Exclude untagged unions from `extra_derives.unions`

## Test plan

- [x] `cargo check` passes with new version