### PR TITLE
chore: bump sigil-stitch to v0.6.0, adopt %V verbatim strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,9 +1380,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-stitch"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e22823647c466463882c4241d6b968536fe865a209741a3b35d3d98c782cb5"
+checksum = "e449e04d6d0fdb1f403cd725536245661918a8b12e85bedcf3072ae12a33f25e"
 dependencies = [
  "pretty",
  "serde",
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9512e17dd9073acf7a9297ce6f3ae218c038a49608f51d712c88d25bcf5985"
+checksum = "90c3874fb2fe1270198dbe583670eb214fcba9649a53602d18ac9fe7d089cffd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.148"
 serde_norway = "0.9.42"
 serde_plain = "1.0.2"
-sigil-stitch = "0.5.3"
+sigil-stitch = "0.6.0"
 similar = "2.7.0"
 snafu = "0.8.9"
 toml = "0.9.8"

--- a/src/generators/go/http/sigil_emit.rs
+++ b/src/generators/go/http/sigil_emit.rs
@@ -149,28 +149,30 @@ fn json_tag(json_name: &str, required: bool, nullable: bool) -> String {
 }
 
 fn emit_marshal_json(struct_name: &str) -> String {
+    let func_sig = format!("func (o {struct_name}) MarshalJSON() ([]byte, error)");
+    let plain_alias = format!("type Plain {struct_name}");
     let cb = sigil_quote!(GoLang {
-        $L(format!("func (o {struct_name}) MarshalJSON() ([]byte, error)")) {
-            $L(format!("type Plain {struct_name}"))
-            $L("data, err := json.Marshal(Plain(o))")
-            $L("if err != nil") {
-                $L("return nil, err")
+        $L(func_sig) {
+            $L(plain_alias)
+            data, err := json.Marshal(Plain(o))
+            if err != nil {
+                return nil, err
             }
-            $L("if len(o.AdditionalProperties) == 0") {
-                $L("return data, nil")
+            if len(o.AdditionalProperties) == 0 {
+                return data, nil
             }
-            $L("var base map[string]json.RawMessage")
-            $L("if err := json.Unmarshal(data, &base); err != nil") {
-                $L("return nil, err")
+            var base map[string]json.RawMessage
+            if err := json.Unmarshal(data, &base); err != nil {
+                return nil, err
             }
-            $L("for k, v := range o.AdditionalProperties") {
-                $L("raw, err := json.Marshal(v)")
-                $L("if err != nil") {
-                    $L("return nil, err")
+            for k, v := range o.AdditionalProperties {
+                raw, err := json.Marshal(v)
+                if err != nil {
+                    return nil, err
                 }
-                $L("base[k] = raw")
+                base[k] = raw
             }
-            $L("return json.Marshal(base)")
+            return json.Marshal(base)
         }
     })
     .expect("MarshalJSON builds");
@@ -186,29 +188,34 @@ fn emit_unmarshal_json(struct_name: &str, obj: &IrObject, value_type: &str) -> S
         .collect::<Vec<_>>()
         .join(", ");
 
+    let func_sig = format!("func (o *{struct_name}) UnmarshalJSON(data []byte) error");
+    let plain_alias = format!("type Plain {struct_name}");
+    let known_decl = format!("known := map[string]bool{{{known_map}}}");
+    let make_map = format!("o.AdditionalProperties = make(map[string]{value_type})");
+    let var_parsed = format!("var parsed {value_type}");
     let cb = sigil_quote!(GoLang {
-        $L(format!("func (o *{struct_name}) UnmarshalJSON(data []byte) error")) {
-            $L(format!("type Plain {struct_name}"))
-            $L("if err := json.Unmarshal(data, (*Plain)(o)); err != nil") {
-                $L("return err")
+        $L(func_sig) {
+            $L(plain_alias)
+            if err := json.Unmarshal(data, (*Plain)(o)); err != nil {
+                return err
             }
-            $L("var raw map[string]json.RawMessage")
-            $L("if err := json.Unmarshal(data, &raw); err != nil") {
-                $L("return err")
+            var raw map[string]json.RawMessage
+            if err := json.Unmarshal(data, &raw); err != nil {
+                return err
             }
-            $L(format!("known := map[string]bool{{{known_map}}}"))
-            $L(format!("o.AdditionalProperties = make(map[string]{value_type})"))
-            $L("for k, v := range raw") {
-                $L("if known[k]") {
-                    $L("continue")
+            $L(known_decl)
+            $L(make_map)
+            for k, v := range raw {
+                if known[k] {
+                    continue
                 }
-                $L(format!("var parsed {value_type}"))
-                $L("if err := json.Unmarshal(v, &parsed); err != nil") {
-                    $L("continue")
+                $L(var_parsed)
+                if err := json.Unmarshal(v, &parsed); err != nil {
+                    continue
                 }
-                $L("o.AdditionalProperties[k] = parsed")
+                o.AdditionalProperties[k] = parsed
             }
-            $L("return nil")
+            return nil
         }
     })
     .expect("UnmarshalJSON builds");

--- a/src/generators/go/http/sigil_emit_api.rs
+++ b/src/generators/go/http/sigil_emit_api.rs
@@ -690,11 +690,12 @@ fn emit_decode_into(field: &str, go_ty: &str) -> CodeBlock {
             format!("resp.{field} = &payload"),
         )
     };
+    let var_decl = format!("var payload {elem_ty}");
     sigil_quote!(GoLang {
         $>
-        $L(format!("var payload {elem_ty}"))
-        $L("if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil") {
-            $L("return nil, fmt.Errorf(\"decode response: %w\", err)")
+        $L(var_decl)
+        if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil {
+            return nil, fmt.Errorf("decode response: %w", err)
         }
         $L(assignment)
         $<

--- a/src/generators/python/httpx/emit_api.rs
+++ b/src/generators/python/httpx/emit_api.rs
@@ -166,8 +166,8 @@ fn build_method_body(plan: &OpPlan<'_>, ir: &IrSpec, error_type: &TypeName) -> C
     let mut cb = CodeBlock::builder();
 
     // Path interpolation
-    let path_expr = if plan.path_params.is_empty() {
-        format!("\"{}\"", plan.op.path)
+    if plan.path_params.is_empty() {
+        cb.add_statement(&format!("path = \"{}\"", plan.op.path), ());
     } else {
         let mut path_template = plan.op.path.clone();
         for p in &plan.path_params {
@@ -175,9 +175,8 @@ fn build_method_body(plan: &OpPlan<'_>, ir: &IrSpec, error_type: &TypeName) -> C
             let replacement = format!("{{{}}}", p.var_name);
             path_template = path_template.replace(&placeholder, &replacement);
         }
-        format!("f\"{}\"", path_template)
-    };
-    cb.add_statement(&format!("path = {path_expr}"), ());
+        cb.add_statement("path = %V", VerbatimStrArg(path_template));
+    }
 
     // Query params
     let has_query = !plan.query_params.is_empty();
@@ -262,7 +261,7 @@ fn build_method_body(plan: &OpPlan<'_>, ir: &IrSpec, error_type: &TypeName) -> C
         (),
     );
 
-    // Error handling — %T for ApiError auto-import
+    // Error handling
     cb.add_statement("if response.status_code >= 400:%>", ());
     cb.add_statement(
         "raise %T(response.status_code, response.reason_phrase, response.content)%<",

--- a/src/generators/python/httpx/emit_models.rs
+++ b/src/generators/python/httpx/emit_models.rs
@@ -581,8 +581,10 @@ fn build_tagged_union_helpers(
         }
     }
     cb.add_statement(
-        &format!("raise ValueError(f\"Unknown discriminator value for {pascal_name}: {{data}}\")"),
-        (),
+        "raise ValueError(%V)",
+        VerbatimStrArg(format!(
+            "Unknown discriminator value for {pascal_name}: {{data}}"
+        )),
     );
     cb.end_control_flow();
 
@@ -640,8 +642,8 @@ fn build_tagged_union_helpers(
         }
     }
     cb.add_statement(
-        &format!("raise ValueError(f\"Unknown variant for {pascal_name}: {{type(obj)}}\")"),
-        (),
+        "raise ValueError(%V)",
+        VerbatimStrArg(format!("Unknown variant for {pascal_name}: {{type(obj)}}")),
     );
     cb.end_control_flow();
 

--- a/src/generators/python/requests/emit_api.rs
+++ b/src/generators/python/requests/emit_api.rs
@@ -166,8 +166,8 @@ fn build_method_body(plan: &OpPlan<'_>, ir: &IrSpec, error_type: &TypeName) -> C
     let mut cb = CodeBlock::builder();
 
     // Path interpolation
-    let path_expr = if plan.path_params.is_empty() {
-        format!("\"{}\"", plan.op.path)
+    if plan.path_params.is_empty() {
+        cb.add_statement(&format!("path = \"{}\"", plan.op.path), ());
     } else {
         let mut path_template = plan.op.path.clone();
         for p in &plan.path_params {
@@ -175,9 +175,8 @@ fn build_method_body(plan: &OpPlan<'_>, ir: &IrSpec, error_type: &TypeName) -> C
             let replacement = format!("{{{}}}", p.var_name);
             path_template = path_template.replace(&placeholder, &replacement);
         }
-        format!("f\"{}\"", path_template)
-    };
-    cb.add_statement(&format!("path = {path_expr}"), ());
+        cb.add_statement("path = %V", VerbatimStrArg(path_template));
+    }
 
     // Query params
     let has_query = !plan.query_params.is_empty();
@@ -262,7 +261,7 @@ fn build_method_body(plan: &OpPlan<'_>, ir: &IrSpec, error_type: &TypeName) -> C
         (),
     );
 
-    // Error handling — %T for ApiError auto-import
+    // Error handling
     cb.add_statement("if response.status_code >= 400:%>", ());
     cb.add_statement(
         "raise %T(response.status_code, response.reason, response.content)%<",

--- a/src/generators/python/requests/emit_models.rs
+++ b/src/generators/python/requests/emit_models.rs
@@ -580,8 +580,10 @@ fn build_tagged_union_helpers(
         }
     }
     cb.add_statement(
-        &format!("raise ValueError(f\"Unknown discriminator value for {pascal_name}: {{data}}\")"),
-        (),
+        "raise ValueError(%V)",
+        VerbatimStrArg(format!(
+            "Unknown discriminator value for {pascal_name}: {{data}}"
+        )),
     );
     cb.end_control_flow();
 
@@ -639,8 +641,8 @@ fn build_tagged_union_helpers(
         }
     }
     cb.add_statement(
-        &format!("raise ValueError(f\"Unknown variant for {pascal_name}: {{type(obj)}}\")"),
-        (),
+        "raise ValueError(%V)",
+        VerbatimStrArg(format!("Unknown variant for {pascal_name}: {{type(obj)}}")),
     );
     cb.end_control_flow();
 

--- a/src/generators/rust/common/emit_api.rs
+++ b/src/generators/rust/common/emit_api.rs
@@ -15,6 +15,7 @@ use crate::ir::types::{
 };
 use heck::{ToPascalCase, ToSnakeCase};
 use sigil_stitch::code_block::{CodeBlock, CodeBlockBuilder};
+use sigil_stitch::prelude::sigil_quote;
 use sigil_stitch::spec::annotation_spec::AnnotationSpec;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -141,35 +142,41 @@ fn emit_api_file(
     // Build struct + impl as a CodeBlock (lifetimes/generics don't fit TypeSpec)
     let mut body = CodeBlock::builder();
 
-    // Struct doc + declaration
-    body.add(&format!("/// API operations under the \"{tag}\" tag."), ());
-    body.add_line();
-    body.add(&format!("pub struct {struct_name}{struct_gen}"), ());
-    body.begin_control_flow("", ());
-    body.add(&format!("client: &'a Client{client_field_args},\n"), ());
-    body.end_control_flow();
-    body.add_line();
-
-    // Impl block
-    body.add(&format!("impl{impl_gen} {struct_name}{type_args}"), ());
-    body.begin_control_flow("", ());
-
-    // Constructor
-    body.add(
-        &format!("/// Create a new `{struct_name}` bound to the given client."),
-        (),
+    // Struct declaration via sigil_quote
+    let doc_struct = format!("/// API operations under the \"{tag}\" tag.");
+    let generics = struct_gen.as_str();
+    let client_type_suffix = client_field_args.as_str();
+    let client_field = format!("client: &'a Client{client_type_suffix},");
+    body.add_code(
+        sigil_quote!(RustLang {
+            $L(doc_struct)
+            pub struct $N(struct_name.as_str())$L(generics) {
+                $L(client_field)
+            }
+        })
+        .expect("struct sigil_quote builds"),
     );
     body.add_line();
-    body.add(
-        &format!("pub fn new(client: &'a Client{client_field_args}) -> Self"),
-        (),
+
+    // Impl block (kept open for method injection)
+    let impl_header = format!("impl{impl_gen} {struct_name}{type_args}");
+    body.add(&impl_header, ());
+    body.begin_control_flow("", ());
+
+    // Constructor via sigil_quote
+    let doc_ctor = format!("/// Create a new `{struct_name}` bound to the given client.");
+    let ctor_sig = format!("pub fn new(client: &'a Client{client_type_suffix}) -> Self");
+    body.add_code(
+        sigil_quote!(RustLang {
+            $L(doc_ctor)
+            $L(ctor_sig) {
+                Self {
+                    client,
+                }
+            }
+        })
+        .expect("constructor sigil_quote builds"),
     );
-    body.begin_control_flow("", ());
-    body.add("Self", ());
-    body.begin_control_flow("", ());
-    body.add("client,\n", ());
-    body.end_control_flow();
-    body.end_control_flow();
 
     // Methods
     for plan in &plans {

--- a/src/generators/rust/common/emit_models.rs
+++ b/src/generators/rust/common/emit_models.rs
@@ -226,7 +226,7 @@ fn emit_object(
                     $L(doc_comment_block(prop.description.as_deref().unwrap()).trim_end())
                 }
                 $if(escape_rust_keyword(&json_name.to_snake_case()) != *json_name) {
-                    $L(format!("#[serde(rename = \"{json_name}\")]"))
+                    #[serde(rename = $S(json_name))]
                 }
                 $if(!prop.required || prop.nullable) {
                     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -287,9 +287,9 @@ fn emit_enum(
         pub enum $N(name.as_str()) {
             $for((variant, wire) in variants.iter()) {
                 $if(variant != wire) {
-                    $L(format!("#[serde(rename = \"{}\")]", escape_str(wire)))
+                    #[serde(rename = $S(wire))]
                 }
-                $L(format!("{variant},"))
+                $N(variant.as_str()),
             }
         }
     })
@@ -339,7 +339,7 @@ fn emit_integer_enum(
         #[repr(i64)]
         pub enum $N(name.as_str()) {
             $for((variant_name, n) in int_variants.iter()) {
-                $L(format!("{variant_name} = {n},"))
+                $N(variant_name.as_str()) = $L(n.to_string()),
             }
         }
     })
@@ -467,7 +467,7 @@ fn emit_union(
         #[serde(untagged)]
         pub enum $N(name.as_str()) {
             $for((variant_name, rust_type) in variants.iter()) {
-                $L(format!("{variant_name}({rust_type}),"))
+                $N(variant_name.as_str())($L(rust_type.as_str())),
             }
         }
     })
@@ -581,7 +581,7 @@ fn emit_tagged_union(
                         $if(!rename_attr.is_empty()) {
                             $L(rename_attr.as_str())
                         }
-                        $L(format!("{variant_name},"))
+                        $N(variant_name.as_str()),
                     })
                     .ok()?
                 } else {
@@ -594,7 +594,7 @@ fn emit_tagged_union(
                             let optional = !prop.required || prop.nullable;
                             sigil_quote!(RustLang {
                                 $if(needs_rename) {
-                                    $L(format!("#[serde(rename = \"{json_name}\")]"))
+                                    #[serde(rename = $S(json_name.as_str()))]
                                 }
                                 $if(optional) {
                                     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -627,11 +627,11 @@ fn emit_tagged_union(
                         cb.add_line();
                     }
                     cb.add(&format!("{variant_name} {{\n%>"), ());
-                    for fb in field_blocks {
-                        cb.add_code(fb);
+                    for fb in &field_blocks {
+                        cb.add_code(fb.clone());
                     }
-                    for ab in additional_blocks {
-                        cb.add_code(ab);
+                    for ab in &additional_blocks {
+                        cb.add_code(ab.clone());
                     }
                     cb.add("%<},", ());
                     cb.build().ok()?
@@ -642,7 +642,7 @@ fn emit_tagged_union(
                     $if(!rename_attr.is_empty()) {
                         $L(rename_attr.as_str())
                     }
-                    $L(format!("{variant_name}({content_ty}),"))
+                    $N(variant_name.as_str())($L(content_ty.as_str())),
                 })
                 .ok()?
             }
@@ -652,7 +652,7 @@ fn emit_tagged_union(
                 $if(!rename_attr.is_empty()) {
                     $L(rename_attr.as_str())
                 }
-                $L(format!("{variant_name}({content_ty}),"))
+                $N(variant_name.as_str())($L(content_ty.as_str())),
             })
             .ok()?
         };
@@ -728,7 +728,7 @@ fn emit_intersection(
         pub struct $N(name.as_str()) {
             $for((field_name, rust_type) in fields.iter()) {
                 #[serde(flatten)]
-                $L(format!("pub {field_name}: {rust_type},"))
+                pub $N(field_name.as_str()): $L(rust_type.as_str()),
             }
         }
     })
@@ -761,7 +761,7 @@ fn build_utoipa_one_of_impl(name: &str, variant_types: &[String]) -> Option<Code
 
         impl utoipa::ToSchema for $N(name) {
             fn name() -> std::borrow::Cow<'static, str> {
-                $L(format!("std::borrow::Cow::Borrowed(\"{name}\")"))
+                std::borrow::Cow::Borrowed($S(name))
             }
         }
     })
@@ -789,7 +789,7 @@ fn build_string_enum_display(name: &str, variants: &[(String, String)]) -> Optio
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self {
                     $for((variant, wire_value) in variants.iter()) {
-                        $L(format!("{name}::{variant} => write!(f, {wire_value:?}),"))
+                        $N(name)::$N(variant.as_str()) => write!(f, $S(wire_value)),
                     }
                 }
             }

--- a/src/generators/typescript/fetch/sigil_emit_api.rs
+++ b/src/generators/typescript/fetch/sigil_emit_api.rs
@@ -545,7 +545,10 @@ fn emit_url_path(cb: &mut sigil_stitch::code_block::CodeBlockBuilder, op: &IrOpe
         .iter()
         .any(|p| matches!(p.location, IrParameterLocation::Path));
     let binding = if has_path_params { "let" } else { "const" };
-    cb.add(&format!("{} urlPath = `{}`;\n", binding, op.path), vec![]);
+    cb.add(
+        &format!("{binding} urlPath = %V;\n"),
+        vec![Arg::VerbatimStr(op.path.clone())],
+    );
 
     let names = resolve_param_names(op);
     for p in op
@@ -556,13 +559,9 @@ fn emit_url_path(cb: &mut sigil_stitch::code_block::CodeBlockBuilder, op: &IrOpe
         let resolved = resolved_param(&names, p);
         let original = &p.name;
         let access = request_parameters_access(&resolved);
-        // The backtick template and the ${...} must both survive into TS output.
         cb.add(
-            &format!(
-                "urlPath = urlPath.replace(`{{{}}}`, encodeURIComponent(String({})));\n",
-                original, access
-            ),
-            vec![],
+            &format!("urlPath = urlPath.replace(%V, encodeURIComponent(String({access})));\n"),
+            vec![Arg::VerbatimStr(format!("{{{original}}}"))],
         );
     }
 }


### PR DESCRIPTION
## Summary
- Bump `sigil-stitch` 0.5.3 → 0.6.0 (adds `%V` verbatim string literals, `CodeLang`/`RendererLang` split, shell fixes)
- Use `%V` / `VerbatimStrArg` for Python f-string generation — eliminates manual `f\"...\"` escaping in `emit_models.rs` and `emit_api.rs`
- Use `%V` / `Arg::VerbatimStr` for TypeScript template literal generation — eliminates manual backtick construction in `sigil_emit_api.rs`
- No output changes — all golden tests pass unchanged

## Test plan
- [x] `cargo test` — all 1100+ tests pass
- [x] `UPDATE_GOLDEN=1 cargo test` — zero golden file diffs
- [x] No new warnings or clippy issues