### PR TITLE
feat(rust-aioduct): config-driven feature management and version bump to 0.1.8

### DIFF
--- a/docs/src/rust_config.md
+++ b/docs/src/rust_config.md
@@ -2,6 +2,8 @@
 
 All three Rust backends (`rust-reqwest`, `rust-ureq`, `rust-aioduct`) share the same configuration options.
 
+The `rust-aioduct` backend has an additional `[aioduct]` section for controlling aioduct-specific features.
+
 ## Full Example
 
 ```toml
@@ -108,3 +110,58 @@ When enabled:
 The `dependency` field accepts any valid TOML inline table or string that would appear after `utoipa = ` in Cargo.toml. If omitted, defaults to `"*"`.
 
 You do NOT need to add `utoipa::ToSchema` to `extra_derives` when using this config. The `[utoipa]` section handles everything, including the cases where the derive macro cannot be used.
+
+### `aioduct` (rust-aioduct only)
+
+Configure aioduct-specific dependency features for the generated crate. This section only applies to the `rust-aioduct` generator.
+
+```toml
+[generators.rust-aioduct.aioduct]
+version = "0.1.8"
+runtime = "tokio"
+tls = "rustls-ring"
+compression = ["gzip", "brotli", "zstd"]
+features = ["tracing", "http3"]
+```
+
+All fields are optional. Defaults: `runtime = "tokio"`, `tls = "rustls-ring"`, no compression, no extra features. The `json` feature is always included.
+
+#### `version`
+
+Override the pinned aioduct version. Defaults to `"0.1.8"`.
+
+#### `runtime`
+
+Which async runtime to use. One of:
+
+| Value | Description |
+|-------|-------------|
+| `"tokio"` (default) | Tokio runtime |
+| `"smol"` | smol runtime |
+| `"compio"` | compio (io_uring) runtime |
+
+#### `tls`
+
+TLS backend selection:
+
+| Value | Description |
+|-------|-------------|
+| `"rustls-ring"` (default) | rustls with ring crypto |
+| `"rustls-aws-lc-rs"` | rustls with AWS-LC crypto |
+| `"false"` | Disable TLS (HTTP-only) |
+
+#### `compression`
+
+List of decompression codecs to enable. Valid values: `"gzip"`, `"brotli"`, `"zstd"`, `"deflate"`.
+
+```toml
+compression = ["gzip", "zstd"]
+```
+
+#### `features`
+
+Pass-through feature flags appended to the aioduct dependency. Use this for features not covered by the structured fields above (e.g., `"tracing"`, `"otel"`, `"http3"`, `"hickory-dns"`, `"doh"`, `"dot"`, `"blocking"`, `"tower"`).
+
+```toml
+features = ["tracing", "http3", "blocking"]
+```

--- a/src/generators/rust/aioduct/codegen.rs
+++ b/src/generators/rust/aioduct/codegen.rs
@@ -35,9 +35,14 @@ impl RustAioductCodeGenerator {
     }
 
     fn generate_ir(&self, ir: &IrSpec) -> Result<Vec<FileInfo>, Box<dyn Error + Send + Sync>> {
+        use super::config::{AioductFeatureConfig, default_aioduct_features};
+
         let header = project_files::render_file_header(&ir.info);
         let crate_name = self.crate_name(&ir.info);
         let backend_config = aioduct_backend_config();
+        let default_cfg = default_aioduct_features();
+        let aioduct_cfg: &AioductFeatureConfig =
+            self.config.aioduct.as_ref().unwrap_or(&default_cfg);
 
         let mut files = Vec::new();
 
@@ -63,7 +68,7 @@ impl RustAioductCodeGenerator {
             .map_err(|msg| Box::<dyn Error + Send + Sync>::from(format!("emit_api: {msg}")))?,
         );
 
-        files.extend(runtime_files(&header));
+        files.extend(runtime_files(&header, aioduct_cfg));
 
         files.push(cargo_toml_file(&crate_name, ir, &self.config));
         files.push(project_files::lib_rs_file(&header));
@@ -94,8 +99,14 @@ impl FileWriter for RustAioductCodeGenerator {
 }
 
 fn cargo_toml_file(crate_name: &str, ir: &IrSpec, config: &RustGeneratorConfig) -> FileInfo {
+    use crate::generators::rust::aioduct::config::default_aioduct_features;
     use crate::generators::rust::common::config::WorkspaceDepsMode;
     use crate::ir::types::ParameterLocation;
+
+    let default_cfg = default_aioduct_features();
+    let aioduct_cfg = config.aioduct.as_ref().unwrap_or(&default_cfg);
+    let aioduct_version = aioduct_cfg.version();
+    let aioduct_features = aioduct_cfg.features_toml_array();
 
     let description = ir
         .info
@@ -159,7 +170,7 @@ serde_repr.workspace = true
         WorkspaceDepsMode::WorkspaceVersion => format!(
             r#"
 [dependencies]
-aioduct = {{ workspace = true, features = ["tokio", "rustls", "rustls-ring", "json"] }}
+aioduct = {{ workspace = true, features = {aioduct_features} }}
 serde = {{ workspace = true, features = ["derive"] }}
 serde_json.workspace = true
 serde_repr.workspace = true
@@ -168,7 +179,7 @@ serde_repr.workspace = true
         WorkspaceDepsMode::Explicit => format!(
             r#"
 [dependencies]
-aioduct = {{ version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }}
+aioduct = {{ version = "{aioduct_version}", features = {aioduct_features} }}
 serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
 serde_repr = "0.1"

--- a/src/generators/rust/aioduct/config.rs
+++ b/src/generators/rust/aioduct/config.rs
@@ -1,3 +1,247 @@
 //! Rust aioduct generator-specific configuration.
 
 pub use crate::generators::rust::common::config::RustGeneratorConfig as RustAioductConfig;
+
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_AIODUCT_VERSION: &str = "0.1.8";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AioductRuntime {
+    #[default]
+    Tokio,
+    Smol,
+    Compio,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum AioductTls {
+    #[default]
+    RustlsRing,
+    RustlsAwsLcRs,
+    #[serde(rename = "false", alias = "disabled", alias = "none")]
+    Disabled,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AioductFeatureConfig {
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub runtime: Option<AioductRuntime>,
+    #[serde(default)]
+    pub tls: Option<AioductTls>,
+    #[serde(default)]
+    pub compression: Option<Vec<String>>,
+    #[serde(default)]
+    pub features: Option<Vec<String>>,
+}
+
+impl AioductFeatureConfig {
+    pub fn version(&self) -> &str {
+        self.version.as_deref().unwrap_or(DEFAULT_AIODUCT_VERSION)
+    }
+
+    pub fn resolved_features(&self) -> Vec<String> {
+        let mut feats = Vec::new();
+
+        // Runtime (exactly one required)
+        match self.runtime.as_ref().unwrap_or(&AioductRuntime::Tokio) {
+            AioductRuntime::Tokio => feats.push("tokio".to_string()),
+            AioductRuntime::Smol => feats.push("smol".to_string()),
+            AioductRuntime::Compio => feats.push("compio".to_string()),
+        }
+
+        // TLS
+        match self.tls.as_ref().unwrap_or(&AioductTls::RustlsRing) {
+            AioductTls::RustlsRing => {
+                feats.push("rustls".to_string());
+                feats.push("rustls-ring".to_string());
+            }
+            AioductTls::RustlsAwsLcRs => {
+                feats.push("rustls".to_string());
+                feats.push("rustls-aws-lc-rs".to_string());
+            }
+            AioductTls::Disabled => {}
+        }
+
+        // JSON (always required for generated SDK)
+        feats.push("json".to_string());
+
+        // Compression
+        if let Some(compression) = &self.compression {
+            for c in compression {
+                let normalized = c.to_lowercase();
+                if matches!(normalized.as_str(), "gzip" | "brotli" | "zstd" | "deflate") {
+                    feats.push(normalized);
+                }
+            }
+        }
+
+        // Pass-through extras
+        if let Some(extras) = &self.features {
+            for f in extras {
+                if !feats.contains(f) {
+                    feats.push(f.clone());
+                }
+            }
+        }
+
+        feats
+    }
+
+    pub fn features_toml_array(&self) -> String {
+        let feats = self.resolved_features();
+        let quoted: Vec<String> = feats.iter().map(|f| format!("\"{f}\"")).collect();
+        format!("[{}]", quoted.join(", "))
+    }
+}
+
+pub fn default_aioduct_features() -> AioductFeatureConfig {
+    AioductFeatureConfig::default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_resolves_to_tokio_rustls_ring_json() {
+        let config = AioductFeatureConfig::default();
+        assert_eq!(
+            config.resolved_features(),
+            vec!["tokio", "rustls", "rustls-ring", "json"]
+        );
+    }
+
+    #[test]
+    fn default_version_is_current() {
+        let config = AioductFeatureConfig::default();
+        assert_eq!(config.version(), "0.1.8");
+    }
+
+    #[test]
+    fn custom_version_override() {
+        let config = AioductFeatureConfig {
+            version: Some("0.2.0".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(config.version(), "0.2.0");
+    }
+
+    #[test]
+    fn smol_runtime() {
+        let config = AioductFeatureConfig {
+            runtime: Some(AioductRuntime::Smol),
+            ..Default::default()
+        };
+        let feats = config.resolved_features();
+        assert!(feats.contains(&"smol".to_string()));
+        assert!(!feats.contains(&"tokio".to_string()));
+    }
+
+    #[test]
+    fn aws_lc_rs_tls() {
+        let config = AioductFeatureConfig {
+            tls: Some(AioductTls::RustlsAwsLcRs),
+            ..Default::default()
+        };
+        let feats = config.resolved_features();
+        assert!(feats.contains(&"rustls".to_string()));
+        assert!(feats.contains(&"rustls-aws-lc-rs".to_string()));
+        assert!(!feats.contains(&"rustls-ring".to_string()));
+    }
+
+    #[test]
+    fn tls_disabled() {
+        let config = AioductFeatureConfig {
+            tls: Some(AioductTls::Disabled),
+            ..Default::default()
+        };
+        let feats = config.resolved_features();
+        assert!(!feats.contains(&"rustls".to_string()));
+        assert!(!feats.contains(&"rustls-ring".to_string()));
+    }
+
+    #[test]
+    fn compression_features() {
+        let config = AioductFeatureConfig {
+            compression: Some(vec!["gzip".to_string(), "brotli".to_string()]),
+            ..Default::default()
+        };
+        let feats = config.resolved_features();
+        assert!(feats.contains(&"gzip".to_string()));
+        assert!(feats.contains(&"brotli".to_string()));
+    }
+
+    #[test]
+    fn invalid_compression_ignored() {
+        let config = AioductFeatureConfig {
+            compression: Some(vec!["lz4".to_string(), "gzip".to_string()]),
+            ..Default::default()
+        };
+        let feats = config.resolved_features();
+        assert!(feats.contains(&"gzip".to_string()));
+        assert!(!feats.contains(&"lz4".to_string()));
+    }
+
+    #[test]
+    fn passthrough_features() {
+        let config = AioductFeatureConfig {
+            features: Some(vec!["tracing".to_string(), "http3".to_string()]),
+            ..Default::default()
+        };
+        let feats = config.resolved_features();
+        assert!(feats.contains(&"tracing".to_string()));
+        assert!(feats.contains(&"http3".to_string()));
+    }
+
+    #[test]
+    fn passthrough_no_duplicates() {
+        let config = AioductFeatureConfig {
+            features: Some(vec!["tokio".to_string(), "json".to_string()]),
+            ..Default::default()
+        };
+        let feats = config.resolved_features();
+        assert_eq!(feats.iter().filter(|f| *f == "tokio").count(), 1);
+        assert_eq!(feats.iter().filter(|f| *f == "json").count(), 1);
+    }
+
+    #[test]
+    fn features_toml_array_format() {
+        let config = AioductFeatureConfig::default();
+        assert_eq!(
+            config.features_toml_array(),
+            r#"["tokio", "rustls", "rustls-ring", "json"]"#
+        );
+    }
+
+    #[test]
+    fn deserialize_from_toml() {
+        let toml_str = r#"
+            version = "0.2.0"
+            runtime = "smol"
+            tls = "rustls-aws-lc-rs"
+            compression = ["gzip", "zstd"]
+            features = ["tracing"]
+        "#;
+        let config: AioductFeatureConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.version(), "0.2.0");
+        assert_eq!(config.runtime, Some(AioductRuntime::Smol));
+        assert_eq!(config.tls, Some(AioductTls::RustlsAwsLcRs));
+        assert_eq!(
+            config.compression,
+            Some(vec!["gzip".to_string(), "zstd".to_string()])
+        );
+        assert_eq!(config.features, Some(vec!["tracing".to_string()]));
+    }
+
+    #[test]
+    fn deserialize_tls_disabled() {
+        let toml_str = r#"tls = "false""#;
+        let config: AioductFeatureConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.tls, Some(AioductTls::Disabled));
+    }
+}

--- a/src/generators/rust/aioduct/runtime.rs
+++ b/src/generators/rust/aioduct/runtime.rs
@@ -1,19 +1,41 @@
 //! Hardcoded Rust runtime source files for aioduct.
 
 use crate::codegen::traits::file_writer::FileInfo;
+use crate::generators::rust::aioduct::config::{AioductFeatureConfig, AioductTls};
 use crate::generators::rust::common::project_files::with_header;
 
-const CLIENT_RS: &str = include_str!("runtime/client.rs.txt");
+const CLIENT_RS_TEMPLATE: &str = include_str!("runtime/client.rs.txt");
 const ERROR_RS: &str = include_str!("runtime/error.rs.txt");
 const AUTH_RS: &str = include_str!("runtime/auth.rs.txt");
 const MOD_RS: &str = include_str!("runtime/mod.rs.txt");
 
 /// Returns runtime files ready to write.
-pub fn runtime_files(header: &str) -> Vec<FileInfo> {
+pub fn runtime_files(header: &str, aioduct_cfg: &AioductFeatureConfig) -> Vec<FileInfo> {
+    let client_rs = render_client_rs(aioduct_cfg);
     vec![
-        FileInfo::runtime("client.rs".to_string(), with_header(header, CLIENT_RS)),
+        FileInfo::runtime("client.rs".to_string(), with_header(header, &client_rs)),
         FileInfo::runtime("error.rs".to_string(), with_header(header, ERROR_RS)),
         FileInfo::runtime("auth.rs".to_string(), with_header(header, AUTH_RS)),
         FileInfo::runtime("mod.rs".to_string(), with_header(header, MOD_RS)),
     ]
+}
+
+fn render_client_rs(cfg: &AioductFeatureConfig) -> String {
+    let has_http3 = cfg
+        .features
+        .as_ref()
+        .is_some_and(|f| f.contains(&"http3".to_string()));
+    let tls = cfg.tls.as_ref().unwrap_or(&AioductTls::RustlsRing);
+
+    let constructor = match (tls, has_http3) {
+        (AioductTls::RustlsRing | AioductTls::RustlsAwsLcRs, true) => {
+            "aioduct::Client::<R>::with_http3()"
+        }
+        (AioductTls::RustlsRing | AioductTls::RustlsAwsLcRs, false) => {
+            "aioduct::Client::<R>::with_rustls()"
+        }
+        (AioductTls::Disabled, _) => "aioduct::Client::<R>::new()",
+    };
+
+    CLIENT_RS_TEMPLATE.replace("{{CLIENT_CONSTRUCTOR}}", constructor)
 }

--- a/src/generators/rust/aioduct/runtime/client.rs.txt
+++ b/src/generators/rust/aioduct/runtime/client.rs.txt
@@ -17,7 +17,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: {{CLIENT_CONSTRUCTOR}},
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/src/generators/rust/common/config.rs
+++ b/src/generators/rust/common/config.rs
@@ -132,6 +132,8 @@ pub struct RustGeneratorConfig {
     pub workspace_deps: Option<WorkspaceDepsMode>,
     #[serde(default)]
     pub utoipa: Option<UtoipaConfig>,
+    #[serde(default)]
+    pub aioduct: Option<crate::generators::rust::aioduct::config::AioductFeatureConfig>,
 }
 
 impl From<toml::value::Table> for RustGeneratorConfig {

--- a/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "API demonstrating OpenAPI additionalProperties with multiple levels of structs (RootLevel -> MiddleLevel -> LeafValue), each with HashMap fields."
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Comprehensive test for all OpenAPI v3.1.2 schema types"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for DELETE operations with JSON response schemas and type alias request bodies"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test API with duplicate parameter names across different locations"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This API demonstrates all 4 kinds of enum representation types: Externally Tagged, Internally Tagged, Adjacently Tagged, and Untagged"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for interfaces that reference enum types"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/minimal/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/src/runtime/client.rs.golden
@@ -22,7 +22,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "A test fixture for multi-line doc comments"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/client.rs.golden
@@ -24,7 +24,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test API with multiple operations having similar request body schema names"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture to verify language property naming conventions"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This is a sample Pet Store Server based on the OpenAPI 3.1 specification"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/petstore/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for query parameters that reference enum schemas"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for object with all optional properties including arrays, references, and inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects with snake_case to camelCase conversion (main case from user issue)"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of referenced model types with recursive FromJSON calls"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects that contain a reference property"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects where each object has nested inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for three levels of nested inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for empty array handling"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for inline object containing an array of inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for inline objects (not arrays) with snake_case to camelCase conversion"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for object with mix of simple types, arrays, references, and inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for nested object reference with recursive FromJSON calls"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional array of inline objects with snake_case to camelCase conversion"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional array of referenced model types"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional nested object reference"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for arrays with primitive items (should not be affected by recursive parsing)"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers non-JSON request body media types to pin Content-Type emission."
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/client.rs.golden
@@ -22,7 +22,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/client.rs.golden
@@ -22,7 +22,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/client.rs.golden
@@ -22,7 +22,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/client.rs.golden
@@ -22,7 +22,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This is a test API specification that includes various server configurations"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/server-object/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for complex union types"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variants are inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/client.rs.golden
@@ -32,7 +32,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for internally tagged (adjacently tagged) discriminator unions."
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/client.rs.golden
@@ -25,7 +25,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for internally tagged discriminated union where the \"unspecified\""
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/client.rs.golden
@@ -28,7 +28,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture with multiple discriminated unions to verify Kind types"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/client.rs.golden
@@ -26,7 +26,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variants are references to component schemas."
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/client.rs.golden
@@ -24,7 +24,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for allOf intersection types"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for allOf intersection types with nullable reference properties"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types that reference other union types"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for simple type aliases (not unions or intersections)"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types with both interfaces and primitives"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types that include the any type"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types (oneOf) with inline object schemas that should generate named interfaces"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for oneOf/anyOf union types with interface members"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types with primitive members"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture covering all schema kinds with utoipa enabled"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for untagged union manual utoipa impl generation"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test that utoipa::ToSchema is additive alongside user extra_derives"
 
 [dependencies]
-aioduct = { version = "0.1.6", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/client.rs.golden
@@ -23,7 +23,7 @@ impl<R: Runtime> Client<R> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::new(),
+            inner: aioduct::Client::<R>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }


### PR DESCRIPTION
## Summary

- Bump aioduct dependency from 0.1.6 to 0.1.8
- Add `[generators.rust-aioduct.aioduct]` config section for controlling aioduct features: runtime (`tokio`/`smol`/`compio`), TLS backend (`rustls-ring`/`rustls-aws-lc-rs`/disabled), compression codecs (`gzip`/`brotli`/`zstd`/`deflate`), and pass-through feature flags
- Generated client now uses the correct constructor based on TLS/HTTP3 config (`with_rustls()` by default instead of the broken `Client::new()` which doesn't configure TLS)

## Config example

```toml
[generators.rust-aioduct.aioduct]
version = "0.1.8"
runtime = "tokio"
tls = "rustls-ring"
compression = ["gzip", "brotli", "zstd"]
features = ["tracing", "http3"]
```

All fields optional. Defaults match previous behavior (minus the TLS fix).

## Test plan

- [x] 13 unit tests for config deserialization and feature resolution
- [x] 648 lib tests pass
- [x] 52 aioduct golden tests pass
- [x] 52/52 golden builds compile (`just golden-rust::build-aioduct`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean