### PR TITLE
fix(python,go): fix 8 serialization and codegen bugs

### DIFF
--- a/src/generators/go/http/sigil_emit.rs
+++ b/src/generators/go/http/sigil_emit.rs
@@ -22,6 +22,7 @@ use crate::ir::types::{
     IrSchemaKind, IrSpec, IrTaggedUnion, IrTypeExpr, IrUnion, TaggingStyle,
 };
 use heck::{ToPascalCase, ToSnakeCase};
+use sigil_stitch::lang::go_lang::GoLang;
 use sigil_stitch::prelude::{CodeBlock, sigil_quote};
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -91,11 +92,36 @@ fn emit_object(schema: &IrSchema, obj: &IrObject) -> Option<String> {
         tb = tb.add_field(build_struct_field(json_name, prop));
     }
 
+    if let Some(ap_type) = &obj.additional_properties {
+        let value_type = go_type_str(ap_type);
+        let ap_field = FieldSpec::builder(
+            "AdditionalProperties",
+            TypeName::primitive(&format!("map[string]{value_type}")),
+        )
+        .tag("json:\"-\"")
+        .doc("Additional properties not captured by defined fields.")
+        .build()
+        .expect("AP field builds");
+        tb = tb.add_field(ap_field);
+    }
+
     let fb = FileSpec::builder(&format!("{}.go", name))
         .header(package_header())
         .add_type(tb.build().ok()?);
     let file = fb.build().ok()?;
-    file.render(RENDER_WIDTH).ok()
+    let mut rendered = file.render(RENDER_WIDTH).ok()?;
+
+    if let Some(ap_type) = &obj.additional_properties {
+        let value_type = go_type_str(ap_type);
+        // Insert `import "encoding/json"` after the package declaration.
+        if let Some(pos) = rendered.find("\n\n") {
+            rendered.insert_str(pos + 1, "\nimport \"encoding/json\"\n");
+        }
+        rendered.push_str(&emit_marshal_json(&name));
+        rendered.push_str(&emit_unmarshal_json(&name, obj, &value_type));
+    }
+
+    Some(rendered)
 }
 
 fn build_struct_field(json_name: &str, prop: &IrProperty) -> FieldSpec {
@@ -121,6 +147,76 @@ fn json_tag(json_name: &str, required: bool, nullable: bool) -> String {
     } else {
         format!("json:\"{},omitempty\"", json_name)
     }
+}
+
+fn emit_marshal_json(struct_name: &str) -> String {
+    let cb = sigil_quote!(GoLang {
+        $L("")
+        $L(format!("func (o {struct_name}) MarshalJSON() ([]byte, error)")) {
+            $L(format!("type Plain {struct_name}"))
+            $L("data, err := json.Marshal(Plain(o))")
+            $L("if err != nil") {
+                $L("return nil, err")
+            }
+            $L("if len(o.AdditionalProperties) == 0") {
+                $L("return data, nil")
+            }
+            $L("var base map[string]json.RawMessage")
+            $L("if err := json.Unmarshal(data, &base); err != nil") {
+                $L("return nil, err")
+            }
+            $L("for k, v := range o.AdditionalProperties") {
+                $L("raw, err := json.Marshal(v)")
+                $L("if err != nil") {
+                    $L("return nil, err")
+                }
+                $L("base[k] = raw")
+            }
+            $L("return json.Marshal(base)")
+        }
+    })
+    .expect("MarshalJSON builds");
+    cb.render_standalone(&GoLang::new(), RENDER_WIDTH)
+        .expect("MarshalJSON renders")
+}
+
+fn emit_unmarshal_json(struct_name: &str, obj: &IrObject, value_type: &str) -> String {
+    let known_map = obj
+        .properties
+        .keys()
+        .map(|k| format!("\"{k}\": true"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let cb = sigil_quote!(GoLang {
+        $L("")
+        $L(format!("func (o *{struct_name}) UnmarshalJSON(data []byte) error")) {
+            $L(format!("type Plain {struct_name}"))
+            $L("if err := json.Unmarshal(data, (*Plain)(o)); err != nil") {
+                $L("return err")
+            }
+            $L("var raw map[string]json.RawMessage")
+            $L("if err := json.Unmarshal(data, &raw); err != nil") {
+                $L("return err")
+            }
+            $L(format!("known := map[string]bool{{{known_map}}}"))
+            $L(format!("o.AdditionalProperties = make(map[string]{value_type})"))
+            $L("for k, v := range raw") {
+                $L("if known[k]") {
+                    $L("continue")
+                }
+                $L(format!("var parsed {value_type}"))
+                $L("if err := json.Unmarshal(v, &parsed); err != nil") {
+                    $L("continue")
+                }
+                $L("o.AdditionalProperties[k] = parsed")
+            }
+            $L("return nil")
+        }
+    })
+    .expect("UnmarshalJSON builds");
+    cb.render_standalone(&GoLang::new(), RENDER_WIDTH)
+        .expect("UnmarshalJSON renders")
 }
 
 // ---------------------------------------------------------------------------

--- a/src/generators/go/http/sigil_emit_api.rs
+++ b/src/generators/go/http/sigil_emit_api.rs
@@ -617,11 +617,19 @@ fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
     cb.add_line();
 
     if !plan.typed_responses.is_empty() {
-        cb.begin_control_flow("switch httpResp.StatusCode", ());
+        let mut numeric_responses: Vec<&TypedResponse> = Vec::new();
+        let mut wildcard_responses: Vec<&TypedResponse> = Vec::new();
         for tr in &plan.typed_responses {
-            let Some(code) = tr.status.parse::<u16>().ok() else {
-                continue;
-            };
+            if tr.status.parse::<u16>().is_ok() {
+                numeric_responses.push(tr);
+            } else {
+                wildcard_responses.push(tr);
+            }
+        }
+
+        cb.begin_control_flow("switch httpResp.StatusCode", ());
+        for tr in &numeric_responses {
+            let code = tr.status.parse::<u16>().unwrap();
             cb.add(&format!("case {code}:"), ());
             cb.add_line();
             cb.add("%L", emit_decode_into(&tr.field_name, &tr.go_type));
@@ -629,6 +637,23 @@ fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
         cb.add("default:", ());
         cb.add_line();
         cb.add("%>", ());
+        for tr in &wildcard_responses {
+            let (low, high) = wildcard_range(&tr.status);
+            cb.begin_control_flow(
+                &format!(
+                    "if httpResp.StatusCode >= {} && httpResp.StatusCode < {}",
+                    low, high
+                ),
+                (),
+            );
+            cb.add("%L", emit_decode_into(&tr.field_name, &tr.go_type));
+            cb.add(
+                "return resp, &runtime.APIError{StatusCode: httpResp.StatusCode, Status: httpResp.Status}",
+                (),
+            );
+            cb.add_line();
+            cb.end_control_flow();
+        }
         cb.begin_control_flow("if httpResp.StatusCode >= 400", ());
         cb.add("body, _ := io.ReadAll(httpResp.Body)", ());
         cb.add_line();
@@ -708,6 +733,17 @@ fn response_field_name(status: &str) -> String {
         format!("Status{code}")
     } else {
         format!("Status{}", status.to_uppercase())
+    }
+}
+
+fn wildcard_range(status: &str) -> (u16, u16) {
+    match status.to_uppercase().as_str() {
+        "1XX" => (100, 200),
+        "2XX" => (200, 300),
+        "3XX" => (300, 400),
+        "4XX" => (400, 500),
+        "5XX" => (500, 600),
+        _ => (0, 1000),
     }
 }
 

--- a/src/generators/python/httpx/emit_api.rs
+++ b/src/generators/python/httpx/emit_api.rs
@@ -223,6 +223,15 @@ fn build_method_body(plan: &OpPlan<'_>, ir: &IrSpec, error_type: &TypeName) -> C
                     b.var_name, b.var_name
                 )
             }
+        } else if is_array_of_objects(&b.type_expr, ir) {
+            if b.required {
+                format!("[item.to_dict() for item in {}]", b.var_name)
+            } else {
+                format!(
+                    "[item.to_dict() for item in {}] if {} is not None else None",
+                    b.var_name, b.var_name
+                )
+            }
         } else {
             b.var_name.clone()
         }
@@ -292,6 +301,7 @@ fn render_stringify(var: &str, type_expr: &IrTypeExpr) -> String {
             | IrPrimitive::NumberWithFormat(_),
         ) => format!("str({var})"),
         IrTypeExpr::Nullable(inner) => render_stringify(var, inner),
+        IrTypeExpr::Array(_) => format!("\",\".join(str(v) for v in {var})"),
         _ => format!("str({var})"),
     }
 }
