### PR TITLE
chore: bump version to 0.1.11, update changelog and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.11]
+
+### Added
+
+- TypeScript: `indent` config option for controlling output indentation (default `"  "`)
+
+### Fixed
+
+- Python: eliminated extra blank lines between if/elif blocks in tagged union `_from_dict`/`_to_dict` helpers
+
+### Changed
+
+- Bump sigil-stitch 0.5.3 → 0.6.6: adopt `$comment(expr)`, `$attr(expr)`, `%V` verbatim strings, structural braces, and `end_control_flow_no_newline()` across all generators
+
 ## [0.1.10]
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fixture-generator-additional-properties"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "axum",
  "axum-extra",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-enum-repr"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "axum",
  "axum-extra",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-petstore"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1003,7 +1003,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openapi-nexus"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 rust-version = "1.90"
 description = "OpenAPI 3.x multi-language code generator"

--- a/docs/src/ts_config.md
+++ b/docs/src/ts_config.md
@@ -16,6 +16,7 @@ include_build_scripts = true
 emit_enum_constants = true
 emit_type_guards = true
 property_naming = "camelCase"
+indent = "    "
 ```
 
 ## Options Reference
@@ -119,6 +120,15 @@ When `toolchain = "vp"`, the generated `package.json` includes `vite-plus` and `
 ```toml
 [generators.typescript-fetch]
 toolchain = "vp"
+```
+
+### `indent`
+
+Controls the indentation string used in generated TypeScript files. Accepts any string; common values are `"  "` (2 spaces, default), `"    "` (4 spaces), or `"\t"` (tabs).
+
+```toml
+[generators.typescript-fetch]
+indent = "    "
 ```
 
 ### `property_naming`


### PR DESCRIPTION
## Summary
- Bump version from 0.1.10 to 0.1.11
- Add changelog entry for 0.1.11 (TypeScript `indent` config, Python blank-line fix, sigil-stitch 0.6.6)
- Document new `indent` config option in TypeScript config docs

## Test plan
- [x] `cargo test` — all 1,126 tests pass
- [x] `cargo fmt && cargo clippy` — clean
- [x] mdbook rebuilt