### PR TITLE
fix(rust): resolve primitive alias refs, remove aioduct tokio dep, warn missing derive deps

### DIFF
--- a/src/generators/rust/aioduct/codegen.rs
+++ b/src/generators/rust/aioduct/codegen.rs
@@ -132,7 +132,6 @@ description = "{description}"
             serde.workspace = true\n\
             serde_json.workspace = true\n\
             serde_repr.workspace = true\n\
-            tokio.workspace = true\n\
             url.workspace = true\n"
             .to_string(),
         WorkspaceDepsMode::WorkspaceVersion => "\n[dependencies]\n\
@@ -140,7 +139,6 @@ description = "{description}"
             serde = { workspace = true, features = [\"derive\"] }\n\
             serde_json.workspace = true\n\
             serde_repr.workspace = true\n\
-            tokio = { workspace = true, features = [\"full\"] }\n\
             url.workspace = true\n"
             .to_string(),
         WorkspaceDepsMode::Explicit => "\n[dependencies]\n\
@@ -148,7 +146,6 @@ description = "{description}"
             serde = { version = \"1\", features = [\"derive\"] }\n\
             serde_json = \"1\"\n\
             serde_repr = \"0.1\"\n\
-            tokio = { version = \"1\", features = [\"full\"] }\n\
             url = \"2\"\n"
             .to_string(),
     };
@@ -156,6 +153,7 @@ description = "{description}"
     let mut content = format!("{pkg_section}{deps_section}");
 
     if let Some(extra) = &config.extra_derives {
+        extra.warn_missing_dependencies();
         for (name, spec) in extra.all_dependencies() {
             match deps_mode {
                 WorkspaceDepsMode::Full | WorkspaceDepsMode::WorkspaceVersion => {

--- a/src/generators/rust/common/config.rs
+++ b/src/generators/rust/common/config.rs
@@ -55,6 +55,46 @@ impl ExtraDerivesConfig {
         }
         deps
     }
+
+    /// Warn about derives that reference external crates without a matching
+    /// entry in `dependencies`. Call this during codegen so users get feedback.
+    pub fn warn_missing_dependencies(&self) {
+        let deps = self.all_dependencies();
+        for cfg in [
+            &self.structs,
+            &self.enums,
+            &self.unions,
+            &self.response_structs,
+        ]
+        .into_iter()
+        .flatten()
+        {
+            Self::check_derives(&cfg.derives, &deps);
+        }
+        if let Some(per_type) = &self.per_type {
+            for cfg in per_type.values() {
+                Self::check_derives(&cfg.derives, &deps);
+            }
+        }
+    }
+
+    fn check_derives(derives: &[String], deps: &BTreeMap<String, String>) {
+        for d in derives {
+            if let Some(crate_name) = d.split("::").next()
+                && crate_name != d
+            {
+                let normalized = crate_name.replace('-', "_");
+                if !deps.contains_key(&normalized) {
+                    tracing::warn!(
+                        "Derive `{d}` references crate `{normalized}` but no matching entry \
+                         exists in `extra_derives.*.dependencies`. Add \
+                         `[extra_derives.<kind>.dependencies]\n{normalized} = '{{ version = \"...\" }}'` \
+                         to include it in the generated Cargo.toml."
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// How dependencies are rendered in the generated Cargo.toml.
@@ -303,5 +343,42 @@ mod tests {
         assert_eq!(deps.len(), 2);
         assert!(deps.contains_key("utoipa"));
         assert!(deps.contains_key("custom"));
+    }
+
+    #[test]
+    fn all_dependencies_does_not_auto_infer() {
+        let extra = ExtraDerivesConfig {
+            structs: Some(ExtraDeriveConfig {
+                derives: vec!["utoipa::ToSchema".into(), "Clone".into()],
+                dependencies: BTreeMap::new(),
+            }),
+            enums: Some(ExtraDeriveConfig {
+                derives: vec!["strum::Display".into()],
+                dependencies: BTreeMap::new(),
+            }),
+            unions: None,
+            response_structs: None,
+            per_type: None,
+        };
+        let deps = extra.all_dependencies();
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn warn_missing_dependencies_does_not_panic() {
+        let extra = ExtraDerivesConfig {
+            structs: Some(ExtraDeriveConfig {
+                derives: vec!["utoipa::ToSchema".into()],
+                dependencies: BTreeMap::from([("utoipa".into(), r#"{ version = "5" }"#.into())]),
+            }),
+            enums: Some(ExtraDeriveConfig {
+                derives: vec!["strum::Display".into()],
+                dependencies: BTreeMap::new(),
+            }),
+            unions: None,
+            response_structs: None,
+            per_type: None,
+        };
+        extra.warn_missing_dependencies();
     }
 }

--- a/src/generators/rust/common/emit_api.rs
+++ b/src/generators/rust/common/emit_api.rs
@@ -62,7 +62,7 @@ pub fn generate_api_files(
         let stem = tag.to_snake_case();
         let filename = format!("{stem}.rs");
         mod_entries.push(stem);
-        let body = emit_api_file(tag, ops, config, response_extra_derives, body_emitter);
+        let body = emit_api_file(tag, ops, ir, config, response_extra_derives, body_emitter);
         let content = format!("{header}{body}");
         files.push(FileInfo::api(filename, content));
     }
@@ -103,12 +103,13 @@ fn group_by_tag(operations: &[IrOperation]) -> BTreeMap<String, Vec<&IrOperation
 fn emit_api_file(
     tag: &str,
     ops: &[&IrOperation],
+    ir: &IrSpec,
     config: &RustBackendConfig,
     response_extra_derives: Option<&ExtraDeriveConfig>,
     body_emitter: &dyn Fn(&OpPlan<'_>) -> CodeBlock,
 ) -> String {
     let struct_name = format!("{}Api", tag.to_pascal_case());
-    let plans: Vec<OpPlan> = ops.iter().map(|op| plan_operation(op)).collect();
+    let plans: Vec<OpPlan> = ops.iter().map(|op| plan_operation(op, ir)).collect();
 
     let stem = tag.to_snake_case();
     let mut fsb = FileSpec::builder(&format!("{stem}.rs"));
@@ -222,7 +223,7 @@ pub struct TypedResponse {
     pub rust_type: String,
 }
 
-pub fn plan_operation<'a>(op: &'a IrOperation) -> OpPlan<'a> {
+pub fn plan_operation<'a>(op: &'a IrOperation, ir: &'a IrSpec) -> OpPlan<'a> {
     let op_id = sanitize_operation_id(&op.operation_id, &op.method, &op.path);
     let method_name = op_id.to_snake_case();
     let response_type = format!("{}Response", op_id.to_pascal_case());
@@ -235,7 +236,7 @@ pub fn plan_operation<'a>(op: &'a IrOperation) -> OpPlan<'a> {
     let mut header_params = Vec::new();
     for p in &op.parameters {
         let var_name = unique_name(&p.name.to_snake_case(), &mut used_names);
-        let (rust_type, is_optional) = param_rust_type(p);
+        let (rust_type, is_optional) = param_rust_type(p, ir);
         let binding = ParamBinding {
             param: p,
             var_name,
@@ -253,9 +254,13 @@ pub fn plan_operation<'a>(op: &'a IrOperation) -> OpPlan<'a> {
     let body = op
         .request_body
         .as_ref()
-        .and_then(|b| plan_body(b, &mut used_names));
+        .and_then(|b| plan_body(b, &mut used_names, ir));
 
-    let typed_responses = op.responses.iter().filter_map(plan_response).collect();
+    let typed_responses = op
+        .responses
+        .iter()
+        .filter_map(|r| plan_response(r, ir))
+        .collect();
 
     OpPlan {
         op,
@@ -269,9 +274,13 @@ pub fn plan_operation<'a>(op: &'a IrOperation) -> OpPlan<'a> {
     }
 }
 
-pub fn plan_body(b: &IrRequestBody, used_names: &mut HashSet<String>) -> Option<BodyBinding> {
+pub fn plan_body(
+    b: &IrRequestBody,
+    used_names: &mut HashSet<String>,
+    ir: &IrSpec,
+) -> Option<BodyBinding> {
     let t = pick_body_type(b)?;
-    let rust_type = rust_type_str_qualified(&t);
+    let rust_type = rust_type_str_qualified(&t, ir);
     let var_name = unique_name("body", used_names);
     Some(BodyBinding {
         var_name,
@@ -279,9 +288,9 @@ pub fn plan_body(b: &IrRequestBody, used_names: &mut HashSet<String>) -> Option<
     })
 }
 
-pub fn plan_response(r: &IrResponse) -> Option<TypedResponse> {
+pub fn plan_response(r: &IrResponse, ir: &IrSpec) -> Option<TypedResponse> {
     let t = pick_response_type(r)?;
-    let rust_type = rust_type_str_qualified(&t);
+    let rust_type = rust_type_str_qualified(&t, ir);
     Some(TypedResponse {
         status: r.status.clone(),
         field_name: response_field_name(&r.status),
@@ -289,8 +298,8 @@ pub fn plan_response(r: &IrResponse) -> Option<TypedResponse> {
     })
 }
 
-pub fn param_rust_type(p: &IrParameter) -> (String, bool) {
-    let base = rust_type_str_qualified(&p.type_expr);
+pub fn param_rust_type(p: &IrParameter, ir: &IrSpec) -> (String, bool) {
+    let base = rust_type_str_qualified(&p.type_expr, ir);
     if p.required {
         (base, false)
     } else {

--- a/src/generators/rust/common/emit_models.rs
+++ b/src/generators/rust/common/emit_models.rs
@@ -706,15 +706,24 @@ pub fn rust_type_str(expr: &IrTypeExpr) -> String {
 }
 
 /// Map an IR type to a Rust type string, qualified for use from API modules.
-pub fn rust_type_str_qualified(expr: &IrTypeExpr) -> String {
+/// Named references to suppressed primitive aliases are resolved to the primitive type.
+pub fn rust_type_str_qualified(expr: &IrTypeExpr, ir: &IrSpec) -> String {
     match expr {
-        IrTypeExpr::Named(name) => format!("crate::models::{}", name.to_pascal_case()),
-        IrTypeExpr::Array(inner) => format!("Vec<{}>", rust_type_str_qualified(inner)),
+        IrTypeExpr::Named(name) => {
+            if let Some(schema) = ir.schemas.get(name)
+                && let IrSchemaKind::Alias(inner) = &schema.kind
+                && name.to_pascal_case() == rust_type_str_model(inner)
+            {
+                return rust_type_str(inner);
+            }
+            format!("crate::models::{}", name.to_pascal_case())
+        }
+        IrTypeExpr::Array(inner) => format!("Vec<{}>", rust_type_str_qualified(inner, ir)),
         IrTypeExpr::Map(inner) => format!(
             "std::collections::HashMap<String, {}>",
-            rust_type_str_qualified(inner)
+            rust_type_str_qualified(inner, ir)
         ),
-        IrTypeExpr::Nullable(inner) => format!("Option<{}>", rust_type_str_qualified(inner)),
+        IrTypeExpr::Nullable(inner) => format!("Option<{}>", rust_type_str_qualified(inner, ir)),
         other => rust_type_str(other),
     }
 }

--- a/src/generators/rust/reqwest/codegen.rs
+++ b/src/generators/rust/reqwest/codegen.rs
@@ -167,6 +167,7 @@ description = "{description}"
     let mut content = format!("{pkg_section}{deps_section}");
 
     if let Some(extra) = &config.extra_derives {
+        extra.warn_missing_dependencies();
         for (name, spec) in extra.all_dependencies() {
             match deps_mode {
                 WorkspaceDepsMode::Full | WorkspaceDepsMode::WorkspaceVersion => {

--- a/src/generators/rust/ureq/codegen.rs
+++ b/src/generators/rust/ureq/codegen.rs
@@ -150,6 +150,7 @@ description = "{description}"
     let mut content = format!("{pkg_section}{deps_section}");
 
     if let Some(extra) = &config.extra_derives {
+        extra.warn_missing_dependencies();
         for (name, spec) in extra.all_dependencies() {
             match deps_mode {
                 WorkspaceDepsMode::Full | WorkspaceDepsMode::WorkspaceVersion => {

--- a/tests/fixtures/valid/multiline-docs-and-primitive-alias.yaml
+++ b/tests/fixtures/valid/multiline-docs-and-primitive-alias.yaml
@@ -36,6 +36,23 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/NodeStatus"
+  /nodes/{nodeId}/name:
+    get:
+      operationId: getNodeName
+      summary: Get the name of a node (returns a primitive string alias).
+      parameters:
+        - name: nodeId
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/string"
+      responses:
+        "200":
+          description: Node name
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/string"
 components:
   schemas:
     string:

--- a/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/apis/default.rs.golden
@@ -49,6 +49,27 @@ impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
         }
         Ok(result)
     }
+
+    /// Get the name of a node (returns a primitive string alias).
+    pub async fn get_node_name(
+        &self,
+        node_id: &str,
+    ) -> Result<GetNodeNameResponse, Error> {
+        let mut path = "/nodes/{nodeId}/name".to_string();
+        path = path.replace("{nodeId}", &node_id.to_string());
+        let req = self.client.get(&path)?;
+        let resp = req.send().await?;
+        let status_code = resp.status().as_u16();
+        let body_bytes = resp.bytes().await?;
+        let mut result = GetNodeNameResponse { status_code, data: None };
+        match status_code {
+            200 => {
+                result.data = Some(serde_json::from_slice(&body_bytes).map_err(Error::Deserialize)?);
+            }
+            _ => {}
+        }
+        Ok(result)
+    }
 }
 
 /// Response from `accept_node`.
@@ -56,4 +77,11 @@ impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
 pub struct AcceptNodeResponse {
     pub status_code: u16,
     pub data: Option<crate::models::NodeStatus>,
+}
+
+/// Response from `get_node_name`.
+#[derive(Debug)]
+pub struct GetNodeNameResponse {
+    pub status_code: u16,
+    pub data: Option<String>,
 }

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
@@ -9,5 +9,4 @@ aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "js
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
-tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/tests/golden/rust/rust-reqwest/multiline-docs-and-primitive-alias/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-reqwest/multiline-docs-and-primitive-alias/src/apis/default.rs.golden
@@ -49,6 +49,27 @@ impl<'a> DefaultApi<'a> {
         }
         Ok(result)
     }
+
+    /// Get the name of a node (returns a primitive string alias).
+    pub async fn get_node_name(
+        &self,
+        node_id: &str,
+    ) -> Result<GetNodeNameResponse, Error> {
+        let mut path = "/nodes/{nodeId}/name".to_string();
+        path = path.replace("{nodeId}", &node_id.to_string());
+        let req = self.client.request(reqwest::Method::GET, &path).await?;
+        let resp = self.client.send(req).await?;
+        let status_code = resp.status().as_u16();
+        let body_bytes = resp.bytes().await.map_err(Error::Network)?;
+        let mut result = GetNodeNameResponse { status_code, data: None };
+        match status_code {
+            200 => {
+                result.data = Some(serde_json::from_slice(&body_bytes).map_err(Error::Deserialize)?);
+            }
+            _ => {}
+        }
+        Ok(result)
+    }
 }
 
 /// Response from `accept_node`.
@@ -56,4 +77,11 @@ impl<'a> DefaultApi<'a> {
 pub struct AcceptNodeResponse {
     pub status_code: u16,
     pub data: Option<crate::models::NodeStatus>,
+}
+
+/// Response from `get_node_name`.
+#[derive(Debug)]
+pub struct GetNodeNameResponse {
+    pub status_code: u16,
+    pub data: Option<String>,
 }

--- a/tests/golden/rust/rust-ureq/multiline-docs-and-primitive-alias/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-ureq/multiline-docs-and-primitive-alias/src/apis/default.rs.golden
@@ -48,6 +48,27 @@ impl<'a> DefaultApi<'a> {
         }
         Ok(result)
     }
+
+    /// Get the name of a node (returns a primitive string alias).
+    pub fn get_node_name(
+        &self,
+        node_id: &str,
+    ) -> Result<GetNodeNameResponse, Error> {
+        let mut path = "/nodes/{nodeId}/name".to_string();
+        path = path.replace("{nodeId}", &node_id.to_string());
+        let req = self.client.get(&path);
+        let resp = req.call()?;
+        let status_code = resp.status().as_u16();
+        let body_str = resp.into_body().read_to_string()?;
+        let mut result = GetNodeNameResponse { status_code, data: None };
+        match status_code {
+            200 => {
+                result.data = Some(serde_json::from_str(&body_str).map_err(Error::Deserialize)?);
+            }
+            _ => {}
+        }
+        Ok(result)
+    }
 }
 
 /// Response from `accept_node`.
@@ -55,4 +76,11 @@ impl<'a> DefaultApi<'a> {
 pub struct AcceptNodeResponse {
     pub status_code: u16,
     pub data: Option<crate::models::NodeStatus>,
+}
+
+/// Response from `get_node_name`.
+#[derive(Debug)]
+pub struct GetNodeNameResponse {
+    pub status_code: u16,
+    pub data: Option<String>,
 }


### PR DESCRIPTION
## Summary

- **Primitive alias resolution in API types**: `rust_type_str_qualified` now threads `&IrSpec` to detect suppressed primitive aliases (e.g. schema named "string"). References resolve to the primitive type (`String`) instead of generating broken `crate::models::String` paths.
- **Remove tokio from aioduct Cargo.toml**: aioduct already pulls tokio internally via its `"tokio"` feature flag. The standalone dep was unnecessary and forced users to declare tokio in their workspace.
- **Warn on missing derive dependencies**: When `extra_derives` uses a qualified path like `utoipa::ToSchema` without a matching `dependencies` entry, codegen now emits a warning with the exact config snippet to add. No silent `"*"` version injection.

## Test plan

- [x] Added `getNodeName` operation to `multiline-docs-and-primitive-alias.yaml` that references `$ref: "#/components/schemas/string"` as both parameter and response type
- [x] Golden files regenerated for all 3 Rust backends (reqwest, ureq, aioduct)
- [x] Verified generated API code uses `String` / `&str`, not `crate::models::String`
- [x] All 1,076 tests pass
- [x] clippy clean, fmt clean