@@ -324,6 +334,15 @@ fn render_response_parse(type_expr: &IrTypeExpr, ir: &IrSpec) -> String {
 
 fn is_object_type(type_expr: &IrTypeExpr, ir: &IrSpec) -> bool {
     if let IrTypeExpr::Named(name) = type_expr {
+        return is_object_schema(name, ir);
+    }
+    false
+}
+
+fn is_array_of_objects(type_expr: &IrTypeExpr, ir: &IrSpec) -> bool {
+    if let IrTypeExpr::Array(inner) = type_expr
+        && let IrTypeExpr::Named(name) = inner.as_ref()
+    {
         return is_object_schema(name, ir);
     }
     false

--- a/src/generators/python/httpx/emit_models.rs
+++ b/src/generators/python/httpx/emit_models.rs
@@ -352,7 +352,7 @@ fn emit_intersection(schema: &IrSchema, inter: &IrIntersection, ir: &IrSpec) -> 
         return emit_intersection_as_alias(schema, inter);
     }
 
-    emit_intersection_as_dataclass(schema, &all_props)
+    emit_intersection_as_dataclass(schema, &all_props, ir)
 }
 
 fn emit_intersection_as_alias(schema: &IrSchema, inter: &IrIntersection) -> Option<FileSpec> {
@@ -381,6 +381,7 @@ fn emit_intersection_as_alias(schema: &IrSchema, inter: &IrIntersection) -> Opti
 fn emit_intersection_as_dataclass(
     schema: &IrSchema,
     all_props: &indexmap::IndexMap<String, IrProperty>,
+    ir: &IrSpec,
 ) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
 
@@ -431,6 +432,11 @@ fn emit_intersection_as_dataclass(
                     .expect("optional field"),
             );
         }
