### PR TITLE
fix(typescript): fix vp golden build with entry, typescript dep, vp run build

### DIFF
--- a/scripts/golden-build-typescript.sh
+++ b/scripts/golden-build-typescript.sh
@@ -38,9 +38,9 @@ for test_dir in "$golden"/*/; do
   log=$(mktemp)
   if [ "$USE_VP" = "1" ]; then
     if [ -f "$tmp/vite.config.ts" ]; then
-      (cd "$tmp" && vp install --silent) >>"$log" 2>&1 || true
+      (cd "$tmp" && vp install) >>"$log" 2>&1 || true
     fi
-    if (cd "$tmp" && vp check --no-fmt) >>"$log" 2>&1; then
+    if (cd "$tmp" && vp check --no-fmt && vp run build) >>"$log" 2>&1; then
       echo "ok"
       passed=$((passed + 1))
     else

--- a/src/generators/typescript/fetch/codegen.rs
+++ b/src/generators/typescript/fetch/codegen.rs
@@ -291,6 +291,7 @@ impl TypeScriptFetchCodeGenerator {
                         "check": "vp check --no-fmt",
                     });
                     package_json["devDependencies"] = serde_json::json!({
+                        "typescript": "latest",
                         "vite-plus": "latest",
                     });
                 }
@@ -361,6 +362,7 @@ export default defineConfig({
     ignorePatterns: ['node_modules', 'dist'],
   },
   pack: {
+    entry: ['index.ts'],
     dts: true,
     format: ['esm'],
   },

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp/package.json.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp/package.json.golden
@@ -1,6 +1,7 @@
 {
   "description": "Test fixture for discriminated union where variants are references to component schemas.\nThis is similar to the ContainerImage pattern in the infiron API.\n",
   "devDependencies": {
+    "typescript": "latest",
     "vite-plus": "latest"
   },
   "exports": {

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp/vite.config.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp/vite.config.ts.golden
@@ -9,6 +9,7 @@ export default defineConfig({
     ignorePatterns: ['node_modules', 'dist'],
   },
   pack: {
+    entry: ['index.ts'],
     dts: true,
     format: ['esm'],
   },


### PR DESCRIPTION
## Summary

- Adds `entry: ['index.ts']` to generated `vite.config.ts` pack config (vp pack defaults to `src/index.ts` which doesn't exist)
- Adds `typescript` to devDependencies (required by vp pack's dts generation plugin)
- Golden build script uses `vp install` → `vp check --no-fmt` → `vp run build` for full validation

## Test plan

- [x] `vp install` + `vp check --no-fmt` + `vp run build` passes on generated output
- [x] `./scripts/golden-build-typescript.sh` — 59/59 passed
- [x] `cargo test` passes