### PR TITLE
refactor: migrate raw string building to sigil-stitch structured APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,9 +1380,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-stitch"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef030da7cfe1414a050c5defafecc84a9049681c868f71dbddcba27cd3d30808"
+checksum = "4f8f8601502d2b8c9d7e31631daeae614c4561dc1fcddf67eeb5660b5b738d5c"
 dependencies = [
  "pretty",
  "serde",
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858c81e364c0e80d483c1ee13571836c59f35c8f94e01ca1348068882ec7bf71"
+checksum = "b72475db01c5e17d453bec5d2592b78f768005c1cf2816ce9beec9947991be70"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.148"
 serde_norway = "0.9.42"
 serde_plain = "1.0.2"
-sigil-stitch = "0.5.0"
+sigil-stitch = "0.5.1"
 similar = "2.7.0"
 snafu = "0.8.9"
 toml = "0.9.8"

--- a/src/generators/go/http/sigil_emit.rs
+++ b/src/generators/go/http/sigil_emit.rs
@@ -26,6 +26,7 @@ use sigil_stitch::lang::go_lang::GoLang;
 use sigil_stitch::prelude::{CodeBlock, sigil_quote};
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
+use sigil_stitch::spec::import_spec::ImportSpec;
 use sigil_stitch::spec::modifiers::TypeKind;
 use sigil_stitch::spec::type_spec::TypeSpec;
 use sigil_stitch::type_name::TypeName;
@@ -92,11 +93,11 @@ fn emit_object(schema: &IrSchema, obj: &IrObject) -> Option<String> {
         tb = tb.add_field(build_struct_field(json_name, prop));
     }
 
+    let has_ap = obj.additional_properties.is_some();
     if let Some(ap_type) = &obj.additional_properties {
-        let value_type = go_type_str(ap_type);
         let ap_field = FieldSpec::builder(
             "AdditionalProperties",
-            TypeName::primitive(&format!("map[string]{value_type}")),
+            TypeName::map(TypeName::primitive("string"), go_type_name(ap_type)),
         )
         .tag("json:\"-\"")
         .doc("Additional properties not captured by defined fields.")
@@ -105,22 +106,20 @@ fn emit_object(schema: &IrSchema, obj: &IrObject) -> Option<String> {
         tb = tb.add_field(ap_field);
     }
 
-    let fb = FileSpec::builder(&format!("{}.go", name))
+    let mut fb = FileSpec::builder(&format!("{}.go", name))
         .header(package_header())
         .add_type(tb.build().ok()?);
-    let file = fb.build().ok()?;
-    let mut rendered = file.render(RENDER_WIDTH).ok()?;
 
-    if let Some(ap_type) = &obj.additional_properties {
-        let value_type = go_type_str(ap_type);
-        // Insert `import "encoding/json"` after the package declaration.
-        if let Some(pos) = rendered.find("\n\n") {
-            rendered.insert_str(pos + 1, "\nimport \"encoding/json\"\n");
-        }
-        rendered.push_str(&emit_marshal_json(&name));
-        rendered.push_str(&emit_unmarshal_json(&name, obj, &value_type));
+    if has_ap {
+        let value_type = go_type_str(obj.additional_properties.as_ref().unwrap());
+        fb = fb
+            .add_import(ImportSpec::named("encoding/json", "json"))
+            .add_raw(&emit_marshal_json(&name))
+            .add_raw(&emit_unmarshal_json(&name, obj, &value_type));
     }
 
+    let file = fb.build().ok()?;
+    let rendered = file.render(RENDER_WIDTH).ok()?;
     Some(rendered)
 }
 
@@ -151,7 +150,6 @@ fn json_tag(json_name: &str, required: bool, nullable: bool) -> String {
 
 fn emit_marshal_json(struct_name: &str) -> String {
     let cb = sigil_quote!(GoLang {
-        $L("")
         $L(format!("func (o {struct_name}) MarshalJSON() ([]byte, error)")) {
             $L(format!("type Plain {struct_name}"))
             $L("data, err := json.Marshal(Plain(o))")
@@ -189,7 +187,6 @@ fn emit_unmarshal_json(struct_name: &str, obj: &IrObject, value_type: &str) -> S
         .join(", ");
 
     let cb = sigil_quote!(GoLang {
-        $L("")
         $L(format!("func (o *{struct_name}) UnmarshalJSON(data []byte) error")) {
             $L(format!("type Plain {struct_name}"))
             $L("if err := json.Unmarshal(data, (*Plain)(o)); err != nil") {
@@ -308,16 +305,20 @@ fn emit_union(schema: &IrSchema, _union: &IrUnion) -> Option<String> {
 // ---------------------------------------------------------------------------
 
 fn emit_intersection(schema: &IrSchema, inter: &IrIntersection) -> Option<String> {
-    // Hand-rolled: Go embedded fields have no field name, which sigil's
-    // FieldSpec builder rejects. Format the struct directly.
     let name = schema.name.to_pascal_case();
-    let mut out = preamble(&name, schema.description.as_deref());
-    out.push_str(&format!("type {name} struct {{\n"));
-    for member in &inter.members {
-        out.push_str(&format!("\t{}\n", go_type_str(member)));
+    let mut tb = TypeSpec::builder(&name, TypeKind::Struct);
+    if let Some(doc) = &schema.description {
+        tb = tb.doc(doc);
     }
-    out.push_str("}\n");
-    Some(out)
+    for member in &inter.members {
+        tb = tb.add_embedded(go_type_name(member));
+    }
+
+    let fb = FileSpec::builder(&format!("{}.go", name))
+        .header(package_header())
+        .add_type(tb.build().ok()?);
+    let file = fb.build().ok()?;
+    file.render(RENDER_WIDTH).ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -397,7 +398,15 @@ fn preamble(_name: &str, doc: Option<&str>) -> String {
 /// `TypeName::primitive` with the Go identifier. Cross-package imports aren't
 /// needed within the `models/` tree.
 fn go_type_name(expr: &IrTypeExpr) -> TypeName {
-    TypeName::primitive(&go_type_str(expr))
+    match expr {
+        IrTypeExpr::Named(name) => TypeName::primitive(&name.to_pascal_case()),
+        IrTypeExpr::Primitive(p) => TypeName::primitive(go_primitive(p)),
+        IrTypeExpr::Array(inner) => TypeName::slice(go_type_name(inner)),
+        IrTypeExpr::Map(inner) => TypeName::map(TypeName::primitive("string"), go_type_name(inner)),
+        IrTypeExpr::Nullable(inner) => TypeName::pointer(go_type_name(inner)),
+        IrTypeExpr::StringLiteral(_) | IrTypeExpr::StringEnum(_) => TypeName::primitive("string"),
+        IrTypeExpr::Union(_) | IrTypeExpr::Any => TypeName::primitive("any"),
+    }
 }
 
 /// Map an IR type expression to a Go type as a bare string.

--- a/src/generators/go/http/sigil_emit_api.rs
+++ b/src/generators/go/http/sigil_emit_api.rs
@@ -718,7 +718,7 @@ fn pointerize_type_name(go_ty: &str) -> TypeName {
     if go_ty.starts_with('[') || go_ty.starts_with('*') || go_ty.starts_with("map[") {
         TypeName::raw(go_ty)
     } else {
-        TypeName::raw(&format!("*{go_ty}"))
+        TypeName::pointer(TypeName::raw(go_ty))
     }
 }
 

--- a/src/generators/python/httpx/emit_models.rs
+++ b/src/generators/python/httpx/emit_models.rs
@@ -499,7 +499,7 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion, ir: &IrSpec) -> Opti
 
     if !tu.variants.is_empty() {
         let helpers = build_tagged_union_helpers(&name, &snake_name, tu, ir);
-        file = file.add_raw(&helpers);
+        file = file.add_code(helpers);
     }
 
     file.build().ok()
@@ -510,8 +510,7 @@ fn build_tagged_union_helpers(
     snake_name: &str,
     tu: &IrTaggedUnion,
     ir: &IrSpec,
-) -> String {
-    let mut out = String::new();
+) -> CodeBlock {
     let tag_field = &tu.discriminator_field;
 
     // Only generate helpers for variants that resolve to Object schemas
@@ -528,113 +527,161 @@ fn build_tagged_union_helpers(
         })
         .collect();
 
+    let mut cb = CodeBlock::builder();
+
     if resolved_variants.is_empty() {
-        return out;
+        return cb.build_unwrap();
     }
 
     // from_dict
-    out.push('\n');
-    out.push_str(&format!(
-        "def {snake_name}_from_dict(data: dict[str, object]) -> {pascal_name}:\n"
-    ));
+    cb.add_line();
+    cb.begin_control_flow_with_open(
+        &format!("def {snake_name}_from_dict(data: dict[str, object]) -> {pascal_name}"),
+        (),
+        ":",
+    );
     match &tu.tagging {
         TaggingStyle::Internal => {
-            out.push_str(&format!("    _tag = data[\"{tag_field}\"]\n"));
+            cb.add_statement(&format!("_tag = data[\"{tag_field}\"]"), ());
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                out.push_str(&format!(
-                    "    {kw} _tag == \"{}\":\n        return {py_class}.from_dict(data)\n",
-                    variant.discriminator_value
-                ));
+                let cond = format!("_tag == \"{}\"", variant.discriminator_value);
+                emit_elif(&mut cb, i == 0, &cond, "");
+                cb.add_statement(&format!("return {py_class}.from_dict(data)"), ());
             }
+            cb.end_control_flow();
         }
         TaggingStyle::Adjacent { content_field } => {
-            out.push_str(&format!("    _tag = data[\"{tag_field}\"]\n"));
-            out.push_str(&format!(
-                "    _content = data[\"{content_field}\"]  # type: ignore[assignment]\n"
-            ));
+            cb.add_statement(&format!("_tag = data[\"{tag_field}\"]"), ());
+            cb.add_statement(
+                &format!("_content = data[\"{content_field}\"]  # type: ignore[assignment]"),
+                (),
+            );
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                out.push_str(&format!(
-                    "    {kw} _tag == \"{}\":\n        return {py_class}.from_dict(_content)  # type: ignore[arg-type]\n",
-                    variant.discriminator_value
-                ));
+                let cond = format!("_tag == \"{}\"", variant.discriminator_value);
+                emit_elif(&mut cb, i == 0, &cond, "");
+                cb.add_statement(
+                    &format!("return {py_class}.from_dict(_content)  # type: ignore[arg-type]"),
+                    (),
+                );
             }
+            cb.end_control_flow();
         }
         TaggingStyle::External => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                out.push_str(&format!(
-                    "    {kw} \"{}\" in data:\n        return {py_class}.from_dict(data[\"{}\"])  # type: ignore[arg-type]\n",
-                    variant.discriminator_value, variant.discriminator_value
-                ));
+                let cond = format!("\"{}\" in data", variant.discriminator_value);
+                emit_elif(&mut cb, i == 0, &cond, "");
+                cb.add_statement(
+                    &format!(
+                        "return {py_class}.from_dict(data[\"{}\"])  # type: ignore[arg-type]",
+                        variant.discriminator_value
+                    ),
+                    (),
+                );
             }
+            cb.end_control_flow();
         }
     }
-    out.push_str(&format!(
-        "    raise ValueError(f\"Unknown discriminator value for {pascal_name}: {{data}}\")\n"
-    ));
+    cb.add_statement(
+        &format!("raise ValueError(f\"Unknown discriminator value for {pascal_name}: {{data}}\")"),
+        (),
+    );
+    cb.end_control_flow();
 
     // to_dict
-    out.push('\n');
-    out.push_str(&format!(
-        "def {snake_name}_to_dict(obj: {pascal_name}) -> dict[str, object]:\n"
-    ));
+    cb.add_line();
+    cb.begin_control_flow_with_open(
+        &format!("def {snake_name}_to_dict(obj: {pascal_name}) -> dict[str, object]"),
+        (),
+        ":",
+    );
     let last_idx = resolved_variants.len() - 1;
     match &tu.tagging {
         TaggingStyle::Internal => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                let ignore = if i == last_idx {
+                let suffix = if i == last_idx {
                     "  # type: ignore[reportUnnecessaryIsInstance]"
                 } else {
                     ""
                 };
-                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
-                out.push_str("        result = obj.to_dict()\n");
-                out.push_str(&format!(
-                    "        result[\"{tag_field}\"] = \"{}\"\n",
-                    variant.discriminator_value
-                ));
-                out.push_str("        return result\n");
+                let cond = format!("isinstance(obj, {py_class})");
+                emit_elif(&mut cb, i == 0, &cond, suffix);
+                cb.add_statement("result = obj.to_dict()", ());
+                cb.add_statement(
+                    &format!(
+                        "result[\"{tag_field}\"] = \"{}\"",
+                        variant.discriminator_value
+                    ),
+                    (),
+                );
+                cb.add_statement("return result", ());
             }
+            cb.end_control_flow();
         }
         TaggingStyle::Adjacent { content_field } => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                let ignore = if i == last_idx {
+                let suffix = if i == last_idx {
                     "  # type: ignore[reportUnnecessaryIsInstance]"
                 } else {
                     ""
                 };
-                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
-                out.push_str(&format!(
-                    "        return {{\"{tag_field}\": \"{}\", \"{content_field}\": obj.to_dict()}}\n",
-                    variant.discriminator_value
-                ));
+                let cond = format!("isinstance(obj, {py_class})");
+                emit_elif(&mut cb, i == 0, &cond, suffix);
+                cb.add_statement(
+                    &format!(
+                        "return {{\"{tag_field}\": \"{}\", \"{content_field}\": obj.to_dict()}}",
+                        variant.discriminator_value
+                    ),
+                    (),
+                );
             }
+            cb.end_control_flow();
         }
         TaggingStyle::External => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                let ignore = if i == last_idx {
+                let suffix = if i == last_idx {
                     "  # type: ignore[reportUnnecessaryIsInstance]"
                 } else {
                     ""
                 };
-                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
-                out.push_str(&format!(
-                    "        return {{\"{}\": obj.to_dict()}}\n",
-                    variant.discriminator_value
-                ));
+                let cond = format!("isinstance(obj, {py_class})");
+                emit_elif(&mut cb, i == 0, &cond, suffix);
+                cb.add_statement(
+                    &format!(
+                        "return {{\"{}\": obj.to_dict()}}",
+                        variant.discriminator_value
+                    ),
+                    (),
+                );
             }
+            cb.end_control_flow();
         }
     }
-    out.push_str(&format!(
-        "    raise ValueError(f\"Unknown variant for {pascal_name}: {{type(obj)}}\")\n"
-    ));
+    cb.add_statement(
+        &format!("raise ValueError(f\"Unknown variant for {pascal_name}: {{type(obj)}}\")"),
+        (),
+    );
+    cb.end_control_flow();
 
-    out
+    cb.build_unwrap()
+}
+
+/// Emit an if/elif branch header for Python.
+///
+/// Uses `begin_control_flow_with_open` with an empty custom-open so that the
+/// colon and any trailing comment (suffix) are included directly in the format
+/// string, avoiding the issue where `BlockOpen` (`:`) would be placed after the
+/// suffix.
+fn emit_elif(
+    cb: &mut sigil_stitch::code_block::CodeBlockBuilder,
+    is_first: bool,
+    cond: &str,
+    suffix: &str,
+) {
+    let kw = if is_first { "if" } else { "elif" };
+    if !is_first {
+        cb.end_control_flow();
+    }
+    cb.begin_control_flow_with_open(&format!("{kw} {cond}:{suffix}"), (), "");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/generators/python/requests/emit_models.rs
+++ b/src/generators/python/requests/emit_models.rs
@@ -499,7 +499,7 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion, ir: &IrSpec) -> Opti
 
     if !tu.variants.is_empty() {
         let helpers = build_tagged_union_helpers(&name, &snake_name, tu, ir);
-        file = file.add_raw(&helpers);
+        file = file.add_code(helpers);
     }
 
     file.build().ok()
@@ -510,8 +510,7 @@ fn build_tagged_union_helpers(
     snake_name: &str,
     tu: &IrTaggedUnion,
     ir: &IrSpec,
-) -> String {
-    let mut out = String::new();
+) -> CodeBlock {
     let tag_field = &tu.discriminator_field;
 
     let resolved_variants: Vec<(&IrTaggedVariant, String)> = tu
@@ -527,113 +526,156 @@ fn build_tagged_union_helpers(
         })
         .collect();
 
+    let mut cb = CodeBlock::builder();
+
     if resolved_variants.is_empty() {
-        return out;
+        return cb.build_unwrap();
     }
 
     // from_dict
-    out.push('\n');
-    out.push_str(&format!(
-        "def {snake_name}_from_dict(data: dict[str, object]) -> {pascal_name}:\n"
-    ));
+    cb.add_line();
+    cb.begin_control_flow_with_open(
+        &format!("def {snake_name}_from_dict(data: dict[str, object]) -> {pascal_name}"),
+        (),
+        ":",
+    );
     match &tu.tagging {
         TaggingStyle::Internal => {
-            out.push_str(&format!("    _tag = data[\"{tag_field}\"]\n"));
+            cb.add_statement(&format!("_tag = data[\"{tag_field}\"]"), ());
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                out.push_str(&format!(
-                    "    {kw} _tag == \"{}\":\n        return {py_class}.from_dict(data)\n",
-                    variant.discriminator_value
-                ));
+                let cond = format!("_tag == \"{}\"", variant.discriminator_value);
+                emit_elif(&mut cb, i == 0, &cond, "");
+                cb.add_statement(&format!("return {py_class}.from_dict(data)"), ());
             }
+            cb.end_control_flow();
         }
         TaggingStyle::Adjacent { content_field } => {
-            out.push_str(&format!("    _tag = data[\"{tag_field}\"]\n"));
-            out.push_str(&format!(
-                "    _content = data[\"{content_field}\"]  # type: ignore[assignment]\n"
-            ));
+            cb.add_statement(&format!("_tag = data[\"{tag_field}\"]"), ());
+            cb.add_statement(
+                &format!("_content = data[\"{content_field}\"]  # type: ignore[assignment]"),
+                (),
+            );
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                out.push_str(&format!(
-                    "    {kw} _tag == \"{}\":\n        return {py_class}.from_dict(_content)  # type: ignore[arg-type]\n",
-                    variant.discriminator_value
-                ));
+                let cond = format!("_tag == \"{}\"", variant.discriminator_value);
+                emit_elif(&mut cb, i == 0, &cond, "");
+                cb.add_statement(
+                    &format!("return {py_class}.from_dict(_content)  # type: ignore[arg-type]"),
+                    (),
+                );
             }
+            cb.end_control_flow();
         }
         TaggingStyle::External => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                out.push_str(&format!(
-                    "    {kw} \"{}\" in data:\n        return {py_class}.from_dict(data[\"{}\"])  # type: ignore[arg-type]\n",
-                    variant.discriminator_value, variant.discriminator_value
-                ));
+                let cond = format!("\"{}\" in data", variant.discriminator_value);
+                emit_elif(&mut cb, i == 0, &cond, "");
+                cb.add_statement(
+                    &format!(
+                        "return {py_class}.from_dict(data[\"{}\"])  # type: ignore[arg-type]",
+                        variant.discriminator_value
+                    ),
+                    (),
+                );
             }
+            cb.end_control_flow();
         }
     }
-    out.push_str(&format!(
-        "    raise ValueError(f\"Unknown discriminator value for {pascal_name}: {{data}}\")\n"
-    ));
+    cb.add_statement(
+        &format!("raise ValueError(f\"Unknown discriminator value for {pascal_name}: {{data}}\")"),
+        (),
+    );
+    cb.end_control_flow();
 
     // to_dict
-    out.push('\n');
-    out.push_str(&format!(
-        "def {snake_name}_to_dict(obj: {pascal_name}) -> dict[str, object]:\n"
-    ));
+    cb.add_line();
+    cb.begin_control_flow_with_open(
+        &format!("def {snake_name}_to_dict(obj: {pascal_name}) -> dict[str, object]"),
+        (),
+        ":",
+    );
     let last_idx = resolved_variants.len() - 1;
     match &tu.tagging {
         TaggingStyle::Internal => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                let ignore = if i == last_idx {
+                let suffix = if i == last_idx {
                     "  # type: ignore[reportUnnecessaryIsInstance]"
                 } else {
                     ""
                 };
-                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
-                out.push_str("        result = obj.to_dict()\n");
-                out.push_str(&format!(
-                    "        result[\"{tag_field}\"] = \"{}\"\n",
-                    variant.discriminator_value
-                ));
-                out.push_str("        return result\n");
+                let cond = format!("isinstance(obj, {py_class})");
+                emit_elif(&mut cb, i == 0, &cond, suffix);
+                cb.add_statement("result = obj.to_dict()", ());
+                cb.add_statement(
+                    &format!(
+                        "result[\"{tag_field}\"] = \"{}\"",
+                        variant.discriminator_value
+                    ),
+                    (),
+                );
+                cb.add_statement("return result", ());
             }
+            cb.end_control_flow();
         }
         TaggingStyle::Adjacent { content_field } => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                let ignore = if i == last_idx {
+                let suffix = if i == last_idx {
                     "  # type: ignore[reportUnnecessaryIsInstance]"
                 } else {
                     ""
                 };
-                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
-                out.push_str(&format!(
-                    "        return {{\"{tag_field}\": \"{}\", \"{content_field}\": obj.to_dict()}}\n",
-                    variant.discriminator_value
-                ));
+                let cond = format!("isinstance(obj, {py_class})");
+                emit_elif(&mut cb, i == 0, &cond, suffix);
+                cb.add_statement(
+                    &format!(
+                        "return {{\"{tag_field}\": \"{}\", \"{content_field}\": obj.to_dict()}}",
+                        variant.discriminator_value
+                    ),
+                    (),
+                );
             }
+            cb.end_control_flow();
         }
         TaggingStyle::External => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
-                let kw = if i == 0 { "if" } else { "elif" };
-                let ignore = if i == last_idx {
+                let suffix = if i == last_idx {
                     "  # type: ignore[reportUnnecessaryIsInstance]"
                 } else {
                     ""
                 };
-                out.push_str(&format!("    {kw} isinstance(obj, {py_class}):{ignore}\n"));
-                out.push_str(&format!(
-                    "        return {{\"{}\": obj.to_dict()}}\n",
-                    variant.discriminator_value
-                ));
+                let cond = format!("isinstance(obj, {py_class})");
+                emit_elif(&mut cb, i == 0, &cond, suffix);
+                cb.add_statement(
+                    &format!(
+                        "return {{\"{}\": obj.to_dict()}}",
+                        variant.discriminator_value
+                    ),
+                    (),
+                );
             }
+            cb.end_control_flow();
         }
     }