+
+        let all_fields: Vec<(&String, &IrProperty)> =
+            required.iter().chain(optional.iter()).copied().collect();
+        cls = cls.add_method(build_to_dict_method(&all_fields, ir, all_props));
+        cls = cls.add_method(build_from_dict_method(&name, &all_fields, ir, all_props));
     }
 
     file = file.add_type(cls.build().ok()?);
@@ -822,6 +828,14 @@ fn render_to_dict_expr(
             }
             value_expr.to_string()
         }
+        Some(IrTypeExpr::Map(inner)) => {
+            if let IrTypeExpr::Named(ref_name) = inner.as_ref()
+                && is_object_schema(ref_name, ir)
+            {
+                return format!("{{k: v.to_dict() for k, v in {value_expr}.items()}}");
+            }
+            value_expr.to_string()
+        }
         _ => value_expr.to_string(),
     }
 }
@@ -850,6 +864,17 @@ fn render_from_dict_expr(
                 let py_name = ref_name.to_pascal_case();
                 return format!(
                     "[{py_name}.from_dict(item) for item in {accessor}]  # type: ignore[union-attr]"
+                );
+            }
+            format!("{accessor}  # type: ignore[assignment]")
+        }
+        Some(IrTypeExpr::Map(inner)) => {
+            if let IrTypeExpr::Named(ref_name) = inner.as_ref()
+                && is_object_schema(ref_name, ir)
+            {
+                let py_name = ref_name.to_pascal_case();
+                return format!(
+                    "{{k: {py_name}.from_dict(v) for k, v in {accessor}.items()}}  # type: ignore[union-attr]"
                 );
             }
             format!("{accessor}  # type: ignore[assignment]")
@@ -892,14 +917,35 @@ fn render_from_dict_optional_expr(
             }
             format!("{accessor}  # type: ignore[assignment]")
         }
+        Some(IrTypeExpr::Map(inner)) => {
+            if let IrTypeExpr::Named(ref_name) = inner.as_ref()
+                && is_object_schema(ref_name, ir)
+            {
+                let py_name = ref_name.to_pascal_case();
+                return format!(
+                    "{{k: {py_name}.from_dict(v) for k, v in {accessor}.items()}} if {accessor} is not None else None  # type: ignore[union-attr]"
+                );
+            }
+            format!("{accessor}  # type: ignore[assignment]")
+        }
         _ => format!("{accessor}  # type: ignore[assignment]"),
     }
 }
 
 pub fn is_object_schema(name: &str, ir: &IrSpec) -> bool {
-    ir.schemas
-        .get(name)
-        .is_some_and(|s| matches!(s.kind, IrSchemaKind::Object(_)))
+    ir.schemas.get(name).is_some_and(|s| match &s.kind {
+        IrSchemaKind::Object(_) => true,
+        IrSchemaKind::Intersection(inter) => inter.members.iter().any(|m| {
+            if let IrTypeExpr::Named(ref_name) = m {
+                ir.schemas
+                    .get(ref_name.as_str())
+                    .is_some_and(|ms| matches!(ms.kind, IrSchemaKind::Object(_)))
+            } else {
+                false
+            }
+        }),
+        _ => false,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/generators/python/requests/emit_api.rs
+++ b/src/generators/python/requests/emit_api.rs
@@ -223,6 +223,15 @@ fn build_method_body(plan: &OpPlan<'_>, ir: &IrSpec, error_type: &TypeName) -> C
                     b.var_name, b.var_name
                 )
             }
+        } else if is_array_of_objects(&b.type_expr, ir) {
+            if b.required {
+                format!("[item.to_dict() for item in {}]", b.var_name)
+            } else {
+                format!(
+                    "[item.to_dict() for item in {}] if {} is not None else None",
+                    b.var_name, b.var_name
+                )
+            }
         } else {
             b.var_name.clone()
         }
@@ -292,6 +301,7 @@ fn render_stringify(var: &str, type_expr: &IrTypeExpr) -> String {
             | IrPrimitive::NumberWithFormat(_),
         ) => format!("str({var})"),
         IrTypeExpr::Nullable(inner) => render_stringify(var, inner),
+        IrTypeExpr::Array(_) => format!("\",\".join(str(v) for v in {var})"),
         _ => format!("str({var})"),
     }
 }
@@ -324,6 +334,15 @@ fn render_response_parse(type_expr: &IrTypeExpr, ir: &IrSpec) -> String {
 
 fn is_object_type(type_expr: &IrTypeExpr, ir: &IrSpec) -> bool {
     if let IrTypeExpr::Named(name) = type_expr {
+        return is_object_schema(name, ir);
+    }
+    false
+}
+
+fn is_array_of_objects(type_expr: &IrTypeExpr, ir: &IrSpec) -> bool {
+    if let IrTypeExpr::Array(inner) = type_expr
+        && let IrTypeExpr::Named(name) = inner.as_ref()
+    {
         return is_object_schema(name, ir);
     }
     false

--- a/src/generators/python/requests/emit_models.rs
+++ b/src/generators/python/requests/emit_models.rs
@@ -352,7 +352,7 @@ fn emit_intersection(schema: &IrSchema, inter: &IrIntersection, ir: &IrSpec) -> 
         return emit_intersection_as_alias(schema, inter);
     }
 
-    emit_intersection_as_dataclass(schema, &all_props)
+    emit_intersection_as_dataclass(schema, &all_props, ir)
 }
 
 fn emit_intersection_as_alias(schema: &IrSchema, inter: &IrIntersection) -> Option<FileSpec> {
@@ -381,6 +381,7 @@ fn emit_intersection_as_alias(schema: &IrSchema, inter: &IrIntersection) -> Opti
 fn emit_intersection_as_dataclass(
     schema: &IrSchema,
     all_props: &indexmap::IndexMap<String, IrProperty>,
+    ir: &IrSpec,
 ) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
 
@@ -431,6 +432,11 @@ fn emit_intersection_as_dataclass(
                     .expect("optional field"),
             );
         }
