### PR TITLE
chore: bump version to 0.1.9, add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9]
+
+### Added
+
+- TypeScript: `toolchain = "vp"` config for vite-plus — generates `vite.config.ts` with type-aware linting, `vp pack` library build, and `vp check --no-fmt` type checking
+
+### Fixed
+
+- TypeScript: wildcard response codes (4XX, 5XX) now emit range checks instead of duplicate `status === 0` branches
+- TypeScript: split import collection into request-only and response-only sets so `toJSON` is only imported for request body types
+- TypeScript: empty-object `fromJSON`/`toJSON` converters use pass-through cast instead of empty destructure
+- TypeScript: vp toolchain emits `.mjs`/`.d.mts` paths in `package.json` to match `vp pack` output
+- Python: add `to_dict`/`from_dict` to allOf intersection dataclasses
+- Python: serialize `list[Model]` request bodies with `to_dict` mapping
+- Python: use comma-join for array query params instead of `str(list)`
+- Python: recursively serialize Map values containing object types
+- Go: populate `Status4XX`/`Status5XX` fields for wildcard response codes
+- Go: emit `AdditionalProperties` field with `MarshalJSON`/`UnmarshalJSON`
+
+### Changed
+
+- Bumped sigil-stitch 0.5.0 → 0.5.1
+- Internal: migrated raw `format!()` string building to sigil-stitch structured APIs (Go `TypeName`, `add_embedded`, Python `CodeBlock`, Rust `AnnotationSpec::args`)
+
 ## [0.1.8]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fixture-generator-additional-properties"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "axum",
  "axum-extra",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-enum-repr"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "axum",
  "axum-extra",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-petstore"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1003,7 +1003,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openapi-nexus"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 rust-version = "1.90"
 description = "OpenAPI 3.x multi-language code generator"


### PR DESCRIPTION
## Summary

- Bump workspace version 0.1.8 → 0.1.9
- Add changelog covering 5 commits since 0.1.8: vp toolchain feature, TypeScript/Python/Go fixes, sigil-stitch 0.5.1 upgrade

## Test plan

- [x] `cargo check` passes with updated lockfile
- [x] CI green