-    out.push_str(&format!(
-        "    raise ValueError(f\"Unknown variant for {pascal_name}: {{type(obj)}}\")\n"
-    ));
+    cb.add_statement(
+        &format!("raise ValueError(f\"Unknown variant for {pascal_name}: {{type(obj)}}\")"),
+        (),
+    );
+    cb.end_control_flow();
 
-    out
+    cb.build_unwrap()
+}
+
+/// Emit an if/elif branch header for Python.
+fn emit_elif(
+    cb: &mut sigil_stitch::code_block::CodeBlockBuilder,
+    is_first: bool,
+    cond: &str,
+    suffix: &str,
+) {
+    let kw = if is_first { "if" } else { "elif" };
+    if !is_first {
+        cb.end_control_flow();
+    }
+    cb.begin_control_flow_with_open(&format!("{kw} {cond}:{suffix}"), (), "");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/generators/rust/common/emit_api.rs
+++ b/src/generators/rust/common/emit_api.rs
@@ -414,12 +414,9 @@ pub fn emit_response_struct(plan: &OpPlan<'_>, extra: Option<&ExtraDeriveConfig>
     tb = tb.visibility(Visibility::Public);
     tb = tb.doc(&format!("Response from `{}`.", plan.method_name));
 
-    let mut ann = AnnotationSpec::new("derive");
-    ann = ann.arg("Debug");
+    let mut ann = AnnotationSpec::new("derive").args(["Debug"]);
     if let Some(cfg) = extra {
-        for d in &cfg.derives {
-            ann = ann.arg(d);
-        }
+        ann = ann.args(cfg.derives.iter().map(|s| s.as_str()));
     }
     tb = tb.annotate(ann);
 


### PR DESCRIPTION
## Summary

- Bump sigil-stitch 0.5.0 → 0.5.1 and adopt new `TypeSpec::add_embedded()` and `AnnotationSpec::args(iter)` APIs
- **Go**: replace `format!()` string building with structured `TypeName` variants (`slice`, `map`, `pointer`), rewrite `emit_intersection()` to use `add_embedded()`, and eliminate post-render import injection in `emit_object()` by building the complete `FileSpec` upfront
- **Python**: replace `push_str` tagged-union helpers with `CodeBlock::builder()` and proper control-flow methods in both httpx and requests backends
- **Rust**: use `AnnotationSpec::args(iter)` for derive annotations instead of individual `.arg()` calls

## Test plan

- [x] All 1,177 golden tests pass with byte-identical output (no golden updates needed)
- [x] `cargo clippy` clean, zero warnings
- [x] `cargo fmt` applied