+
+        let all_fields: Vec<(&String, &IrProperty)> =
+            required.iter().chain(optional.iter()).copied().collect();
+        cls = cls.add_method(build_to_dict_method(&all_fields, ir, all_props));
+        cls = cls.add_method(build_from_dict_method(&name, &all_fields, ir, all_props));
     }
 
     file = file.add_type(cls.build().ok()?);
@@ -821,6 +827,14 @@ fn render_to_dict_expr(
             }
             value_expr.to_string()
         }
+        Some(IrTypeExpr::Map(inner)) => {
+            if let IrTypeExpr::Named(ref_name) = inner.as_ref()
+                && is_object_schema(ref_name, ir)
+            {
+                return format!("{{k: v.to_dict() for k, v in {value_expr}.items()}}");
+            }
+            value_expr.to_string()
+        }
         _ => value_expr.to_string(),
     }
 }
@@ -849,6 +863,17 @@ fn render_from_dict_expr(
                 let py_name = ref_name.to_pascal_case();
                 return format!(
                     "[{py_name}.from_dict(item) for item in {accessor}]  # type: ignore[union-attr]"
+                );
+            }
+            format!("{accessor}  # type: ignore[assignment]")
+        }
+        Some(IrTypeExpr::Map(inner)) => {
+            if let IrTypeExpr::Named(ref_name) = inner.as_ref()
+                && is_object_schema(ref_name, ir)
+            {
+                let py_name = ref_name.to_pascal_case();
+                return format!(
+                    "{{k: {py_name}.from_dict(v) for k, v in {accessor}.items()}}  # type: ignore[union-attr]"
                 );
             }
             format!("{accessor}  # type: ignore[assignment]")
@@ -891,14 +916,35 @@ fn render_from_dict_optional_expr(
             }
             format!("{accessor}  # type: ignore[assignment]")
         }
