### PR TITLE
refactor: bump sigil-stitch to 0.6.6, eliminate $L workarounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,9 +1380,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sigil-stitch"
-version = "0.6.1"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8133249e74f54d112c38af557388a3e6fdea8f30a4698127eba9942b60c9d7e"
+checksum = "bfce2daaa97cab4f7c3a185c82caefa44bc178d8372f016134a84bdb661cb788"
 dependencies = [
  "pretty",
  "serde",
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.6.1"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584c482b81fb076307d601e9605a707fc330500403e354a325acca0958e0d252"
+checksum = "8ac4d4c7ed4dfc614eb9ba956a56d47a25fd096590b0e8e3e30098bc825a540a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.148"
 serde_norway = "0.9.42"
 serde_plain = "1.0.2"
-sigil-stitch = "0.6.1"
+sigil-stitch = "0.6.6"
 similar = "2.7.0"
 snafu = "0.8.9"
 toml = "0.9.8"
@@ -98,3 +98,4 @@ similar = { workspace = true, optional = true }
 [dev-dependencies]
 tracing-test.workspace = true
 openapi-nexus = { path = ".", features = ["test-utils"] }
+sigil-stitch.workspace = true

--- a/src/generators/go/http/sigil_emit.rs
+++ b/src/generators/go/http/sigil_emit.rs
@@ -149,11 +149,9 @@ fn json_tag(json_name: &str, required: bool, nullable: bool) -> String {
 }
 
 fn emit_marshal_json(struct_name: &str) -> String {
-    let func_sig = format!("func (o {struct_name}) MarshalJSON() ([]byte, error)");
-    let plain_alias = format!("type Plain {struct_name}");
     let cb = sigil_quote!(GoLang {
-        $L(func_sig) {
-            $L(plain_alias)
+        func (o $L(struct_name)) MarshalJSON() ([]byte, error) {
+            type Plain $L(struct_name)
             data, err := json.Marshal(Plain(o))
             if err != nil {
                 return nil, err
@@ -188,14 +186,11 @@ fn emit_unmarshal_json(struct_name: &str, obj: &IrObject, value_type: &str) -> S
         .collect::<Vec<_>>()
         .join(", ");
 
-    let func_sig = format!("func (o *{struct_name}) UnmarshalJSON(data []byte) error");
-    let plain_alias = format!("type Plain {struct_name}");
     let known_decl = format!("known := map[string]bool{{{known_map}}}");
     let make_map = format!("o.AdditionalProperties = make(map[string]{value_type})");
-    let var_parsed = format!("var parsed {value_type}");
     let cb = sigil_quote!(GoLang {
-        $L(func_sig) {
-            $L(plain_alias)
+        func (o *$L(struct_name)) UnmarshalJSON(data []byte) error {
+            type Plain $L(struct_name)
             if err := json.Unmarshal(data, (*Plain)(o)); err != nil {
                 return err
             }
@@ -209,7 +204,7 @@ fn emit_unmarshal_json(struct_name: &str, obj: &IrObject, value_type: &str) -> S
                 if known[k] {
                     continue
                 }
-                $L(var_parsed)
+                var parsed $L(value_type)
                 if err := json.Unmarshal(v, &parsed); err != nil {
                     continue
                 }
@@ -233,49 +228,50 @@ fn emit_enum(schema: &IrSchema, en: &IrEnum) -> Option<String> {
         IrEnumValueType::String => "string",
         IrEnumValueType::Integer => "int",
         IrEnumValueType::Number => "float64",
-        // Mixed-type enums aren't representable as a typed Go enum; fall back
-        // to a plain `interface{}` alias below so callers can pass either
-        // string or number.
         IrEnumValueType::Mixed => {
-            return Some(render_alias_file(
-                &name,
-                "any",
-                schema.description.as_deref(),
-            ));
+            return render_alias_file(&name, "any", schema.description.as_deref());
         }
     };
 
-    // `type Name <base>`
-    let type_decl = format!("type {name} {go_base}");
-
-    // `const ( A Name = "a"; B Name = "b" )`
-    let mut lines = Vec::with_capacity(en.values.len());
-    for v in &en.values {
-        let (const_name, rhs) = match en.value_type {
+    let const_lines: Vec<String> = en
+        .values
+        .iter()
+        .map(|v| match en.value_type {
             IrEnumValueType::String => {
                 let s = v.value.as_str()?;
-                (
-                    format!("{name}{}", s.to_pascal_case()),
-                    format!("\"{}\"", escape_go_string(s)),
-                )
+                Some(format!(
+                    "{}{} {name} = \"{}\"",
+                    name,
+                    s.to_pascal_case(),
+                    escape_go_string(s)
+                ))
             }
             IrEnumValueType::Integer | IrEnumValueType::Number => {
                 let n = v.value.as_number()?;
                 let pretty = n.to_string().replace(['-', '.'], "_");
-                (format!("{name}N{}", pretty), n.to_string())
+                Some(format!("{name}N{pretty} {name} = {n}"))
             }
             IrEnumValueType::Mixed => unreachable!(),
-        };
-        lines.push(format!("\t{const_name} {name} = {rhs}"));
-    }
+        })
+        .collect::<Option<Vec<_>>>()?;
 
-    let body = format!(
-        "{}\n{}\nconst (\n{}\n)\n",
-        preamble(&name, schema.description.as_deref()),
-        type_decl,
-        lines.join("\n"),
-    );
-    Some(body)
+    let cb = sigil_quote!(GoLang {
+        package $L(MODELS_PACKAGE)
+
+        $if(schema.description.is_some()) {
+            $comment(schema.description.as_deref().unwrap())
+        }
+        type $L(name) $L(go_base)
+
+        const (
+        $for(line in const_lines.iter()) {
+            $L(line.as_str())
+        }
+        )
+
+    })
+    .ok()?;
+    cb.render_standalone(&GoLang::new(), RENDER_WIDTH).ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -285,11 +281,7 @@ fn emit_enum(schema: &IrSchema, en: &IrEnum) -> Option<String> {
 fn emit_alias(schema: &IrSchema, expr: &IrTypeExpr) -> Option<String> {
     let name = schema.name.to_pascal_case();
     let rhs = go_type_str(expr);
-    Some(render_alias_file(
-        &name,
-        &rhs,
-        schema.description.as_deref(),
-    ))
+    render_alias_file(&name, &rhs, schema.description.as_deref())
 }
 
 // ---------------------------------------------------------------------------
@@ -300,11 +292,7 @@ fn emit_union(schema: &IrSchema, _union: &IrUnion) -> Option<String> {
     // Untagged unions in Go don't have a clean representation without a
     // discriminator. Use `interface{}` (any) and let callers type-assert.
     let name = schema.name.to_pascal_case();
-    Some(render_alias_file(
-        &name,
-        "any",
-        schema.description.as_deref(),
-    ))
+    render_alias_file(&name, "any", schema.description.as_deref())
 }
 
 // ---------------------------------------------------------------------------
@@ -354,7 +342,7 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<String> {
         Some(desc) => format!("{desc}\n\n{hint}"),
         None => hint,
     };
-    Some(render_alias_file(&name, "any", Some(&combined_doc)))
+    render_alias_file(&name, "any", Some(&combined_doc))
 }
 
 // ---------------------------------------------------------------------------
@@ -373,30 +361,17 @@ fn package_header() -> CodeBlock {
 ///
 /// Used for Alias, mixed-Enum, Union, and TaggedUnion (all reduce to a single
 /// type alias in this pass).
-fn render_alias_file(name: &str, rhs: &str, doc: Option<&str>) -> String {
-    let mut out = String::new();
-    out.push_str(&format!("package {MODELS_PACKAGE}\n\n"));
-    if let Some(d) = doc {
-        for line in d.lines() {
-            out.push_str(&format!("// {line}\n"));
-        }
-    }
-    out.push_str(&format!("type {name} = {rhs}\n"));
-    out
-}
+fn render_alias_file(name: &str, rhs: &str, doc: Option<&str>) -> Option<String> {
+    let cb = sigil_quote!(GoLang {
+        package $L(MODELS_PACKAGE)
 
-/// Preamble = `package models` + optional doc comment.
-///
-/// Used for hand-rolled files (enum const blocks, intersection structs) that
-/// don't fit sigil's builders cleanly.
-fn preamble(_name: &str, doc: Option<&str>) -> String {
-    let mut out = format!("package {MODELS_PACKAGE}\n\n");
-    if let Some(d) = doc {
-        for line in d.lines() {
-            out.push_str(&format!("// {line}\n"));
+        $if(doc.is_some()) {
+            $comment(doc.unwrap())
         }
-    }
-    out
+        type $L(name) = $L(rhs)
+    })
+    .ok()?;
+    cb.render_standalone(&GoLang::new(), RENDER_WIDTH).ok()
 }
 
 /// Map an IR type expression to a sigil `TypeName`.

--- a/src/generators/go/http/sigil_emit_api.rs
+++ b/src/generators/go/http/sigil_emit_api.rs
@@ -238,7 +238,7 @@ fn build_constructor(struct_name: &str, module_path: &str) -> FunSpec {
     let func_name = format!("New{struct_name}");
 
     let body = sigil_quote!(GoLang {
-        $L(format!("return &{struct_name}{{client: client}}"))
+        return &$N(struct_name){client: client};
     })
     .expect("constructor body builds");
 
@@ -690,10 +690,9 @@ fn emit_decode_into(field: &str, go_ty: &str) -> CodeBlock {
             format!("resp.{field} = &payload"),
         )
     };
-    let var_decl = format!("var payload {elem_ty}");
     sigil_quote!(GoLang {
         $>
-        $L(var_decl)
+        var $L("payload @{elem_ty}")
         if err := json.NewDecoder(httpResp.Body).Decode(&payload); err != nil {
             return nil, fmt.Errorf("decode response: %w", err)
         }

--- a/src/generators/python/httpx/emit_models.rs
+++ b/src/generators/python/httpx/emit_models.rs
@@ -547,7 +547,7 @@ fn build_tagged_union_helpers(
                 emit_elif(&mut cb, i == 0, false, &cond);
                 cb.add_statement(&format!("return {py_class}.from_dict(data)"), ());
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
         TaggingStyle::Adjacent { content_field } => {
             cb.add_statement(&format!("_tag = data[\"{tag_field}\"]"), ());
@@ -563,7 +563,7 @@ fn build_tagged_union_helpers(
                     (),
                 );
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
         TaggingStyle::External => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
@@ -577,7 +577,7 @@ fn build_tagged_union_helpers(
                     (),
                 );
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
     }
     cb.add_statement(
@@ -610,7 +610,7 @@ fn build_tagged_union_helpers(
                 );
                 cb.add_statement("return result", ());
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
         TaggingStyle::Adjacent { content_field } => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
@@ -624,7 +624,7 @@ fn build_tagged_union_helpers(
                     (),
                 );
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
         TaggingStyle::External => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
@@ -638,7 +638,7 @@ fn build_tagged_union_helpers(
                     (),
                 );
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
     }
     cb.add_statement(
@@ -657,7 +657,7 @@ fn emit_elif(
     cond: &str,
 ) {
     if !is_first {
-        cb.end_control_flow();
+        cb.end_control_flow_no_newline();
     }
     if is_last && !is_first {
         cb.begin_control_flow("else", ());

--- a/src/generators/python/requests/emit_models.rs
+++ b/src/generators/python/requests/emit_models.rs
@@ -546,7 +546,7 @@ fn build_tagged_union_helpers(
                 emit_elif(&mut cb, i == 0, false, &cond);
                 cb.add_statement(&format!("return {py_class}.from_dict(data)"), ());
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
         TaggingStyle::Adjacent { content_field } => {
             cb.add_statement(&format!("_tag = data[\"{tag_field}\"]"), ());
@@ -562,7 +562,7 @@ fn build_tagged_union_helpers(
                     (),
                 );
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
         TaggingStyle::External => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
@@ -576,7 +576,7 @@ fn build_tagged_union_helpers(
                     (),
                 );
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
     }
     cb.add_statement(
@@ -609,7 +609,7 @@ fn build_tagged_union_helpers(
                 );
                 cb.add_statement("return result", ());
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
         TaggingStyle::Adjacent { content_field } => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
@@ -623,7 +623,7 @@ fn build_tagged_union_helpers(
                     (),
                 );
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
         TaggingStyle::External => {
             for (i, (variant, py_class)) in resolved_variants.iter().enumerate() {
@@ -637,7 +637,7 @@ fn build_tagged_union_helpers(
                     (),
                 );
             }
-            cb.end_control_flow();
+            cb.end_control_flow_no_newline();
         }
     }
     cb.add_statement(
@@ -656,7 +656,7 @@ fn emit_elif(
     cond: &str,
 ) {
     if !is_first {
-        cb.end_control_flow();
+        cb.end_control_flow_no_newline();
     }
     if is_last && !is_first {
         cb.begin_control_flow("else", ());

--- a/src/generators/rust/common/emit_api.rs
+++ b/src/generators/rust/common/emit_api.rs
@@ -165,11 +165,10 @@ fn emit_api_file(
 
     // Constructor via sigil_quote
     let doc_ctor = format!("/// Create a new `{struct_name}` bound to the given client.");
-    let ctor_sig = format!("pub fn new(client: &'a Client{client_type_suffix}) -> Self");
     body.add_code(
         sigil_quote!(RustLang {
             $L(doc_ctor)
-            $L(ctor_sig) {
+            pub fn $L("new(client: &'a Client@{client_type_suffix}) -> Self") {
                 Self {
                     client,
                 }

--- a/src/generators/rust/common/emit_models.rs
+++ b/src/generators/rust/common/emit_models.rs
@@ -176,12 +176,12 @@ fn derive_attr(base: &str, extra: Option<&ExtraDeriveConfig>) -> String {
                 .filter(|d| !base_set.contains(d))
                 .collect();
             if unique_extra.is_empty() {
-                format!("#[derive({base})]")
+                format!("derive({base})")
             } else {
-                format!("#[derive({base}, {})]", unique_extra.join(", "))
+                format!("derive({base}, {})", unique_extra.join(", "))
             }
         }
-        _ => format!("#[derive({base})]"),
+        _ => format!("derive({base})"),
     }
 }
 
@@ -219,7 +219,7 @@ fn emit_object(
         $if(schema.description.is_some()) {
             $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
         }
-        $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+        $attr(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
         pub struct $N(name.as_str()) {
             $for((json_name, prop) in obj.properties.iter()) {
                 $if(prop.description.is_some()) {
@@ -230,14 +230,14 @@ fn emit_object(
                 }
                 $if(!prop.required || prop.nullable) {
                     #[serde(skip_serializing_if = "Option::is_none", default)]
-                    $L(format!("pub {}: Option<{}>,", escape_rust_keyword(&json_name.to_snake_case()), rust_type_str_model(&prop.type_expr)))
+                    pub $L("@{escape_rust_keyword(&json_name.to_snake_case())}: Option<@{rust_type_str_model(&prop.type_expr)}>,")
                 } $else {
-                    $L(format!("pub {}: {},", escape_rust_keyword(&json_name.to_snake_case()), rust_type_str_model(&prop.type_expr)))
+                    pub $L("@{escape_rust_keyword(&json_name.to_snake_case())}: @{rust_type_str_model(&prop.type_expr)},")
                 }
             }
             $if(obj.additional_properties.is_some()) {
                 #[serde(flatten)]
-                $L(format!("pub additional_properties: std::collections::HashMap<String, {}>,", rust_type_str_model(obj.additional_properties.as_ref().unwrap())))
+                pub $L("additional_properties: std::collections::HashMap<String, @{rust_type_str_model(obj.additional_properties.as_ref().unwrap())}>,")
             }
         }
     })
@@ -283,7 +283,7 @@ fn emit_enum(
         $if(schema.description.is_some()) {
             $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
         }
-        $L(derive_attr("Debug, Clone, PartialEq, Eq, Serialize, Deserialize", extra))
+        $attr(derive_attr("Debug, Clone, PartialEq, Eq, Serialize, Deserialize", extra))
         pub enum $N(name.as_str()) {
             $for((variant, wire) in variants.iter()) {
                 $if(variant != wire) {
@@ -335,7 +335,7 @@ fn emit_integer_enum(
         $if(schema.description.is_some()) {
             $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
         }
-        $L(derive_attr("Debug, Clone, Copy, PartialEq, Eq, Serialize_repr, Deserialize_repr", extra))
+        $attr(derive_attr("Debug, Clone, Copy, PartialEq, Eq, Serialize_repr, Deserialize_repr", extra))
         #[repr(i64)]
         pub enum $N(name.as_str()) {
             $for((variant_name, n) in int_variants.iter()) {
@@ -391,7 +391,7 @@ fn emit_alias(
             $if(schema.description.is_some()) {
                 $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
             }
-            $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+            $attr(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
             #[serde(transparent)]
             pub struct $N(name.as_str())(pub $T(rhs_type));
         })
@@ -463,7 +463,7 @@ fn emit_union(
         $if(schema.description.is_some()) {
             $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
         }
-        $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+        $attr(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
         #[serde(untagged)]
         pub enum $N(name.as_str()) {
             $for((variant_name, rust_type) in variants.iter()) {
@@ -534,14 +534,11 @@ fn emit_tagged_union(
 
     let serde_tag_attr = match &tu.tagging {
         TaggingStyle::Internal => {
-            format!(
-                "#[serde(tag = \"{}\")]",
-                escape_str(&tu.discriminator_field)
-            )
+            format!("serde(tag = \"{}\")", escape_str(&tu.discriminator_field))
         }
         TaggingStyle::Adjacent { content_field } => {
             format!(
-                "#[serde(tag = \"{}\", content = \"{}\")]",
+                "serde(tag = \"{}\", content = \"{}\")",
                 escape_str(&tu.discriminator_field),
                 escape_str(content_field)
             )
@@ -560,7 +557,7 @@ fn emit_tagged_union(
 
         let rename_attr = if variant_name != variant.discriminator_value {
             format!(
-                "#[serde(rename = \"{}\")]",
+                "serde(rename = \"{}\")",
                 escape_str(&variant.discriminator_value)
             )
         } else {
@@ -579,7 +576,7 @@ fn emit_tagged_union(
                 if non_tag_fields.is_empty() && !has_additional {
                     sigil_quote!(RustLang {
                         $if(!rename_attr.is_empty()) {
-                            $L(rename_attr.as_str())
+                            $attr(rename_attr.as_str())
                         }
                         $N(variant_name.as_str()),
                     })
@@ -623,7 +620,7 @@ fn emit_tagged_union(
 
                     let mut cb = CodeBlock::builder();
                     if !rename_attr.is_empty() {
-                        cb.add(&rename_attr, ());
+                        cb.add(&format!("#[{rename_attr}]"), ());
                         cb.add_line();
                     }
                     cb.add(&format!("{variant_name} {{\n%>"), ());
@@ -640,7 +637,7 @@ fn emit_tagged_union(
                 let content_ty = rust_type_str_model(&variant.content_type);
                 sigil_quote!(RustLang {
                     $if(!rename_attr.is_empty()) {
-                        $L(rename_attr.as_str())
+                        $attr(rename_attr.as_str())
                     }
                     $N(variant_name.as_str())($L(content_ty.as_str())),
                 })
@@ -650,7 +647,7 @@ fn emit_tagged_union(
             let content_ty = rust_type_str_model(&variant.content_type);
             sigil_quote!(RustLang {
                 $if(!rename_attr.is_empty()) {
-                    $L(rename_attr.as_str())
+                    $attr(rename_attr.as_str())
                 }
                 $N(variant_name.as_str())($L(content_ty.as_str())),
             })
@@ -664,9 +661,9 @@ fn emit_tagged_union(
         $if(schema.description.is_some()) {
             $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
         }
-        $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+        $attr(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
         $if(!serde_tag_attr.is_empty()) {
-            $L(serde_tag_attr.as_str())
+            $attr(serde_tag_attr.as_str())
         }
         pub enum $N(name.as_str()) {
             $C_each(variant_blocks);
@@ -724,7 +721,7 @@ fn emit_intersection(
         $if(schema.description.is_some()) {
             $L(doc_comment_block(schema.description.as_deref().unwrap()).trim_end())
         }
-        $L(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
+        $attr(derive_attr("Debug, Clone, Serialize, Deserialize", extra))
         pub struct $N(name.as_str()) {
             $for((field_name, rust_type) in fields.iter()) {
                 #[serde(flatten)]

--- a/src/generators/typescript/fetch/codegen.rs
+++ b/src/generators/typescript/fetch/codegen.rs
@@ -4,6 +4,8 @@ use std::error::Error;
 
 use heck::{ToKebabCase as _, ToLowerCamelCase as _, ToPascalCase as _, ToSnakeCase as _};
 
+use sigil_stitch::lang::typescript::TypeScript;
+
 use super::config::TypeScriptFetchConfig;
 use super::config::typescript_fetch_config::Toolchain;
 use super::project_files::{render_index_file, render_readme_file, render_runtime_file};
@@ -50,13 +52,14 @@ impl TypeScriptFetchCodeGenerator {
         &self,
         ir: &crate::ir::types::IrSpec,
     ) -> Result<Vec<FileInfo>, Box<dyn Error + Send + Sync>> {
+        let ts = TypeScript::new().with_indent(&self.config.indent);
         let flags = super::sigil_emit::EmitFlags {
             emit_enum_constants: self.config.emit_enum_constants,
             emit_type_guards: self.config.emit_type_guards,
             property_naming_camel_case: self.config.property_naming
                 == super::config::PropertyNaming::CamelCase,
         };
-        let mut files = super::sigil_emit::generate_model_files(ir, flags).map_err(|msg| {
+        let mut files = super::sigil_emit::generate_model_files(ir, flags, &ts).map_err(|msg| {
             Box::<dyn Error + Send + Sync>::from(format!("sigil_emit model generation: {msg}"))
         })?;
 
@@ -168,9 +171,11 @@ impl TypeScriptFetchCodeGenerator {
         &self,
         ir: &crate::ir::types::IrSpec,
     ) -> Result<Vec<FileInfo>, Box<dyn Error + Send + Sync>> {
+        let ts = TypeScript::new().with_indent(&self.config.indent);
         let mut files = super::sigil_emit_api::generate_api_files(
             ir,
             self.config.property_naming == super::config::PropertyNaming::CamelCase,
+            &ts,
         )
         .map_err(|msg| {
             Box::<dyn Error + Send + Sync>::from(format!("sigil_emit_api generation: {msg}"))

--- a/src/generators/typescript/fetch/config/typescript_fetch_config.rs
+++ b/src/generators/typescript/fetch/config/typescript_fetch_config.rs
@@ -95,6 +95,14 @@ pub struct TypeScriptFetchConfig {
     /// - `vp`: vite-plus with type-aware linting and type checking.
     #[serde(default)]
     pub toolchain: Toolchain,
+
+    /// Indent string for generated TypeScript (e.g., `"  "`, `"    "`, `"\t"`).
+    #[serde(default = "default_indent")]
+    pub indent: String,
+}
+
+fn default_indent() -> String {
+    "  ".to_string()
 }
 
 fn default_file_naming_convention() -> NamingConvention {
@@ -171,6 +179,7 @@ impl Default for TypeScriptFetchConfig {
             emit_type_guards: false,
             property_naming: PropertyNaming::default(),
             toolchain: Toolchain::default(),
+            indent: default_indent(),
         }
     }
 }

--- a/src/generators/typescript/fetch/sigil_emit.rs
+++ b/src/generators/typescript/fetch/sigil_emit.rs
@@ -20,6 +20,7 @@ use crate::ir::types::{
 };
 use heck::{ToLowerCamelCase, ToPascalCase};
 use sigil_stitch::code_block::{Arg, CodeBlock};
+use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::prelude::sigil_quote;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -143,23 +144,24 @@ pub fn emit_model_file(
     schema: &IrSchema,
     flags: EmitFlags,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Option<FileSpec> {
     match &schema.kind {
-        IrSchemaKind::Object(obj) => emit_object_file(schema, obj, flags, convertible),
-        IrSchemaKind::Enum(en) => emit_enum_file_from(schema, en, flags),
-        IrSchemaKind::Alias(expr) => emit_alias_file(schema, expr),
-        IrSchemaKind::Union(u) => emit_union_file(schema, u, flags, convertible),
-        IrSchemaKind::Intersection(i) => emit_intersection_file(schema, i, flags, convertible),
-        IrSchemaKind::TaggedUnion(tu) => emit_tagged_union_file(schema, tu, flags, convertible),
+        IrSchemaKind::Object(obj) => emit_object_file(schema, obj, flags, convertible, ts),
+        IrSchemaKind::Enum(en) => emit_enum_file_from(schema, en, flags, ts),
+        IrSchemaKind::Alias(expr) => emit_alias_file(schema, expr, ts),
+        IrSchemaKind::Union(u) => emit_union_file(schema, u, flags, convertible, ts),
+        IrSchemaKind::Intersection(i) => emit_intersection_file(schema, i, flags, convertible, ts),
+        IrSchemaKind::TaggedUnion(tu) => emit_tagged_union_file(schema, tu, flags, convertible, ts),
     }
 }
 
 /// Back-compat alias used by the enum prototype test. Prefer `emit_model_file`.
-pub fn emit_enum_file(schema: &IrSchema) -> Option<FileSpec> {
+pub fn emit_enum_file(schema: &IrSchema, ts: &TypeScript) -> Option<FileSpec> {
     let IrSchemaKind::Enum(en) = &schema.kind else {
         return None;
     };
-    emit_enum_file_from(schema, en, EmitFlags::default())
+    emit_enum_file_from(schema, en, EmitFlags::default(), ts)
 }
 
 fn emit_object_file(
@@ -167,11 +169,12 @@ fn emit_object_file(
     obj: &IrObject,
     flags: EmitFlags,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
 
     if flags.property_naming_camel_case {
-        return emit_object_file_camel_case(schema, obj, &name, convertible);
+        return emit_object_file_camel_case(schema, obj, &name, convertible, ts);
     }
 
     let mut tb = TypeSpec::builder(&name, TypeKind::Interface).visibility(Visibility::Public);
@@ -184,7 +187,7 @@ fn emit_object_file(
     }
 
     let filename = format!("{}.ts", name);
-    FileSpec::builder(&filename)
+    FileSpec::builder_with(&filename, ts.clone())
         .add_type(tb.build().ok()?)
         .build()
         .ok()
@@ -197,6 +200,7 @@ fn emit_object_file_camel_case(
     obj: &IrObject,
     name: &str,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Option<FileSpec> {
     let wire_name = format!("{}$Wire", name);
     let filename = format!("{}.ts", name);
@@ -227,7 +231,7 @@ fn emit_object_file_camel_case(
     let from_json = build_from_json_fn(name, &wire_name, obj, convertible)?;
     let to_json = build_to_json_fn(name, &wire_name, obj, convertible)?;
 
-    let mut fb = FileSpec::builder(&filename);
+    let mut fb = FileSpec::builder_with(&filename, ts.clone());
     fb = fb.add_type(wire_tb.build().ok()?);
     fb = fb.add_type(ergo_tb.build().ok()?);
 
@@ -427,26 +431,26 @@ fn build_from_json_fn(
             let ergo_key = obj_literal_key(&camel);
             let wire_access = wire_field_access(&prop.name);
             let conv = from_json_expr(&prop.type_expr, &wire_access, !prop.required, convertible);
-            CodeBlock::of(&format!("    {ergo_key}: {conv},"), ())
+            CodeBlock::of(&format!("{ergo_key}: {conv},"), ())
         })
         .collect::<Result<_, _>>()
         .ok()?;
 
     if obj.properties.is_empty() {
         return sigil_quote!(TypeScript {
-            $L(format!("export function {fn_name}(json: {wire_name}): {name} {{"))
-            $L(format!("  return json as unknown as {name};"))
-            $L("}")
+            export function $N(fn_name)(json: $N(wire_name)): $N(name) {
+                return json as unknown as $N(name);
+            }
         })
         .ok();
     }
 
     sigil_quote!(TypeScript {
-        $L(format!("export function {fn_name}(json: {wire_name}): {name} {{"))
-        $L("  return {")
+        export function $N(fn_name)(json: $N(wire_name)): $N(name) {
+        return {
         $C_each(fields);
-        $L("  };")
-        $L("}")
+        };
+        }
     })
     .ok()
 }
@@ -467,26 +471,26 @@ fn build_to_json_fn(
             let wire_key = obj_literal_key(&prop.name);
             let ergo_access = ergo_field_access(&camel);
             let conv = to_json_expr(&prop.type_expr, &ergo_access, !prop.required, convertible);
-            CodeBlock::of(&format!("    {wire_key}: {conv},"), ())
+            CodeBlock::of(&format!("{wire_key}: {conv},"), ())
         })
         .collect::<Result<_, _>>()
         .ok()?;
 
     if obj.properties.is_empty() {
         return sigil_quote!(TypeScript {
-            $L(format!("export function {fn_name}(value: {name}): {wire_name} {{"))
-            $L(format!("  return value as unknown as {wire_name};"))
-            $L("}")
+            export function $N(fn_name)(value: $N(name)): $N(wire_name) {
+                return value as unknown as $N(wire_name);
+            }
         })
         .ok();
     }
 
     sigil_quote!(TypeScript {
-        $L(format!("export function {fn_name}(value: {name}): {wire_name} {{"))
-        $L("  return {")
+        export function $N(fn_name)(value: $N(name)): $N(wire_name) {
+        return {
         $C_each(fields);
-        $L("  };")
-        $L("}")
+        };
+        }
     })
     .ok()
 }
@@ -666,17 +670,22 @@ fn collect_named_refs_from_expr(
 ///
 /// Handles string / integer / number / mixed value types. Returns `None` if
 /// any enum value can't be rendered as a TS literal.
-fn emit_enum_file_from(schema: &IrSchema, en: &IrEnum, flags: EmitFlags) -> Option<FileSpec> {
+fn emit_enum_file_from(
+    schema: &IrSchema,
+    en: &IrEnum,
+    flags: EmitFlags,
+    ts: &TypeScript,
+) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
     let union_body = enum_union_body(en)?;
 
     let type_alias = sigil_quote!(TypeScript {
-        export type $N(name.as_str()) = $L(union_body.as_str());
+        export type $N(name.as_str()) = $L(union_body);
     })
     .ok()?;
 
     let filename = format!("{}.ts", name);
-    let mut fb = FileSpec::builder(&filename);
+    let mut fb = FileSpec::builder_with(&filename, ts.clone());
     if let Some(doc) = &schema.description {
         // FileSpec has no structural doc slot — use a raw prelude comment.
         fb = fb.add_raw(&format!("/** {doc} */\n"));
@@ -720,14 +729,14 @@ fn build_enum_const_object(name: &str, en: &IrEnum) -> Option<CodeBlock> {
             } else {
                 format!("'{key}'")
             };
-            CodeBlock::of(&format!("    {key_lit}: {val_literal},"), ()).ok()
+            CodeBlock::of(&format!("  {key_lit}: {val_literal},"), ()).ok()
         })
         .collect();
 
     sigil_quote!(TypeScript {
-        $L(format!("export const {name} = {{"))
-        $C_each(entries);
-        $L("};")
+        export const $N(name) = {
+            $C_each(entries);
+        }
     })
     .ok()
 }
@@ -747,7 +756,7 @@ fn is_valid_ts_identifier(s: &str) -> bool {
 
 /// Alias file: `export type Name = Inner;` — where `Inner` may be a named ref
 /// (import auto-emitted), a primitive, a readonly array, etc.
-fn emit_alias_file(schema: &IrSchema, expr: &IrTypeExpr) -> Option<FileSpec> {
+fn emit_alias_file(schema: &IrSchema, expr: &IrTypeExpr, ts: &TypeScript) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
     let rhs = type_expr_to_typename(expr);
 
@@ -757,7 +766,7 @@ fn emit_alias_file(schema: &IrSchema, expr: &IrTypeExpr) -> Option<FileSpec> {
     .ok()?;
 
     let filename = format!("{}.ts", name);
-    let mut fb = FileSpec::builder(&filename);
+    let mut fb = FileSpec::builder_with(&filename, ts.clone());
     if let Some(doc) = &schema.description {
         fb = fb.add_raw(&format!("/** {doc} */\n"));
     }
@@ -773,11 +782,12 @@ fn emit_union_file(
     union: &IrUnion,
     flags: EmitFlags,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
 
     if flags.property_naming_camel_case && convertible.contains(&schema.name) {
-        return emit_union_file_camel_case(schema, union, &name, convertible);
+        return emit_union_file_camel_case(schema, union, &name, convertible, ts);
     }
 
     let mut members: Vec<TypeName> = union.members.iter().map(type_expr_to_typename).collect();
@@ -792,7 +802,7 @@ fn emit_union_file(
     .ok()?;
 
     let filename = format!("{}.ts", name);
-    let mut fb = FileSpec::builder(&filename);
+    let mut fb = FileSpec::builder_with(&filename, ts.clone());
     if let Some(doc) = &schema.description {
         fb = fb.add_raw(&format!("/** {doc} */\n"));
     }
@@ -808,6 +818,7 @@ fn emit_intersection_file(
     intersection: &IrIntersection,
     flags: EmitFlags,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Option<FileSpec> {
     if intersection.members.is_empty() {
         return None;
@@ -815,7 +826,7 @@ fn emit_intersection_file(
     let name = schema.name.to_pascal_case();
 
     if flags.property_naming_camel_case && convertible.contains(&schema.name) {
-        return emit_intersection_file_camel_case(schema, intersection, &name, convertible);
+        return emit_intersection_file_camel_case(schema, intersection, &name, convertible, ts);
     }
 
     let members: Vec<TypeName> = intersection
@@ -831,7 +842,7 @@ fn emit_intersection_file(
     .ok()?;
 
     let filename = format!("{}.ts", name);
-    let mut fb = FileSpec::builder(&filename);
+    let mut fb = FileSpec::builder_with(&filename, ts.clone());
     if let Some(doc) = &schema.description {
         fb = fb.add_raw(&format!("/** {doc} */\n"));
     }
@@ -852,6 +863,7 @@ fn emit_tagged_union_file(
     tu: &IrTaggedUnion,
     flags: EmitFlags,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Option<FileSpec> {
     if tu.variants.is_empty() {
         return None;
@@ -860,7 +872,7 @@ fn emit_tagged_union_file(
     let name = schema.name.to_pascal_case();
 
     if flags.property_naming_camel_case {
-        return emit_tagged_union_file_camel_case(schema, tu, &name, flags, convertible);
+        return emit_tagged_union_file_camel_case(schema, tu, &name, flags, convertible, ts);
     }
 
     // Build `export type Name = <piece> | <piece>;` where each piece
@@ -893,7 +905,7 @@ fn emit_tagged_union_file(
     let code = cb.build().ok()?;
 
     let filename = format!("{}.ts", name);
-    let mut fb = FileSpec::builder(&filename);
+    let mut fb = FileSpec::builder_with(&filename, ts.clone());
     if let Some(doc) = &schema.description {
         fb = fb.add_raw(&format!("/** {doc} */\n"));
     }
@@ -916,6 +928,7 @@ fn emit_tagged_union_file_camel_case(
     name: &str,
     flags: EmitFlags,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Option<FileSpec> {
     let wire_name = format!("{}$Wire", name);
     let filename = format!("{}.ts", name);
@@ -968,7 +981,7 @@ fn emit_tagged_union_file_camel_case(
     let from_json = build_tagged_union_from_json(name, &wire_name, tu, convertible)?;
     let to_json = build_tagged_union_to_json(name, &wire_name, tu, convertible)?;
 
-    let mut fb = FileSpec::builder(&filename);
+    let mut fb = FileSpec::builder_with(&filename, ts.clone());
     if let Some(doc) = &schema.description {
         fb = fb.add_raw(&format!("/** {doc} */\n"));
     }
@@ -1034,7 +1047,7 @@ fn build_tagged_union_from_json(
             &variant.content_type,
             convertible,
         );
-        case_lines.push(format!("    case '{val}': {case_body}"));
+        case_lines.push(format!("case '{val}': {case_body}"));
     }
     let cases: Vec<CodeBlock> = case_lines
         .iter()
@@ -1043,11 +1056,11 @@ fn build_tagged_union_from_json(
         .ok()?;
 
     sigil_quote!(TypeScript {
-        $L(format!("export function {fn_name}(json: {wire_name}): {name} {{"))
-        $L(format!("  switch ({disc_access}) {{"))
+        export function $N(fn_name)(json: $N(wire_name)): $N(name) {
+          switch ($L(disc_access)) {
         $C_each(cases);
-        $L("  }")
-        $L("}")
+          }
+        }
     })
     .ok()
 }
@@ -1113,9 +1126,9 @@ fn build_external_tagged_from_json(
     for variant in &tu.variants {
         let val = &variant.discriminator_value;
         let ret_expr = external_variant_from_json_expr(val, &variant.content_type, convertible);
-        body_lines.push(format!("  if ('{val}' in json) return {ret_expr};"));
+        body_lines.push(format!("if ('{val}' in json) return {ret_expr};"));
     }
-    body_lines.push("  throw new Error('Unknown variant');".to_string());
+    body_lines.push("throw new Error('Unknown variant');".to_string());
     let body: Vec<CodeBlock> = body_lines
         .iter()
         .map(|l| CodeBlock::of(l, ()))
@@ -1123,9 +1136,9 @@ fn build_external_tagged_from_json(
         .ok()?;
 
     sigil_quote!(TypeScript {
-        $L(format!("export function {fn_name}(json: {wire_name}): {name} {{"))
+        export function $N(fn_name)(json: $N(wire_name)): $N(name) {
         $C_each(body);
-        $L("}")
+        }
     })
     .ok()
 }
@@ -1183,7 +1196,7 @@ fn build_tagged_union_to_json(
             &variant.content_type,
             convertible,
         );
-        case_lines.push(format!("    case '{val}': {case_body}"));
+        case_lines.push(format!("case '{val}': {case_body}"));
     }
     let cases: Vec<CodeBlock> = case_lines
         .iter()
@@ -1192,11 +1205,11 @@ fn build_tagged_union_to_json(
         .ok()?;
 
     sigil_quote!(TypeScript {
-        $L(format!("export function {fn_name}(value: {name}): {wire_name} {{"))
-        $L(format!("  switch ({disc_access}) {{"))
+        export function $N(fn_name)(value: $N(name)): $N(wire_name) {
+          switch ($L(disc_access)) {
         $C_each(cases);
-        $L("  }")
-        $L("}")
+          }
+        }
     })
     .ok()
 }
@@ -1270,9 +1283,9 @@ fn build_external_tagged_to_json(
     for variant in &tu.variants {
         let val = &variant.discriminator_value;
         let ret_expr = external_variant_to_json_expr(val, &variant.content_type, convertible);
-        body_lines.push(format!("  if ('{val}' in value) return {ret_expr};"));
+        body_lines.push(format!("if ('{val}' in value) return {ret_expr};"));
     }
-    body_lines.push("  throw new Error('Unknown variant');".to_string());
+    body_lines.push("throw new Error('Unknown variant');".to_string());
     let body: Vec<CodeBlock> = body_lines
         .iter()
         .map(|l| CodeBlock::of(l, ()))
@@ -1280,9 +1293,9 @@ fn build_external_tagged_to_json(
         .ok()?;
 
     sigil_quote!(TypeScript {
-        $L(format!("export function {fn_name}(value: {name}): {wire_name} {{"))
+        export function $N(fn_name)(value: $N(name)): $N(wire_name) {
         $C_each(body);
-        $L("}")
+        }
     })
     .ok()
 }
@@ -1312,15 +1325,17 @@ fn emit_union_file_camel_case(
     union: &IrUnion,
     name: &str,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Option<FileSpec> {
     let filename = format!("{}.ts", name);
-    let mut fb = FileSpec::builder(&filename);
+    let mut fb = FileSpec::builder_with(&filename, ts.clone());
 
     if let Some(doc) = &schema.description {
         fb = fb.add_raw(&format!("/** {doc} */\n"));
     }
 
     // $Wire type alias
+    let wire_name = format!("{name}$Wire");
     let mut wire_members: Vec<String> = union
         .members
         .iter()
@@ -1331,7 +1346,7 @@ fn emit_union_file_camel_case(
     }
     let wire_body = wire_members.join(" | ");
     let wire_type = sigil_quote!(TypeScript {
-        $L(format!("export type {name}$Wire = {wire_body};"))
+        export type $N(wire_name.as_str()) = $L(wire_body);
     })
     .ok()?;
     fb = fb.add_code(wire_type);
@@ -1343,26 +1358,28 @@ fn emit_union_file_camel_case(
     }
     let ergo_body = ergo_members.join(" | ");
     let ergo_type = sigil_quote!(TypeScript {
-        $L(format!("export type {name} = {ergo_body};"))
+        export type $N(name) = $L(ergo_body);
     })
     .ok()?;
     fb = fb.add_code(ergo_type);
 
     // fromJSON: cast-through
     let base = fn_base_name(name);
+    let from_fn = format!("{base}FromJSON");
+    let to_fn = format!("{base}ToJSON");
     let from_json = sigil_quote!(TypeScript {
-        $L(format!("export function {base}FromJSON(json: {name}$Wire): {name} {{"))
-        $L(format!("  return json as unknown as {name};"))
-        $L("}")
+        export function $N(from_fn)(json: $N(wire_name.as_str())): $N(name) {
+            return json as unknown as $N(name);
+        }
     })
     .ok()?;
     fb = fb.add_code(from_json);
 
     // toJSON: cast-through
     let to_json = sigil_quote!(TypeScript {
-        $L(format!("export function {base}ToJSON(value: {name}): {name}$Wire {{"))
-        $L(format!("  return value as unknown as {name}$Wire;"))
-        $L("}")
+        export function $N(to_fn)(value: $N(name)): $N(wire_name.as_str()) {
+            return value as unknown as $N(wire_name.as_str());
+        }
     })
     .ok()?;
     fb = fb.add_code(to_json);
@@ -1396,15 +1413,17 @@ fn emit_intersection_file_camel_case(
     intersection: &IrIntersection,
     name: &str,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Option<FileSpec> {
     let filename = format!("{}.ts", name);
-    let mut fb = FileSpec::builder(&filename);
+    let mut fb = FileSpec::builder_with(&filename, ts.clone());
 
     if let Some(doc) = &schema.description {
         fb = fb.add_raw(&format!("/** {doc} */\n"));
     }
 
     // $Wire type alias: A$Wire & B$Wire & ... (only $Wire for convertible refs)
+    let wire_name = format!("{name}$Wire");
     let wire_members: Vec<String> = intersection
         .members
         .iter()
@@ -1412,7 +1431,7 @@ fn emit_intersection_file_camel_case(
         .collect();
     let wire_body = wire_members.join(" & ");
     let wire_type = sigil_quote!(TypeScript {
-        $L(format!("export type {name}$Wire = {wire_body};"))
+        export type $N(wire_name.as_str()) = $L(wire_body);
     })
     .ok()?;
     fb = fb.add_code(wire_type);
@@ -1421,13 +1440,15 @@ fn emit_intersection_file_camel_case(
     let ergo_members: Vec<String> = intersection.members.iter().map(type_expr_str).collect();
     let ergo_body = ergo_members.join(" & ");
     let ergo_type = sigil_quote!(TypeScript {
-        $L(format!("export type {name} = {ergo_body};"))
+        export type $N(name) = $L(ergo_body);
     })
     .ok()?;
     fb = fb.add_code(ergo_type);
 
     // fromJSON: spread each convertible Named member's converter
     let base = fn_base_name(name);
+    let from_fn = format!("{base}FromJSON");
+    let to_fn = format!("{base}ToJSON");
     let from_spreads: Vec<String> = intersection
         .members
         .iter()
@@ -1448,10 +1469,11 @@ fn emit_intersection_file_camel_case(
         })
         .collect();
 
+    let from_spreads = from_spreads.join(", ");
     let from_json = sigil_quote!(TypeScript {
-        $L(format!("export function {base}FromJSON(json: {name}$Wire): {name} {{"))
-        $L(format!("  return {{ {} }} as {name};", from_spreads.join(", ")))
-        $L("}")
+        export function $N(from_fn)(json: $N(wire_name.as_str())): $N(name) {
+            return $L("{ @{from_spreads} } as @{name};")
+        }
     })
     .ok()?;
     fb = fb.add_code(from_json);
@@ -1475,10 +1497,11 @@ fn emit_intersection_file_camel_case(
         })
         .collect();
 
+    let to_spreads = to_spreads.join(", ");
     let to_json = sigil_quote!(TypeScript {
-        $L(format!("export function {base}ToJSON(value: {name}): {name}$Wire {{"))
-        $L(format!("  return {{ {} }} as {name}$Wire;", to_spreads.join(", ")))
-        $L("}")
+        export function $N(to_fn)(value: $N(name)): $N(wire_name.as_str()) {
+            return $L("{ @{to_spreads} } as @{name}$Wire;")
+        }
     })
     .ok()?;
     fb = fb.add_code(to_json);
@@ -1536,11 +1559,9 @@ fn build_tagged_union_type_guards(name: &str, tu: &IrTaggedUnion) -> Vec<CodeBlo
 
             let predicate = format!("value is {guard_type}");
             sigil_quote!(TypeScript {
-                $L(format!("export function {guard_name}("))
-                $L(format!("    value: {name}"))
-                $L(format!("): {predicate} {{"))
-                $L(format!("    return {check_body};"))
-                $L("}")
+                export function $N(guard_name)(value: $N(name)): $L(predicate) {
+                return $L(check_body);
+                }
             })
             .ok()
         })
@@ -1802,13 +1823,17 @@ pub fn build_convertible_set(ir: &IrSpec, flags: EmitFlags) -> HashSet<String> {
 }
 
 /// Lower every `IrSchema` in the spec into a sigil-rendered `FileInfo`.
-pub fn generate_model_files(ir: &IrSpec, flags: EmitFlags) -> Result<Vec<FileInfo>, String> {
+pub fn generate_model_files(
+    ir: &IrSpec,
+    flags: EmitFlags,
+    ts: &TypeScript,
+) -> Result<Vec<FileInfo>, String> {
     let header = super::project_files::render_file_header(&ir.info);
     let convertible = build_convertible_set(ir, flags);
     let mut files = Vec::with_capacity(ir.schemas.len());
 
     for (name, schema) in &ir.schemas {
-        let file_spec = emit_model_file(schema, flags, &convertible).ok_or_else(|| {
+        let file_spec = emit_model_file(schema, flags, &convertible, ts).ok_or_else(|| {
             format!(
                 "sigil_emit: unsupported schema kind for {name}: {:?}",
                 schema.kind

--- a/src/generators/typescript/fetch/sigil_emit_api.rs
+++ b/src/generators/typescript/fetch/sigil_emit_api.rs
@@ -25,6 +25,7 @@ use crate::ir::types::{
 };
 use heck::{ToLowerCamelCase as _, ToPascalCase as _};
 use sigil_stitch::code_block::{Arg, CodeBlock};
+use sigil_stitch::lang::typescript::TypeScript;
 use sigil_stitch::prelude::sigil_quote;
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -42,6 +43,7 @@ const RUNTIME_MOD: &str = "../runtime/runtime";
 pub fn generate_api_files(
     ir: &IrSpec,
     property_naming_camel_case: bool,
+    ts: &TypeScript,
 ) -> Result<Vec<FileInfo>, String> {
     let header = super::project_files::render_file_header(&ir.info);
     let by_tag = group_by_tag(&ir.operations);
@@ -53,7 +55,7 @@ pub fn generate_api_files(
 
     let mut files = Vec::with_capacity(by_tag.len());
     for (tag, ops) in &by_tag {
-        let file_spec = emit_api_file(tag, ops, property_naming_camel_case, &convertible)?;
+        let file_spec = emit_api_file(tag, ops, property_naming_camel_case, &convertible, ts)?;
         let body = file_spec
             .render(100)
             .map_err(|e| format!("sigil_emit_api: render {tag}: {e}"))?;
@@ -129,11 +131,12 @@ fn emit_api_file(
     ops: &[&IrOperation],
     property_naming_camel_case: bool,
     convertible: &HashSet<String>,
+    ts: &TypeScript,
 ) -> Result<FileSpec, String> {
     let class_name = format!("{}Api", tag.to_pascal_case());
     let interface_name = format!("{}Interface", class_name);
 
-    let mut fb = FileSpec::builder(&format!("{}.ts", class_name));
+    let mut fb = FileSpec::builder_with(&format!("{}.ts", class_name), ts.clone());
 
     // Request interfaces — one per op that has at least one parameter / body.
     for op in ops {

--- a/tests/golden/go/go-http/comprehensive-schemas/models/number_enum.go.golden
+++ b/tests/golden/go/go-http/comprehensive-schemas/models/number_enum.go.golden
@@ -6,8 +6,8 @@
 package models
 
 // Enum of number values
-
 type NumberEnum int
+
 const (
 	NumberEnumN1 NumberEnum = 1
 	NumberEnumN2 NumberEnum = 2

--- a/tests/golden/go/go-http/comprehensive-schemas/models/string_enum.go.golden
+++ b/tests/golden/go/go-http/comprehensive-schemas/models/string_enum.go.golden
@@ -6,8 +6,8 @@
 package models
 
 // Enum of string values
-
 type StringEnum string
+
 const (
 	StringEnumActive StringEnum = "active"
 	StringEnumInactive StringEnum = "inactive"

--- a/tests/golden/go/go-http/enum-repr/models/adjacently_tagged_enum.go.golden
+++ b/tests/golden/go/go-http/enum-repr/models/adjacently_tagged_enum.go.golden
@@ -6,9 +6,9 @@
 package models
 
 // Adjacently tagged enum
-// 
+//
 // The tag and content are separate fields:
 // `{"ty": "VariantA", "data": {"field1": "...", "field2": 123}}`
-// 
+//
 // Discriminator: ty / content: data (adjacent).
 type AdjacentlyTaggedEnum = any

--- a/tests/golden/go/go-http/enum-repr/models/externally_tagged_enum.go.golden
+++ b/tests/golden/go/go-http/enum-repr/models/externally_tagged_enum.go.golden
@@ -6,9 +6,9 @@
 package models
 
 // Externally tagged enum (default Serde representation)
-// 
+//
 // This is the default representation where the variant name is the key
 // and the content is the value: `{"VariantA": {"field1": "...", "field2": 123}}`
-// 
+//
 // Discriminator: variant key (external).
 type ExternallyTaggedEnum = any

--- a/tests/golden/go/go-http/enum-repr/models/internally_tagged_enum.go.golden
+++ b/tests/golden/go/go-http/enum-repr/models/internally_tagged_enum.go.golden
@@ -6,9 +6,9 @@
 package models
 
 // Internally tagged enum
-// 
+//
 // The tag is a field inside the object alongside other fields:
 // `{"ty": "VariantA", "field1": "...", "field2": 123}`
-// 
+//
 // Discriminator: ty (internal).
 type InternallyTaggedEnum = any

--- a/tests/golden/go/go-http/enum-repr/models/mixed_enum.go.golden
+++ b/tests/golden/go/go-http/enum-repr/models/mixed_enum.go.golden
@@ -6,7 +6,7 @@
 package models
 
 // Mixed enum with unit variants (SimpleA, SimpleB) and tuple variants (VariantA(VariantA), VariantB(VariantB))
-// 
+//
 // Serializes as externally tagged: `{"SimpleA": null}`, `{"VariantA": {"field1": "...", "field2": 123}}`,
 // `{"SimpleB": null}`, `{"VariantB": {"field3": true, "field4": 1.23}}`
 type MixedEnum = any

--- a/tests/golden/go/go-http/enum-repr/models/untagged_enum.go.golden
+++ b/tests/golden/go/go-http/enum-repr/models/untagged_enum.go.golden
@@ -6,7 +6,7 @@
 package models
 
 // Untagged enum
-// 
+//
 // No tag is used, variants are distinguished by their structure:
 // `{"field1": "...", "field2": 123}` or `{"field3": true, "field4": 1.23}`
 type UntaggedEnum = any

--- a/tests/golden/go/go-http/interface-with-enum-reference/models/az.go.golden
+++ b/tests/golden/go/go-http/interface-with-enum-reference/models/az.go.golden
@@ -6,8 +6,8 @@
 package models
 
 // AZ enum
-
 type Az string
+
 const (
 	AzFoo Az = "foo"
 	AzBar Az = "bar"

--- a/tests/golden/go/go-http/interface-with-enum-reference/models/bar_status.go.golden
+++ b/tests/golden/go/go-http/interface-with-enum-reference/models/bar_status.go.golden
@@ -6,8 +6,8 @@
 package models
 
 // Bar status enum
-
 type BarStatus string
+
 const (
 	BarStatusFoo BarStatus = "foo"
 	BarStatusBar BarStatus = "bar"

--- a/tests/golden/go/go-http/interface-with-enum-reference/models/foo_type.go.golden
+++ b/tests/golden/go/go-http/interface-with-enum-reference/models/foo_type.go.golden
@@ -6,8 +6,8 @@
 package models
 
 // Foo type enum
-
 type FooType string
+
 const (
 	FooTypeFoo FooType = "foo"
 	FooTypeBar FooType = "bar"

--- a/tests/golden/go/go-http/petstore/models/order_status.go.golden
+++ b/tests/golden/go/go-http/petstore/models/order_status.go.golden
@@ -6,8 +6,8 @@
 package models
 
 // Order status enum
-
 type OrderStatus string
+
 const (
 	OrderStatusPlaced OrderStatus = "placed"
 	OrderStatusApproved OrderStatus = "approved"

--- a/tests/golden/go/go-http/petstore/models/pet_status.go.golden
+++ b/tests/golden/go/go-http/petstore/models/pet_status.go.golden
@@ -6,8 +6,8 @@
 package models
 
 // Pet status enum
-
 type PetStatus string
+
 const (
 	PetStatusAvailable PetStatus = "available"
 	PetStatusPending PetStatus = "pending"

--- a/tests/golden/go/go-http/query-param-enum/models/foo_status.go.golden
+++ b/tests/golden/go/go-http/query-param-enum/models/foo_status.go.golden
@@ -6,8 +6,8 @@
 package models
 
 // Foo status enum
-
 type FooStatus string
+
 const (
 	FooStatusFoo FooStatus = "foo"
 	FooStatusBar FooStatus = "bar"

--- a/tests/golden/go/go-http/type-aliases-discriminated-union-mixed-unit-and-allof/models/setup.go.golden
+++ b/tests/golden/go/go-http/type-aliases-discriminated-union-mixed-unit-and-allof/models/setup.go.golden
@@ -11,6 +11,6 @@
 package models
 
 // Setup: quick (managed), custom, or unspecified.
-// 
+//
 // Discriminator: kind (internal).
 type Setup = any

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
@@ -27,9 +27,11 @@ def adjacently_tagged_enum_from_dict(data: dict[str, object]) -> AdjacentlyTagge
         return VariantB.from_dict(_content)  # type: ignore[arg-type]
     raise ValueError(f"Unknown discriminator value for AdjacentlyTaggedEnum: {data}")
 
+
 def adjacently_tagged_enum_to_dict(obj: AdjacentlyTaggedEnum) -> dict[str, object]:
     if isinstance(obj, VariantA):
         return {"ty": "ADJACENTLY_TAGGED_ENUM_VARIANT_A", "data": obj.to_dict()}
     else:
         return {"ty": "ADJACENTLY_TAGGED_ENUM_VARIANT_B", "data": obj.to_dict()}
     raise ValueError(f"Unknown variant for AdjacentlyTaggedEnum: {type(obj)}")
+

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
@@ -25,9 +25,11 @@ def externally_tagged_enum_from_dict(data: dict[str, object]) -> ExternallyTagge
         return VariantB.from_dict(data["EXTERNALLY_TAGGED_ENUM_VARIANT_B"])  # type: ignore[arg-type]
     raise ValueError(f"Unknown discriminator value for ExternallyTaggedEnum: {data}")
 
+
 def externally_tagged_enum_to_dict(obj: ExternallyTaggedEnum) -> dict[str, object]:
     if isinstance(obj, VariantA):
         return {"EXTERNALLY_TAGGED_ENUM_VARIANT_A": obj.to_dict()}
     else:
         return {"EXTERNALLY_TAGGED_ENUM_VARIANT_B": obj.to_dict()}
     raise ValueError(f"Unknown variant for ExternallyTaggedEnum: {type(obj)}")
+

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
@@ -26,6 +26,7 @@ def internally_tagged_enum_from_dict(data: dict[str, object]) -> InternallyTagge
         return VariantB.from_dict(data)
     raise ValueError(f"Unknown discriminator value for InternallyTaggedEnum: {data}")
 
+
 def internally_tagged_enum_to_dict(obj: InternallyTaggedEnum) -> dict[str, object]:
     if isinstance(obj, VariantA):
         result = obj.to_dict()
@@ -36,3 +37,4 @@ def internally_tagged_enum_to_dict(obj: InternallyTaggedEnum) -> dict[str, objec
         result["ty"] = "INTERNALLY_TAGGED_ENUM_VARIANT_B"
         return result
     raise ValueError(f"Unknown variant for InternallyTaggedEnum: {type(obj)}")
+

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
@@ -26,6 +26,7 @@ def resource_from_dict(data: dict[str, object]) -> Resource:
         return ResourceCustom.from_dict(data)
     raise ValueError(f"Unknown discriminator value for Resource: {data}")
 
+
 def resource_to_dict(obj: Resource) -> dict[str, object]:
     if isinstance(obj, ResourceUnspecified):
         result = obj.to_dict()
@@ -40,3 +41,4 @@ def resource_to_dict(obj: Resource) -> dict[str, object]:
         result["kind"] = "RESOURCE_CUSTOM"
         return result
     raise ValueError(f"Unknown variant for Resource: {type(obj)}")
+

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/models/setup.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/models/setup.py.golden
@@ -31,6 +31,7 @@ def setup_from_dict(data: dict[str, object]) -> Setup:
         return SetupCustom.from_dict(data)
     raise ValueError(f"Unknown discriminator value for Setup: {data}")
 
+
 def setup_to_dict(obj: Setup) -> dict[str, object]:
     if isinstance(obj, SetupSetupUnspecified):
         result = obj.to_dict()
@@ -45,3 +46,4 @@ def setup_to_dict(obj: Setup) -> dict[str, object]:
         result["kind"] = "SETUP_CUSTOM"
         return result
     raise ValueError(f"Unknown variant for Setup: {type(obj)}")
+

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
@@ -24,6 +24,7 @@ def container_kind_from_dict(data: dict[str, object]) -> ContainerKind:
         return ContainerKindCustom.from_dict(data)
     raise ValueError(f"Unknown discriminator value for ContainerKind: {data}")
 
+
 def container_kind_to_dict(obj: ContainerKind) -> dict[str, object]:
     if isinstance(obj, ContainerKindManaged):
         result = obj.to_dict()
@@ -34,3 +35,4 @@ def container_kind_to_dict(obj: ContainerKind) -> dict[str, object]:
         result["kind"] = "CONTAINER_KIND_CUSTOM"
         return result
     raise ValueError(f"Unknown variant for ContainerKind: {type(obj)}")
+

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
@@ -24,6 +24,7 @@ def volume_kind_from_dict(data: dict[str, object]) -> VolumeKind:
         return VolumeKindRemote.from_dict(data)
     raise ValueError(f"Unknown discriminator value for VolumeKind: {data}")
 
+
 def volume_kind_to_dict(obj: VolumeKind) -> dict[str, object]:
     if isinstance(obj, VolumeKindLocal):
         result = obj.to_dict()
@@ -34,3 +35,4 @@ def volume_kind_to_dict(obj: VolumeKind) -> dict[str, object]:
         result["kind"] = "VOLUME_KIND_REMOTE"
         return result
     raise ValueError(f"Unknown variant for VolumeKind: {type(obj)}")
+

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
@@ -22,6 +22,7 @@ def container_image_from_dict(data: dict[str, object]) -> ContainerImage:
         return ContainerImageCustom.from_dict(data)
     raise ValueError(f"Unknown discriminator value for ContainerImage: {data}")
 
+
 def container_image_to_dict(obj: ContainerImage) -> dict[str, object]:
     if isinstance(obj, ContainerImageManaged):
         result = obj.to_dict()
@@ -32,3 +33,4 @@ def container_image_to_dict(obj: ContainerImage) -> dict[str, object]:
         result["kind"] = "CONTAINER_IMAGE_CUSTOM"
         return result
     raise ValueError(f"Unknown variant for ContainerImage: {type(obj)}")
+

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
@@ -27,9 +27,11 @@ def adjacently_tagged_enum_from_dict(data: dict[str, object]) -> AdjacentlyTagge
         return VariantB.from_dict(_content)  # type: ignore[arg-type]
     raise ValueError(f"Unknown discriminator value for AdjacentlyTaggedEnum: {data}")
 
+
 def adjacently_tagged_enum_to_dict(obj: AdjacentlyTaggedEnum) -> dict[str, object]:
     if isinstance(obj, VariantA):
         return {"ty": "ADJACENTLY_TAGGED_ENUM_VARIANT_A", "data": obj.to_dict()}
     else:
         return {"ty": "ADJACENTLY_TAGGED_ENUM_VARIANT_B", "data": obj.to_dict()}
     raise ValueError(f"Unknown variant for AdjacentlyTaggedEnum: {type(obj)}")
+

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
@@ -25,9 +25,11 @@ def externally_tagged_enum_from_dict(data: dict[str, object]) -> ExternallyTagge
         return VariantB.from_dict(data["EXTERNALLY_TAGGED_ENUM_VARIANT_B"])  # type: ignore[arg-type]
     raise ValueError(f"Unknown discriminator value for ExternallyTaggedEnum: {data}")
 
+
 def externally_tagged_enum_to_dict(obj: ExternallyTaggedEnum) -> dict[str, object]:
     if isinstance(obj, VariantA):
         return {"EXTERNALLY_TAGGED_ENUM_VARIANT_A": obj.to_dict()}
     else:
         return {"EXTERNALLY_TAGGED_ENUM_VARIANT_B": obj.to_dict()}
     raise ValueError(f"Unknown variant for ExternallyTaggedEnum: {type(obj)}")
+

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
@@ -26,6 +26,7 @@ def internally_tagged_enum_from_dict(data: dict[str, object]) -> InternallyTagge
         return VariantB.from_dict(data)
     raise ValueError(f"Unknown discriminator value for InternallyTaggedEnum: {data}")
 
+
 def internally_tagged_enum_to_dict(obj: InternallyTaggedEnum) -> dict[str, object]:
     if isinstance(obj, VariantA):
         result = obj.to_dict()
@@ -36,3 +37,4 @@ def internally_tagged_enum_to_dict(obj: InternallyTaggedEnum) -> dict[str, objec
         result["ty"] = "INTERNALLY_TAGGED_ENUM_VARIANT_B"
         return result
     raise ValueError(f"Unknown variant for InternallyTaggedEnum: {type(obj)}")
+

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
@@ -26,6 +26,7 @@ def resource_from_dict(data: dict[str, object]) -> Resource:
         return ResourceCustom.from_dict(data)
     raise ValueError(f"Unknown discriminator value for Resource: {data}")
 
+
 def resource_to_dict(obj: Resource) -> dict[str, object]:
     if isinstance(obj, ResourceUnspecified):
         result = obj.to_dict()
@@ -40,3 +41,4 @@ def resource_to_dict(obj: Resource) -> dict[str, object]:
         result["kind"] = "RESOURCE_CUSTOM"
         return result
     raise ValueError(f"Unknown variant for Resource: {type(obj)}")
+

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/models/setup.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/models/setup.py.golden
@@ -31,6 +31,7 @@ def setup_from_dict(data: dict[str, object]) -> Setup:
         return SetupCustom.from_dict(data)
     raise ValueError(f"Unknown discriminator value for Setup: {data}")
 
+
 def setup_to_dict(obj: Setup) -> dict[str, object]:
     if isinstance(obj, SetupSetupUnspecified):
         result = obj.to_dict()
@@ -45,3 +46,4 @@ def setup_to_dict(obj: Setup) -> dict[str, object]:
         result["kind"] = "SETUP_CUSTOM"
         return result
     raise ValueError(f"Unknown variant for Setup: {type(obj)}")
+

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
@@ -24,6 +24,7 @@ def container_kind_from_dict(data: dict[str, object]) -> ContainerKind:
         return ContainerKindCustom.from_dict(data)
     raise ValueError(f"Unknown discriminator value for ContainerKind: {data}")
 
+
 def container_kind_to_dict(obj: ContainerKind) -> dict[str, object]:
     if isinstance(obj, ContainerKindManaged):
         result = obj.to_dict()
@@ -34,3 +35,4 @@ def container_kind_to_dict(obj: ContainerKind) -> dict[str, object]:
         result["kind"] = "CONTAINER_KIND_CUSTOM"
         return result
     raise ValueError(f"Unknown variant for ContainerKind: {type(obj)}")
+

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
@@ -24,6 +24,7 @@ def volume_kind_from_dict(data: dict[str, object]) -> VolumeKind:
         return VolumeKindRemote.from_dict(data)
     raise ValueError(f"Unknown discriminator value for VolumeKind: {data}")
 
+
 def volume_kind_to_dict(obj: VolumeKind) -> dict[str, object]:
     if isinstance(obj, VolumeKindLocal):
         result = obj.to_dict()
@@ -34,3 +35,4 @@ def volume_kind_to_dict(obj: VolumeKind) -> dict[str, object]:
         result["kind"] = "VOLUME_KIND_REMOTE"
         return result
     raise ValueError(f"Unknown variant for VolumeKind: {type(obj)}")
+

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
@@ -22,6 +22,7 @@ def container_image_from_dict(data: dict[str, object]) -> ContainerImage:
         return ContainerImageCustom.from_dict(data)
     raise ValueError(f"Unknown discriminator value for ContainerImage: {data}")
 
+
 def container_image_to_dict(obj: ContainerImage) -> dict[str, object]:
     if isinstance(obj, ContainerImageManaged):
         result = obj.to_dict()
@@ -32,3 +33,4 @@ def container_image_to_dict(obj: ContainerImage) -> dict[str, object]:
         result["kind"] = "CONTAINER_IMAGE_CUSTOM"
         return result
     raise ValueError(f"Unknown variant for ContainerImage: {type(obj)}")
+

--- a/tests/golden/typescript/typescript-fetch/ts-enum-const/models/ItemKind.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-enum-const/models/ItemKind.ts.golden
@@ -11,4 +11,4 @@ export const ItemKind = {
     BOOK: 'BOOK' as const,
     MOVIE: 'MOVIE' as const,
     MUSIC: 'MUSIC' as const,
-};
+}

--- a/tests/golden/typescript/typescript-fetch/ts-enum-const/models/Mood.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-enum-const/models/Mood.ts.golden
@@ -12,4 +12,4 @@ export const Mood = {
     sad: 'sad' as const,
     '0': 0 as const,
     '1': 1 as const,
-};
+}

--- a/tests/golden/typescript/typescript-fetch/ts-enum-const/models/Priority.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-enum-const/models/Priority.ts.golden
@@ -11,4 +11,4 @@ export const Priority = {
     '1': 1 as const,
     '2': 2 as const,
     '3': 3 as const,
-};
+}

--- a/tests/golden/typescript/typescript-fetch/ts-enum-const/models/Score.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-enum-const/models/Score.ts.golden
@@ -11,4 +11,4 @@ export const Score = {
     '0.5': 0.5 as const,
     '1.0': 1.0 as const,
     '1.5': 1.5 as const,
-};
+}

--- a/tests/golden/typescript/typescript-fetch/ts-type-guards/models/AppEvent.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-type-guards/models/AppEvent.ts.golden
@@ -11,20 +11,14 @@ import type { ScrollEvent } from './ScrollEvent';
 
 export type AppEvent = ({ eventType: 'ClickEvent' } & ClickEvent) | ({ eventType: 'ScrollEvent' } & ScrollEvent) | ({ eventType: 'KeyEvent' } & KeyEvent);
 
-export function isClickEvent(
-    value: AppEvent
-): value is ({ eventType: 'ClickEvent' } & ClickEvent) {
-    return value.eventType === 'ClickEvent';
+export function isClickEvent(value: AppEvent): value is ({ eventType: 'ClickEvent' } & ClickEvent) {
+  return value.eventType === 'ClickEvent';
 }
 
-export function isScrollEvent(
-    value: AppEvent
-): value is ({ eventType: 'ScrollEvent' } & ScrollEvent) {
-    return value.eventType === 'ScrollEvent';
+export function isScrollEvent(value: AppEvent): value is ({ eventType: 'ScrollEvent' } & ScrollEvent) {
+  return value.eventType === 'ScrollEvent';
 }
 
-export function isKeyEvent(
-    value: AppEvent
-): value is ({ eventType: 'KeyEvent' } & KeyEvent) {
-    return value.eventType === 'KeyEvent';
+export function isKeyEvent(value: AppEvent): value is ({ eventType: 'KeyEvent' } & KeyEvent) {
+  return value.eventType === 'KeyEvent';
 }

--- a/tests/golden/typescript/typescript-fetch/ts-type-guards/models/Shape.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-type-guards/models/Shape.ts.golden
@@ -10,14 +10,10 @@ import type { Rectangle } from './Rectangle';
 
 export type Shape = ({ kind: 'circle' } & Circle) | ({ kind: 'rectangle' } & Rectangle);
 
-export function isCircle(
-    value: Shape
-): value is ({ kind: 'circle' } & Circle) {
-    return value.kind === 'circle';
+export function isCircle(value: Shape): value is ({ kind: 'circle' } & Circle) {
+  return value.kind === 'circle';
 }
 
-export function isRectangle(
-    value: Shape
-): value is ({ kind: 'rectangle' } & Rectangle) {
-    return value.kind === 'rectangle';
+export function isRectangle(value: Shape): value is ({ kind: 'rectangle' } & Rectangle) {
+  return value.kind === 'rectangle';
 }

--- a/tests/sigil_api_scaffold.rs
+++ b/tests/sigil_api_scaffold.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::Path;
 
 use openapi_nexus::generators::typescript::fetch::sigil_emit_api::generate_api_files;
+use sigil_stitch::lang::typescript::TypeScript;
 
 fn read_fixture(rel: &str) -> String {
     for base in [
@@ -29,7 +30,7 @@ fn petstore_api_scaffold_emits_one_file_per_tag() {
     let parsed = openapi_nexus::parser::parse_content_yaml(&yaml).unwrap();
     let ir = openapi_nexus::ir::lower::lower(parsed).unwrap();
 
-    let files = generate_api_files(&ir, false).expect("scaffold renders");
+    let files = generate_api_files(&ir, false, &TypeScript::new()).expect("scaffold renders");
     assert!(
         !files.is_empty(),
         "expected at least one API file for petstore"
@@ -73,7 +74,7 @@ fn minimal_api_scaffold_has_no_request_interface_when_op_has_no_params() {
     let parsed = openapi_nexus::parser::parse_content_yaml(&yaml).unwrap();
     let ir = openapi_nexus::ir::lower::lower(parsed).unwrap();
 
-    let files = generate_api_files(&ir, false).expect("scaffold renders");
+    let files = generate_api_files(&ir, false, &TypeScript::new()).expect("scaffold renders");
     let default_api = files
         .iter()
         .find(|f| f.filename.ends_with("DefaultApi.ts"))

--- a/tests/sigil_enum_prototype.rs
+++ b/tests/sigil_enum_prototype.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::Path;
 
 use openapi_nexus::generators::typescript::fetch::sigil_emit::emit_enum_file;
+use sigil_stitch::lang::typescript::TypeScript;
 
 fn read_fixture(rel: &str) -> String {
     for base in [
@@ -32,7 +33,7 @@ fn foo_type_enum_renders_as_union_alias() {
     let ir = openapi_nexus::ir::lower::lower(parsed).unwrap();
 
     let foo = ir.schemas.get("FooType").expect("FooType schema in IR");
-    let file = emit_enum_file(foo).expect("prototype supports string Enum");
+    let file = emit_enum_file(foo, &TypeScript::new()).expect("prototype supports string Enum");
     let rendered = file.render(100).expect("renders");
 
     println!("--- rendered FooType.ts ---\n{rendered}\n--- end ---");

--- a/tests/sigil_kinds_stage_a.rs
+++ b/tests/sigil_kinds_stage_a.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::path::Path;
 
 use openapi_nexus::generators::typescript::fetch::sigil_emit;
+use sigil_stitch::lang::typescript::TypeScript;
 
 fn read_fixture(rel: &str) -> String {
     for base in [
@@ -28,7 +29,7 @@ fn render_models(fixture: &str) -> Vec<(String, String)> {
     let yaml = read_fixture(fixture);
     let parsed = openapi_nexus::parser::parse_content_yaml(&yaml).unwrap();
     let ir = openapi_nexus::ir::lower::lower(parsed).unwrap();
-    sigil_emit::generate_model_files(&ir, sigil_emit::EmitFlags::default())
+    sigil_emit::generate_model_files(&ir, sigil_emit::EmitFlags::default(), &TypeScript::new())
         .expect("all kinds in fixture should be supported")
         .into_iter()
         .map(|f| (f.filename, f.content))

--- a/tests/sigil_kinds_stage_b.rs
+++ b/tests/sigil_kinds_stage_b.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::Path;
 
 use openapi_nexus::generators::typescript::fetch::sigil_emit;
+use sigil_stitch::lang::typescript::TypeScript;
 
 fn read_fixture(rel: &str) -> String {
     for base in [
@@ -27,7 +28,7 @@ fn render_models(fixture: &str) -> Vec<(String, String)> {
     let yaml = read_fixture(fixture);
     let parsed = openapi_nexus::parser::parse_content_yaml(&yaml).unwrap();
     let ir = openapi_nexus::ir::lower::lower(parsed).unwrap();
-    sigil_emit::generate_model_files(&ir, sigil_emit::EmitFlags::default())
+    sigil_emit::generate_model_files(&ir, sigil_emit::EmitFlags::default(), &TypeScript::new())
         .expect("all kinds in fixture should be supported")
         .into_iter()
         .map(|f| (f.filename, f.content))

--- a/tests/sigil_kinds_stage_c.rs
+++ b/tests/sigil_kinds_stage_c.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::Path;
 
 use openapi_nexus::generators::typescript::fetch::sigil_emit;
+use sigil_stitch::lang::typescript::TypeScript;
 
 fn read_fixture(rel: &str) -> String {
     for base in [
@@ -29,7 +30,7 @@ fn render_models(fixture: &str) -> Vec<(String, String)> {
     let yaml = read_fixture(fixture);
     let parsed = openapi_nexus::parser::parse_content_yaml(&yaml).unwrap();
     let ir = openapi_nexus::ir::lower::lower(parsed).unwrap();
-    sigil_emit::generate_model_files(&ir, sigil_emit::EmitFlags::default())
+    sigil_emit::generate_model_files(&ir, sigil_emit::EmitFlags::default(), &TypeScript::new())
         .expect("all kinds in fixture should be supported")
         .into_iter()
         .map(|f| (f.filename, f.content))


### PR DESCRIPTION
## Summary

Bumps sigil-stitch from 0.6.2 to 0.6.6 and eliminates nearly all `$L` workaround patterns across Go, TypeScript, and Rust generators using new sigil-stitch features:

- **Structural braces** replace `$L("{")`/`$L("}")` in TS fromJSON/toJSON, tagged union switch blocks, type guards, and enum const objects
- **`$comment(expr)`** replaces manual `//`-prefixed `$L` strings in Go doc comments
- **`$attr(expr)`** replaces `$L(derive_attr(...))` and `$L(rename_attr/serde_tag_attr)` in Rust
- Go/TS/Rust **keywords** (`func`, `type`, `var`, `pub`, `switch`) extracted from `$L(format!(...))` into plain template tokens
- Added `indent` config to `TypeScriptFetchConfig`, threaded `&TypeScript` through emit functions for consistent 2-space indent

## Test plan

- [x] All 1119 tests pass (Go 48, Python 8+8, Rust 49+49+48+48+52+52+52, TS 67, plus unit/integration)
- [x] `cargo fmt && cargo clippy` clean