+        Some(IrTypeExpr::Map(inner)) => {
+            if let IrTypeExpr::Named(ref_name) = inner.as_ref()
+                && is_object_schema(ref_name, ir)
+            {
+                let py_name = ref_name.to_pascal_case();
+                return format!(
+                    "{{k: {py_name}.from_dict(v) for k, v in {accessor}.items()}} if {accessor} is not None else None  # type: ignore[union-attr]"
+                );
+            }
+            format!("{accessor}  # type: ignore[assignment]")
+        }
         _ => format!("{accessor}  # type: ignore[assignment]"),
     }
 }
 
 pub fn is_object_schema(name: &str, ir: &IrSpec) -> bool {
-    ir.schemas
-        .get(name)
-        .is_some_and(|s| matches!(s.kind, IrSchemaKind::Object(_)))
+    ir.schemas.get(name).is_some_and(|s| match &s.kind {
+        IrSchemaKind::Object(_) => true,
+        IrSchemaKind::Intersection(inter) => inter.members.iter().any(|m| {
+            if let IrTypeExpr::Named(ref_name) = m {
+                ir.schemas
+                    .get(ref_name.as_str())
+                    .is_some_and(|ms| matches!(ms.kind, IrSchemaKind::Object(_)))
+            } else {
+                false
+            }
+        }),
+        _ => false,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/golden/go/go-http/comprehensive-schemas/models/object_with_additional_properties_true.go.golden
+++ b/tests/golden/go/go-http/comprehensive-schemas/models/object_with_additional_properties_true.go.golden
@@ -5,7 +5,58 @@
 
 package models
 
+import "encoding/json"
+
 // Object allowing any additional properties
 type ObjectWithAdditionalPropertiesTrue struct {
 	Name string `json:"name"`
+	// Additional properties not captured by defined fields.
+	AdditionalProperties map[string]any `json:"-"`
+}
+
+func (o ObjectWithAdditionalPropertiesTrue) MarshalJSON() ([]byte, error) {
+	type Plain ObjectWithAdditionalPropertiesTrue
+	data, err := json.Marshal(Plain(o))
+	if err != nil {
+		return nil, err
+	}
+	if len(o.AdditionalProperties) == 0 {
+		return data, nil
+	}
+	var base map[string]json.RawMessage
+	if err := json.Unmarshal(data, &base); err != nil {
+		return nil, err
+	}
+	for k, v := range o.AdditionalProperties {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		base[k] = raw
+	}
+	return json.Marshal(base)
+}
+
+func (o *ObjectWithAdditionalPropertiesTrue) UnmarshalJSON(data []byte) error {
+	type Plain ObjectWithAdditionalPropertiesTrue
+	if err := json.Unmarshal(data, (*Plain)(o)); err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	known := map[string]bool{"name": true}
+	o.AdditionalProperties = make(map[string]any)
+	for k, v := range raw {
+		if known[k] {
+			continue
+		}
+		var parsed any
+		if err := json.Unmarshal(v, &parsed); err != nil {
+			continue
+		}
+		o.AdditionalProperties[k] = parsed
+	}
+	return nil
 }

--- a/tests/golden/go/go-http/comprehensive-schemas/models/object_with_typed_additional_properties.go.golden
+++ b/tests/golden/go/go-http/comprehensive-schemas/models/object_with_typed_additional_properties.go.golden
@@ -5,7 +5,58 @@
 
 package models
 
+import "encoding/json"
+
 // Object with typed additional properties
 type ObjectWithTypedAdditionalProperties struct {
 	Name string `json:"name"`
+	// Additional properties not captured by defined fields.
+	AdditionalProperties map[string]float64 `json:"-"`
+}
+
+func (o ObjectWithTypedAdditionalProperties) MarshalJSON() ([]byte, error) {
+	type Plain ObjectWithTypedAdditionalProperties
+	data, err := json.Marshal(Plain(o))
+	if err != nil {
+		return nil, err
+	}
+	if len(o.AdditionalProperties) == 0 {
+		return data, nil
+	}
+	var base map[string]json.RawMessage
+	if err := json.Unmarshal(data, &base); err != nil {
+		return nil, err
+	}
+	for k, v := range o.AdditionalProperties {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		base[k] = raw
+	}
+	return json.Marshal(base)
+}
+
+func (o *ObjectWithTypedAdditionalProperties) UnmarshalJSON(data []byte) error {
+	type Plain ObjectWithTypedAdditionalProperties
+	if err := json.Unmarshal(data, (*Plain)(o)); err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	known := map[string]bool{"name": true}
+	o.AdditionalProperties = make(map[string]float64)
+	for k, v := range raw {
+		if known[k] {
+			continue
+		}
+		var parsed float64
+		if err := json.Unmarshal(v, &parsed); err != nil {
+			continue
+		}
+		o.AdditionalProperties[k] = parsed
+	}
+	return nil
 }

--- a/tests/golden/go/go-http/delete-with-response-schema/apis/test_resource.go.golden
+++ b/tests/golden/go/go-http/delete-with-response-schema/apis/test_resource.go.golden
@@ -109,6 +109,22 @@ func (a *TestResourceAPI) DeleteTestResource(ctx context.Context, resourceId str
 			}
 			resp.Status200 = &payload
 		default:
+			if httpResp.StatusCode >= 400 && httpResp.StatusCode < 500 {
+					var payload models.HttpErrorResponse
+					if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil {
+						return nil, fmt.Errorf("decode response: %w", err)
+					}
+					resp.Status4XX = &payload
+				return resp, &runtime.APIError{StatusCode: httpResp.StatusCode, Status: httpResp.Status}
+			}
+			if httpResp.StatusCode >= 500 && httpResp.StatusCode < 600 {
+					var payload models.HttpErrorResponse
+					if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil {
+						return nil, fmt.Errorf("decode response: %w", err)
+					}
+					resp.Status5XX = &payload
+				return resp, &runtime.APIError{StatusCode: httpResp.StatusCode, Status: httpResp.Status}
+			}
 			if httpResp.StatusCode >= 400 {
 				body, _ := io.ReadAll(httpResp.Body)
 				return nil, &runtime.APIError{StatusCode: httpResp.StatusCode, Status: httpResp.Status, Body: body}

--- a/tests/golden/go/go-http/response-body-default-and-exact/apis/widget.go.golden
+++ b/tests/golden/go/go-http/response-body-default-and-exact/apis/widget.go.golden
@@ -56,6 +56,14 @@ func (a *WidgetAPI) GetWidget(ctx context.Context) (*GetWidgetResponse, error) {
 			}
 			resp.Status200 = &payload
 		default:
+			if httpResp.StatusCode >= 0 && httpResp.StatusCode < 1000 {
+					var payload models.ErrorResponse
+					if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil {
+						return nil, fmt.Errorf("decode response: %w", err)
+					}
+					resp.Default = &payload
+				return resp, &runtime.APIError{StatusCode: httpResp.StatusCode, Status: httpResp.Status}
+			}
 			if httpResp.StatusCode >= 400 {
 				body, _ := io.ReadAll(httpResp.Body)
 				return nil, &runtime.APIError{StatusCode: httpResp.StatusCode, Status: httpResp.Status, Body: body}

--- a/tests/golden/python/python-httpx/additional-properties/additional_properties_api/models/middle_level.py.golden
+++ b/tests/golden/python/python-httpx/additional-properties/additional_properties_api/models/middle_level.py.golden
@@ -23,7 +23,7 @@ class MiddleLevel:
         result: dict[str, object] = {}
         result["count"] = self.count
         result["key"] = self.key
-        result["nested"] = self.nested
+        result["nested"] = {k: v.to_dict() for k, v in self.nested.items()}
         if self.extras is not None:
             result["extras"] = self.extras
         if self.flags is not None:
@@ -35,7 +35,7 @@ class MiddleLevel:
         return cls(
             count=data["count"],  # type: ignore[assignment]
             key=data["key"],  # type: ignore[assignment]
-            nested=data["nested"],  # type: ignore[assignment]
+            nested={k: LeafValue.from_dict(v) for k, v in data["nested"].items()},  # type: ignore[union-attr]
             extras=data.get("extras"),  # type: ignore[assignment]
             flags=data.get("flags"),  # type: ignore[assignment]
         )

--- a/tests/golden/python/python-httpx/additional-properties/additional_properties_api/models/root_level.py.golden
+++ b/tests/golden/python/python-httpx/additional-properties/additional_properties_api/models/root_level.py.golden
@@ -21,7 +21,7 @@ class RootLevel:
 
     def to_dict(self) -> dict[str, object]:
         result: dict[str, object] = {}
-        result["children"] = self.children
+        result["children"] = {k: v.to_dict() for k, v in self.children.items()}
         result["id"] = self.id
         result["name"] = self.name
         if self.extras is not None:
@@ -33,7 +33,7 @@ class RootLevel:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> RootLevel:
         return cls(
-            children=data["children"],  # type: ignore[assignment]
+            children={k: MiddleLevel.from_dict(v) for k, v in data["children"].items()},  # type: ignore[union-attr]
             id=data["id"],  # type: ignore[assignment]
             name=data["name"],  # type: ignore[assignment]
             extras=data.get("extras"),  # type: ignore[assignment]

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/all_of_objects.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/all_of_objects.py.golden
@@ -14,3 +14,22 @@ class AllOfObjects:
     name: str
     active: bool | None = None
     metadata: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {}
+        result["id"] = self.id
+        result["name"] = self.name
+        if self.active is not None:
+            result["active"] = self.active
+        if self.metadata is not None:
+            result["metadata"] = self.metadata
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> AllOfObjects:
+        return cls(
+            id=data["id"],  # type: ignore[assignment]
+            name=data["name"],  # type: ignore[assignment]
+            active=data.get("active"),  # type: ignore[assignment]
+            metadata=data.get("metadata"),  # type: ignore[assignment]
+        )

--- a/tests/golden/python/python-httpx/naming-conventions/naming_conventions_test/apis/default_api.py.golden
+++ b/tests/golden/python/python-httpx/naming-conventions/naming_conventions_test/apis/default_api.py.golden
@@ -28,7 +28,7 @@ class DefaultApi:
         if kebab_case_param is not None:
             params["kebab-case-param"] = str(kebab_case_param)
         if kebab_case_array is not None:
-            params["kebab-case-array"] = str(kebab_case_array)
+            params["kebab-case-array"] = ",".join(str(v) for v in kebab_case_array)
         if pascal_case_param is not None:
             params["PascalCaseParam"] = str(pascal_case_param)
         if pascal_case_number is not None:

--- a/tests/golden/python/python-httpx/petstore/petstore_api/apis/pet_api.py.golden
+++ b/tests/golden/python/python-httpx/petstore/petstore_api/apis/pet_api.py.golden
@@ -44,7 +44,7 @@ class PetApi:
         """Find pets by tags."""
         path = "/pet/findByTags"
         params: dict[str, str] = {}
-        params["tags"] = str(tags)
+        params["tags"] = ",".join(str(v) for v in tags)
         response = self._client.request("GET", path, params=params)
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason_phrase, response.content)

--- a/tests/golden/python/python-httpx/petstore/petstore_api/apis/user_api.py.golden
+++ b/tests/golden/python/python-httpx/petstore/petstore_api/apis/user_api.py.golden
@@ -24,7 +24,7 @@ class UserApi:
     def create_users_with_list_input(self, *, body: list[User]) -> User:
         """Creates list of users with given input array."""
         path = "/user/createWithList"
-        response = self._client.request("POST", path, json=body)
+        response = self._client.request("POST", path, json=[item.to_dict() for item in body])
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason_phrase, response.content)
         return User.from_dict(response.json())

--- a/tests/golden/python/python-httpx/type-aliases-intersection-allof/intersection_type_all_of_test/apis/default_api.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-intersection-allof/intersection_type_all_of_test/apis/default_api.py.golden
@@ -16,7 +16,7 @@ class DefaultApi:
     def test_intersection(self, *, body: Foo) -> Foo:
         """Test endpoint with intersection type."""
         path = "/test"
-        response = self._client.request("POST", path, json=body)
+        response = self._client.request("POST", path, json=body.to_dict())
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason_phrase, response.content)
-        return response.json()  # type: ignore[return-value]
+        return Foo.from_dict(response.json())

--- a/tests/golden/python/python-httpx/type-aliases-intersection-allof/intersection_type_all_of_test/models/foo.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-intersection-allof/intersection_type_all_of_test/models/foo.py.golden
@@ -14,3 +14,21 @@ class Foo:
     name: str
     email: str
     created_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {}
+        result["id"] = self.id
+        result["name"] = self.name
+        result["email"] = self.email
+        if self.created_at is not None:
+            result["createdAt"] = self.created_at
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Foo:
+        return cls(
+            id=data["id"],  # type: ignore[assignment]
+            name=data["name"],  # type: ignore[assignment]
+            email=data["email"],  # type: ignore[assignment]
+            created_at=data.get("createdAt"),  # type: ignore[assignment]
+        )

--- a/tests/golden/python/python-httpx/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/apis/default_api.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/apis/default_api.py.golden
@@ -16,10 +16,10 @@ class DefaultApi:
     def create_test(self, *, body: Baz) -> Baz:
         """Create test with intersection type."""
         path = "/test"
-        response = self._client.request("POST", path, json=body)
+        response = self._client.request("POST", path, json=body.to_dict())
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason_phrase, response.content)
-        return response.json()  # type: ignore[return-value]
+        return Baz.from_dict(response.json())
 
     def get_test(self, id: str) -> Baz:
         """Get test."""
@@ -27,4 +27,4 @@ class DefaultApi:
         response = self._client.request("GET", path)
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason_phrase, response.content)
-        return response.json()  # type: ignore[return-value]
+        return Baz.from_dict(response.json())

--- a/tests/golden/python/python-httpx/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/models/baz.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/models/baz.py.golden
@@ -19,3 +19,25 @@ class Baz:
     id: str
     status: Literal["active", "inactive", "pending"]
     meta_data: Bar | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {}
+        result["count1"] = self.count1
+        result["count2"] = self.count2
+        result["createdAt"] = self.created_at
+        result["id"] = self.id
+        result["status"] = self.status
+        if self.meta_data is not None:
+            result["metaData"] = self.meta_data.to_dict()
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Baz:
+        return cls(
+            count1=data["count1"],  # type: ignore[assignment]
+            count2=data["count2"],  # type: ignore[assignment]
+            created_at=data["createdAt"],  # type: ignore[assignment]
+            id=data["id"],  # type: ignore[assignment]
+            status=data["status"],  # type: ignore[assignment]
+            meta_data=Bar.from_dict(data.get("metaData")) if data.get("metaData") is not None else None,  # type: ignore[arg-type]
+        )

--- a/tests/golden/python/python-requests/additional-properties/additional_properties_api/models/middle_level.py.golden
+++ b/tests/golden/python/python-requests/additional-properties/additional_properties_api/models/middle_level.py.golden
@@ -23,7 +23,7 @@ class MiddleLevel:
         result: dict[str, object] = {}
         result["count"] = self.count
         result["key"] = self.key
-        result["nested"] = self.nested
+        result["nested"] = {k: v.to_dict() for k, v in self.nested.items()}
         if self.extras is not None:
             result["extras"] = self.extras
         if self.flags is not None:
@@ -35,7 +35,7 @@ class MiddleLevel:
         return cls(
             count=data["count"],  # type: ignore[assignment]
             key=data["key"],  # type: ignore[assignment]
-            nested=data["nested"],  # type: ignore[assignment]
+            nested={k: LeafValue.from_dict(v) for k, v in data["nested"].items()},  # type: ignore[union-attr]
             extras=data.get("extras"),  # type: ignore[assignment]
             flags=data.get("flags"),  # type: ignore[assignment]
         )

--- a/tests/golden/python/python-requests/additional-properties/additional_properties_api/models/root_level.py.golden
+++ b/tests/golden/python/python-requests/additional-properties/additional_properties_api/models/root_level.py.golden
@@ -21,7 +21,7 @@ class RootLevel:
 
     def to_dict(self) -> dict[str, object]:
         result: dict[str, object] = {}
-        result["children"] = self.children
+        result["children"] = {k: v.to_dict() for k, v in self.children.items()}
         result["id"] = self.id
         result["name"] = self.name
         if self.extras is not None:
@@ -33,7 +33,7 @@ class RootLevel:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> RootLevel:
         return cls(
-            children=data["children"],  # type: ignore[assignment]
+            children={k: MiddleLevel.from_dict(v) for k, v in data["children"].items()},  # type: ignore[union-attr]
             id=data["id"],  # type: ignore[assignment]
             name=data["name"],  # type: ignore[assignment]
             extras=data.get("extras"),  # type: ignore[assignment]

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/all_of_objects.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/all_of_objects.py.golden
@@ -14,3 +14,22 @@ class AllOfObjects:
     name: str
     active: bool | None = None
     metadata: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {}
+        result["id"] = self.id
+        result["name"] = self.name
+        if self.active is not None:
+            result["active"] = self.active
+        if self.metadata is not None:
+            result["metadata"] = self.metadata
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> AllOfObjects:
+        return cls(
+            id=data["id"],  # type: ignore[assignment]
+            name=data["name"],  # type: ignore[assignment]
+            active=data.get("active"),  # type: ignore[assignment]
+            metadata=data.get("metadata"),  # type: ignore[assignment]
+        )

--- a/tests/golden/python/python-requests/naming-conventions/naming_conventions_test/apis/default_api.py.golden
+++ b/tests/golden/python/python-requests/naming-conventions/naming_conventions_test/apis/default_api.py.golden
@@ -28,7 +28,7 @@ class DefaultApi:
         if kebab_case_param is not None:
             params["kebab-case-param"] = str(kebab_case_param)
         if kebab_case_array is not None:
-            params["kebab-case-array"] = str(kebab_case_array)
+            params["kebab-case-array"] = ",".join(str(v) for v in kebab_case_array)
         if pascal_case_param is not None:
             params["PascalCaseParam"] = str(pascal_case_param)
         if pascal_case_number is not None:

--- a/tests/golden/python/python-requests/petstore/petstore_api/apis/pet_api.py.golden
+++ b/tests/golden/python/python-requests/petstore/petstore_api/apis/pet_api.py.golden
@@ -44,7 +44,7 @@ class PetApi:
         """Find pets by tags."""
         path = "/pet/findByTags"
         params: dict[str, str] = {}
-        params["tags"] = str(tags)
+        params["tags"] = ",".join(str(v) for v in tags)
         response = self._client.request("GET", path, params=params)
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason, response.content)

--- a/tests/golden/python/python-requests/petstore/petstore_api/apis/user_api.py.golden
+++ b/tests/golden/python/python-requests/petstore/petstore_api/apis/user_api.py.golden
@@ -24,7 +24,7 @@ class UserApi:
     def create_users_with_list_input(self, *, body: list[User]) -> User:
         """Creates list of users with given input array."""
         path = "/user/createWithList"
-        response = self._client.request("POST", path, json=body)
+        response = self._client.request("POST", path, json=[item.to_dict() for item in body])
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason, response.content)
         return User.from_dict(response.json())

--- a/tests/golden/python/python-requests/type-aliases-intersection-allof/intersection_type_all_of_test/apis/default_api.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-intersection-allof/intersection_type_all_of_test/apis/default_api.py.golden
@@ -16,7 +16,7 @@ class DefaultApi:
     def test_intersection(self, *, body: Foo) -> Foo:
         """Test endpoint with intersection type."""
         path = "/test"
-        response = self._client.request("POST", path, json=body)
+        response = self._client.request("POST", path, json=body.to_dict())
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason, response.content)
-        return response.json()  # type: ignore[return-value]
+        return Foo.from_dict(response.json())

--- a/tests/golden/python/python-requests/type-aliases-intersection-allof/intersection_type_all_of_test/models/foo.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-intersection-allof/intersection_type_all_of_test/models/foo.py.golden
@@ -14,3 +14,21 @@ class Foo:
     name: str
     email: str
     created_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {}
+        result["id"] = self.id
+        result["name"] = self.name
+        result["email"] = self.email
+        if self.created_at is not None:
+            result["createdAt"] = self.created_at
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Foo:
+        return cls(
+            id=data["id"],  # type: ignore[assignment]
+            name=data["name"],  # type: ignore[assignment]
+            email=data["email"],  # type: ignore[assignment]
+            created_at=data.get("createdAt"),  # type: ignore[assignment]
+        )

--- a/tests/golden/python/python-requests/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/apis/default_api.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/apis/default_api.py.golden
@@ -16,10 +16,10 @@ class DefaultApi:
     def create_test(self, *, body: Baz) -> Baz:
         """Create test with intersection type."""
         path = "/test"
-        response = self._client.request("POST", path, json=body)
+        response = self._client.request("POST", path, json=body.to_dict())
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason, response.content)
-        return response.json()  # type: ignore[return-value]
+        return Baz.from_dict(response.json())
 
     def get_test(self, id: str) -> Baz:
         """Get test."""
@@ -27,4 +27,4 @@ class DefaultApi:
         response = self._client.request("GET", path)
         if response.status_code >= 400:
             raise ApiError(response.status_code, response.reason, response.content)
-        return response.json()  # type: ignore[return-value]
+        return Baz.from_dict(response.json())

--- a/tests/golden/python/python-requests/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/models/baz.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/models/baz.py.golden
@@ -19,3 +19,25 @@ class Baz:
     id: str
     status: Literal["active", "inactive", "pending"]
     meta_data: Bar | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {}
+        result["count1"] = self.count1
+        result["count2"] = self.count2
+        result["createdAt"] = self.created_at
+        result["id"] = self.id
+        result["status"] = self.status
+        if self.meta_data is not None:
+            result["metaData"] = self.meta_data.to_dict()
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> Baz:
+        return cls(
+            count1=data["count1"],  # type: ignore[assignment]
+            count2=data["count2"],  # type: ignore[assignment]
+            created_at=data["createdAt"],  # type: ignore[assignment]
+            id=data["id"],  # type: ignore[assignment]
+            status=data["status"],  # type: ignore[assignment]
+            meta_data=Bar.from_dict(data.get("metaData")) if data.get("metaData") is not None else None,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

- **Python allOf intersection**: add `to_dict`/`from_dict` methods to intersection dataclasses, expand `is_object_schema` to recognize them in API emit
- **Python array handling**: serialize `list[Model]` bodies with `to_dict`, use comma-join for array query params
- **Python map values**: recursively serialize `dict[str, Model]` with `to_dict`/`from_dict`
- **Go wildcard responses**: populate `Status4XX`/`Status5XX` fields by decoding body in range-matched default arm
- **Go additionalProperties**: emit `AdditionalProperties` field with custom `MarshalJSON`/`UnmarshalJSON` using `sigil_quote!`

## Test plan

- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all pass
- [x] `scripts/golden-build-go.sh` — 48/48
- [x] `scripts/golden-build-python.sh httpx` — 48/48
- [x] `scripts/golden-build-python.sh requests` — 48/48