### PR TITLE
feat: dynamic provider support for ApiKeyAuth and BasicAuth across all generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Kotlin: `BearerAuth` gains `(() -> String)` secondary constructor
   - Python: `BearerAuth` accepts `str | Callable[[], str]`
   - Rust: `BearerAuth` gains `from_provider()` factory with internal `TokenSource` enum
+- `ApiKeyAuth` dynamic key provider support (all generators)
+  - Go: `KeyProvider func() string` field; Java: `Supplier<String>` constructor; Kotlin: `() -> String` constructor; Python: `str | Callable[[], str]`; Rust: `from_provider()` factory
+- `BasicAuth` dynamic credential provider support
+  - Go: `UsernameProvider` / `PasswordProvider` func fields
+  - TypeScript: `username` / `password` accept `(() => string | Promise<string>)`, wired into `createFetchParams()`
 
 ## [0.1.11]
 

--- a/docs/src/auth.md
+++ b/docs/src/auth.md
@@ -2,6 +2,189 @@
 
 Every generated SDK includes a runtime authentication module with built-in support for Bearer tokens, API keys, and HTTP Basic auth. Security schemes declared in your OpenAPI spec are reflected in the generated client interface — you supply the credentials when constructing the client, and they are automatically attached to every outgoing request.
 
+## Usage Patterns
+
+### Static Token
+
+The simplest case: a long-lived token known at startup.
+
+**TypeScript**
+
+```ts
+import { Configuration, PetsApi } from "@example/petstore";
+
+const api = new PetsApi(new Configuration({
+  basePath: "https://api.example.com",
+  accessToken: process.env.API_TOKEN,
+}));
+
+const pet = await api.getPetById({ petId: 42 });
+```
+
+**Go**
+
+```go
+client := runtime.NewClient("https://api.example.com",
+    runtime.WithAuth(runtime.BearerAuth{Token: os.Getenv("API_TOKEN")}),
+)
+api := sdk.NewPetsApi(client)
+pet, err := api.GetPetById(context.Background(), 42)
+```
+
+**Python**
+
+```python
+import os
+from sdk import PetsApi
+from sdk.runtime import Client, BearerAuth
+
+api = PetsApi(Client(
+    base_url="https://api.example.com",
+    authenticator=BearerAuth(os.environ["API_TOKEN"]),
+))
+pet = api.get_pet_by_id(pet_id=42)
+```
+
+**Rust**
+
+```rust
+use sdk::PetsApi;
+use sdk::runtime::{Client, BearerAuth};
+
+let client = Client::new("https://api.example.com")
+    .with_auth(BearerAuth::new(std::env::var("API_TOKEN").unwrap()));
+let api = PetsApi::new(client);
+let pet = api.get_pet_by_id(42).await?;
+```
+
+### Dynamic Token (OAuth2 refresh)
+
+When tokens expire and need periodic refresh, pass a function that returns the current token. The function is called on **every request**, so it always picks up the latest value.
+
+**TypeScript**
+
+```ts
+class TokenStore {
+  private token: string | null = null;
+  private expiresAt = 0;
+
+  async getToken(): Promise<string> {
+    if (Date.now() > this.expiresAt) {
+      const res = await fetch("/oauth/token", {
+        method: "POST",
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: process.env.CLIENT_ID!,
+          client_secret: process.env.CLIENT_SECRET!,
+        }),
+      });
+      const data = await res.json();
+      this.token = data.access_token;
+      this.expiresAt = Date.now() + data.expires_in * 1000;
+    }
+    return this.token!;
+  }
+}
+
+const store = new TokenStore();
+const api = new PetsApi(new Configuration({
+  basePath: "https://api.example.com",
+  accessToken: () => store.getToken(),  // evaluated per-request
+}));
+```
+
+**Go**
+
+```go
+type TokenStore struct {
+    mu        sync.Mutex
+    token     string
+    expiresAt time.Time
+}
+
+func (s *TokenStore) GetToken() string {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    if time.Now().After(s.expiresAt) {
+        // refresh logic ...
+        s.token = refreshedToken
+        s.expiresAt = time.Now().Add(1 * time.Hour)
+    }
+    return s.token
+}
+
+store := &TokenStore{}
+client := runtime.NewClient("https://api.example.com",
+    runtime.WithAuth(runtime.BearerAuth{
+        TokenProvider: store.GetToken,  // evaluated per-request
+    }),
+)
+```
+
+**Python**
+
+```python
+import time
+import httpx
+from sdk import PetsApi
+from sdk.runtime import Client, BearerAuth
+
+class TokenStore:
+    def __init__(self):
+        self._token: str | None = None
+        self._expires_at = 0.0
+
+    def get_token(self) -> str:
+        if time.time() > self._expires_at:
+            resp = httpx.post("https://auth.example.com/oauth/token", data={
+                "grant_type": "client_credentials",
+                "client_id": os.environ["CLIENT_ID"],
+                "client_secret": os.environ["CLIENT_SECRET"],
+            })
+            data = resp.json()
+            self._token = data["access_token"]
+            self._expires_at = time.time() + data["expires_in"]
+        return self._token
+
+store = TokenStore()
+api = PetsApi(Client(
+    base_url="https://api.example.com",
+    authenticator=BearerAuth(store.get_token),  # evaluated per-request
+))
+```
+
+**Rust**
+
+```rust
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use sdk::PetsApi;
+use sdk::runtime::{Client, BearerAuth};
+
+struct TokenStore {
+    token: Mutex<String>,
+    expires_at: Mutex<Instant>,
+}
+
+impl TokenStore {
+    fn get_token(&self) -> String {
+        let mut expires = self.expires_at.lock().unwrap();
+        if Instant::now() > *expires {
+            // refresh logic ...
+            *self.token.lock().unwrap() = refreshed_token;
+            *expires = Instant::now() + Duration::from_secs(3600);
+        }
+        self.token.lock().unwrap().clone()
+    }
+}
+
+let store = Arc::new(TokenStore { /* ... */ });
+let s = Arc::clone(&store);
+let client = Client::new("https://api.example.com")
+    .with_auth(BearerAuth::from_provider(move || s.get_token()));
+let api = PetsApi::new(client);
+```
+
 ## Authenticator Interface
 
 All generators expose an `Authenticator` interface (trait in Rust, abstract base class in Python) that the generated client calls before each request. The runtime ships with three concrete implementations:
@@ -174,7 +357,9 @@ Kotlin's trailing-lambda syntax makes the provider form especially concise. `Bea
 
 ## API Key Authentication
 
-`ApiKeyAuth` sends a named key in a header, query parameter, or cookie.
+`ApiKeyAuth` sends a named key in a header, query parameter, or cookie. Like `BearerAuth`, it supports both static keys and dynamic key providers evaluated per-request.
+
+### Static Key
 
 **Go**
 
@@ -226,9 +411,71 @@ import com.example.sdk.runtime.ApiKeyLocation
 ApiKeyAuth("sk-abc123", "X-API-Key", ApiKeyLocation.HEADER)
 ```
 
+**TypeScript**
+
+TypeScript handles API keys through the `apiKey` field on `ConfigurationParameters`, which supports the same `string | Promise<string> | ((name: string) => string | Promise<string>)` union as `accessToken`. Because the wire placement (header name, query parameter, or cookie) depends on the OpenAPI security scheme definition, the key is available for use in custom middleware rather than being auto-wired:
+
+```ts
+const config = new Configuration({
+  basePath: "https://api.example.com",
+  apiKey: (name) => getApiKey(name),  // called with the scheme name
+});
+```
+
+### Dynamic Key Provider
+
+**Go**
+
+```go
+client := runtime.NewClient("https://api.example.com",
+    runtime.WithAuth(runtime.ApiKeyAuth{
+        KeyProvider: func() string {
+            return getCurrentApiKey()  // called per-request
+        },
+        Name:     "X-API-Key",
+        Location: runtime.APIKeyInHeader,
+    }),
+)
+```
+
+**Rust**
+
+```rust
+let client = Client::new("https://api.example.com")
+    .with_auth(ApiKeyAuth::from_provider("X-API-Key", || {
+        get_current_api_key()  // called per-request
+    }));
+```
+
+**Python**
+
+```python
+client = Client(
+    base_url="https://api.example.com",
+    authenticator=ApiKeyAuth(
+        header_name="X-API-Key",
+        api_key=lambda: get_current_api_key(),  # called per-request
+    ),
+)
+```
+
+**Java**
+
+```java
+new ApiKeyAuth(() -> getCurrentApiKey(), "X-API-Key", ApiKeyLocation.HEADER);
+```
+
+**Kotlin**
+
+```kotlin
+ApiKeyAuth({ getCurrentApiKey() }, "X-API-Key", ApiKeyLocation.HEADER)
+```
+
 ## HTTP Basic Authentication
 
-`BasicAuth` sends a base64-encoded `username:password` pair. Available in Go; for other languages, implement a custom `Authenticator`.
+`BasicAuth` sends a base64-encoded `username:password` pair. Available in Go and TypeScript; for other languages, implement a custom `Authenticator`.
+
+### Static Credentials
 
 **Go**
 
@@ -240,6 +487,41 @@ client := runtime.NewClient("https://api.example.com",
     }),
 )
 ```
+
+**TypeScript**
+
+```ts
+const config = new Configuration({
+  basePath: "https://api.example.com",
+  username: "alice",
+  password: "s3cret",
+});
+```
+
+### Dynamic Credentials
+
+**Go**
+
+```go
+client := runtime.NewClient("https://api.example.com",
+    runtime.WithAuth(runtime.BasicAuth{
+        UsernameProvider: func() string { return getCurrentUser() },
+        PasswordProvider: func() string { return getCurrentPass() },
+    }),
+)
+```
+
+**TypeScript**
+
+```ts
+const config = new Configuration({
+  basePath: "https://api.example.com",
+  username: () => getCurrentUser(),
+  password: () => getCurrentPass(),
+});
+```
+
+The `username` and `password` fields accept `string | (() => string | Promise<string>)`. A plain function is called synchronously; an async function is awaited. Basic auth is only applied when no `Authorization` header has already been set by `accessToken`.
 
 ## Custom Authenticators
 

--- a/src/generators/go/http/runtime/auth.go.txt
+++ b/src/generators/go/http/runtime/auth.go.txt
@@ -45,25 +45,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -71,13 +80,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/src/generators/java/okhttp/runtime/ApiKeyAuth.java.txt
+++ b/src/generators/java/okhttp/runtime/ApiKeyAuth.java.txt
@@ -1,25 +1,36 @@
 package runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/src/generators/kotlin/okhttp/runtime/auth.kt.txt
+++ b/src/generators/kotlin/okhttp/runtime/auth.kt.txt
@@ -26,17 +26,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/src/generators/python/httpx/runtime/auth.py.txt
+++ b/src/generators/python/httpx/runtime/auth.py.txt
@@ -31,11 +31,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/src/generators/python/requests/runtime/auth.py.txt
+++ b/src/generators/python/requests/runtime/auth.py.txt
@@ -31,11 +31,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/src/generators/rust/aioduct/runtime/auth.rs.txt
+++ b/src/generators/rust/aioduct/runtime/auth.rs.txt
@@ -88,17 +88,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -108,6 +165,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/src/generators/rust/reqwest/runtime/auth.rs.txt
+++ b/src/generators/rust/reqwest/runtime/auth.rs.txt
@@ -90,30 +90,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/src/generators/rust/ureq/runtime/auth.rs.txt
+++ b/src/generators/rust/ureq/runtime/auth.rs.txt
@@ -80,23 +80,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/src/generators/typescript/fetch/project_files/runtime.ts.txt
+++ b/src/generators/typescript/fetch/project_files/runtime.ts.txt
@@ -5,8 +5,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -36,12 +36,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -140,6 +148,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/go/go-http/additional-properties/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/additional-properties/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/comprehensive-schemas/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/comprehensive-schemas/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/delete-with-response-schema/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/delete-with-response-schema/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/duplicate-param-names/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/duplicate-param-names/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/enum-repr/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/enum-repr/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/interface-with-enum-reference/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/interface-with-enum-reference/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/minimal/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/minimal/runtime/auth.go.golden
@@ -49,25 +49,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -75,13 +84,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/multiple-similar-request-schemas/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/multiple-similar-request-schemas/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/naming-conventions/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/naming-conventions/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/petstore/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/petstore/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/query-param-enum/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/query-param-enum/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-all-optional-properties/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-all-optional-properties/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-array-of-inline-objects/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-array-of-inline-objects/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-array-of-referenced-types/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-array-of-referenced-types/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-array-with-reference-property/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-array-with-reference-property/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-complex-array-structure/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-complex-array-structure/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-deeply-nested-inline/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-deeply-nested-inline/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-empty-array/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-empty-array/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-inline-object-with-array/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-inline-object-with-array/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-inline-object/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-inline-object/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-mixed-property-types/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-mixed-property-types/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-nested-object-reference/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-nested-object-reference/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-optional-array-of-inline-objects/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-optional-array-of-inline-objects/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-optional-array-of-referenced-types/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-optional-array-of-referenced-types/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-optional-inline-object/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-optional-inline-object/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-optional-nested-object-reference/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-optional-nested-object-reference/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/recursive-json-primitive-array/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/recursive-json-primitive-array/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/request-body-content-types/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/request-body-content-types/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/response-body-default-and-exact/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/response-body-default-and-exact/runtime/auth.go.golden
@@ -49,25 +49,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -75,13 +84,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/response-body-fallback/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/response-body-fallback/runtime/auth.go.golden
@@ -49,25 +49,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -75,13 +84,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/response-body-multi-status-responses/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/response-body-multi-status-responses/runtime/auth.go.golden
@@ -49,25 +49,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -75,13 +84,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/response-body-no-response-body/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/response-body-no-response-body/runtime/auth.go.golden
@@ -49,25 +49,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -75,13 +84,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/server-object/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/server-object/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-complex-union/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-complex-union/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-discriminated-union-inline-discriminator-only/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-discriminated-union-inline-discriminator-only/runtime/auth.go.golden
@@ -59,25 +59,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -85,13 +94,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-discriminated-union-internally-tagged/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-discriminated-union-internally-tagged/runtime/auth.go.golden
@@ -52,25 +52,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -78,13 +87,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/auth.go.golden
@@ -55,25 +55,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -81,13 +90,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-discriminated-union-multiple/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-discriminated-union-multiple/runtime/auth.go.golden
@@ -53,25 +53,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -79,13 +88,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-discriminated-union-with-refs/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-discriminated-union-with-refs/runtime/auth.go.golden
@@ -51,25 +51,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -77,13 +86,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-intersection-allof/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-intersection-allof/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-intersection-with-nullable-reference/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-intersection-with-nullable-reference/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-nested-union/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-nested-union/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-simple-type-alias/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-simple-type-alias/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-union-mixed/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-union-mixed/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-union-with-any/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-union-with-any/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-union-with-inline-objects/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-union-with-inline-objects/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-union-with-interfaces/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-union-with-interfaces/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/go/go-http/type-aliases-union-with-primitives/runtime/auth.go.golden
+++ b/tests/golden/go/go-http/type-aliases-union-with-primitives/runtime/auth.go.golden
@@ -50,25 +50,34 @@ const (
 )
 
 // APIKeyAuth attaches a named API key to a request.
+//
+// Use the Key field for a static key, or KeyProvider for a function
+// that returns the current key (evaluated per-request).  If both are
+// set, KeyProvider takes precedence.
 type APIKeyAuth struct {
-	Key      string
-	Name     string
-	Location APIKeyLocation
+	Key         string
+	KeyProvider func() string
+	Name        string
+	Location    APIKeyLocation
 }
 
 func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
-	if a.Key == "" || a.Name == "" {
+	key := a.Key
+	if a.KeyProvider != nil {
+		key = a.KeyProvider()
+	}
+	if key == "" || a.Name == "" {
 		return fmt.Errorf("api key auth: empty key or name")
 	}
 	switch a.Location {
 	case APIKeyInHeader:
-		req.Header.Set(a.Name, a.Key)
+		req.Header.Set(a.Name, key)
 	case APIKeyInQuery:
 		q := req.URL.Query()
-		q.Set(a.Name, a.Key)
+		q.Set(a.Name, key)
 		req.URL.RawQuery = q.Encode()
 	case APIKeyInCookie:
-		req.AddCookie(&http.Cookie{Name: a.Name, Value: a.Key})
+		req.AddCookie(&http.Cookie{Name: a.Name, Value: key})
 	default:
 		return fmt.Errorf("api key auth: unknown location %d", a.Location)
 	}
@@ -76,13 +85,28 @@ func (a APIKeyAuth) AuthenticateRequest(req *http.Request) error {
 }
 
 // BasicAuth sends `Authorization: Basic <base64(user:pass)>`.
+//
+// Use the Username/Password fields for static credentials, or
+// UsernameProvider/PasswordProvider for functions that return the
+// current credentials (evaluated per-request).  If a provider is set,
+// it takes precedence over the corresponding static field.
 type BasicAuth struct {
-	Username string
-	Password string
+	Username         string
+	Password         string
+	UsernameProvider func() string
+	PasswordProvider func() string
 }
 
 func (b BasicAuth) AuthenticateRequest(req *http.Request) error {
-	creds := b.Username + ":" + b.Password
+	user := b.Username
+	if b.UsernameProvider != nil {
+		user = b.UsernameProvider()
+	}
+	pass := b.Password
+	if b.PasswordProvider != nil {
+		pass = b.PasswordProvider()
+	}
+	creds := user + ":" + pass
 	encoded := base64.StdEncoding.EncodeToString([]byte(creds))
 	req.Header.Set("Authorization", "Basic "+encoded)
 	return nil

--- a/tests/golden/java/java-okhttp/additional-properties/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/additional-properties/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/comprehensive-schemas/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/comprehensive-schemas/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/delete-with-response-schema/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/delete-with-response-schema/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/duplicate-param-names/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/duplicate-param-names/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/enum-repr/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/enum-repr/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/interface-with-enum-reference/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/interface-with-enum-reference/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/minimal/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/minimal/runtime/ApiKeyAuth.java.golden
@@ -4,26 +4,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/multiple-similar-request-schemas/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/multiple-similar-request-schemas/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/naming-conventions/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/naming-conventions/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/petstore/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/petstore/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/query-param-enum/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/query-param-enum/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-all-optional-properties/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-all-optional-properties/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-array-of-inline-objects/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-array-of-inline-objects/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-array-of-referenced-types/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-array-of-referenced-types/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-array-with-reference-property/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-array-with-reference-property/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-complex-array-structure/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-complex-array-structure/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-deeply-nested-inline/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-deeply-nested-inline/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-empty-array/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-empty-array/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-inline-object-with-array/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-inline-object-with-array/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-inline-object/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-inline-object/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-mixed-property-types/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-mixed-property-types/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-nested-object-reference/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-nested-object-reference/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-optional-array-of-inline-objects/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-optional-array-of-inline-objects/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-optional-array-of-referenced-types/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-optional-array-of-referenced-types/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-optional-inline-object/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-optional-inline-object/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-optional-nested-object-reference/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-optional-nested-object-reference/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/recursive-json-primitive-array/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-primitive-array/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/request-body-content-types/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/request-body-content-types/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/reserved-word-fields/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/reserved-word-fields/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/response-body-default-and-exact/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/response-body-default-and-exact/runtime/ApiKeyAuth.java.golden
@@ -4,26 +4,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/response-body-fallback/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/response-body-fallback/runtime/ApiKeyAuth.java.golden
@@ -4,26 +4,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/response-body-multi-status-responses/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/response-body-multi-status-responses/runtime/ApiKeyAuth.java.golden
@@ -4,26 +4,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/response-body-no-response-body/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/response-body-no-response-body/runtime/ApiKeyAuth.java.golden
@@ -4,26 +4,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/server-object/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/server-object/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-complex-union/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-complex-union/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-inline-discriminator-only/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-inline-discriminator-only/runtime/ApiKeyAuth.java.golden
@@ -14,26 +14,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-internally-tagged/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-internally-tagged/runtime/ApiKeyAuth.java.golden
@@ -7,26 +7,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/ApiKeyAuth.java.golden
@@ -10,26 +10,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-multiple/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-multiple/runtime/ApiKeyAuth.java.golden
@@ -8,26 +8,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-with-refs/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-with-refs/runtime/ApiKeyAuth.java.golden
@@ -6,26 +6,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-intersection-allof/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-intersection-allof/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-intersection-with-nullable-reference/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-intersection-with-nullable-reference/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-nested-union/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-nested-union/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-simple-type-alias/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-simple-type-alias/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-union-mixed/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-mixed/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-union-with-any/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-with-any/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-union-with-inline-objects/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-with-inline-objects/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-union-with-interfaces/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-with-interfaces/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/java/java-okhttp/type-aliases-union-with-primitives/runtime/ApiKeyAuth.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-with-primitives/runtime/ApiKeyAuth.java.golden
@@ -5,26 +5,37 @@
 
 package com.example.sdk.runtime;
 
+import java.util.function.Supplier;
 import okhttp3.Request;
 
 public class ApiKeyAuth implements Authenticator {
     private final String key;
+    private final Supplier<String> keyProvider;
     private final String name;
     private final ApiKeyLocation location;
 
     public ApiKeyAuth(String key, String name, ApiKeyLocation location) {
         this.key = key;
+        this.keyProvider = null;
+        this.name = name;
+        this.location = location;
+    }
+
+    public ApiKeyAuth(Supplier<String> keyProvider, String name, ApiKeyLocation location) {
+        this.key = null;
+        this.keyProvider = keyProvider;
         this.name = name;
         this.location = location;
     }
 
     @Override
     public void authenticate(Request.Builder builder) {
+        String k = keyProvider != null ? keyProvider.get() : key;
         if (location == ApiKeyLocation.HEADER) {
-            builder.header(name, key);
+            builder.header(name, k);
         } else if (location == ApiKeyLocation.QUERY) {
             builder.url(builder.build().url().newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build());
         }
     }

--- a/tests/golden/kotlin/kotlin-okhttp/additional-properties/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/additional-properties/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/comprehensive-schemas/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/comprehensive-schemas/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/delete-with-response-schema/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/delete-with-response-schema/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/duplicate-param-names/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/duplicate-param-names/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/enum-repr/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/enum-repr/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/interface-with-enum-reference/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/interface-with-enum-reference/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/minimal/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/minimal/runtime/Auth.kt.golden
@@ -30,17 +30,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/multiple-similar-request-schemas/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/multiple-similar-request-schemas/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/naming-conventions/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/naming-conventions/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/petstore/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/petstore/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/query-param-enum/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/query-param-enum/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-all-optional-properties/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-all-optional-properties/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-array-of-inline-objects/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-array-of-inline-objects/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-array-of-referenced-types/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-array-of-referenced-types/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-array-with-reference-property/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-array-with-reference-property/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-complex-array-structure/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-complex-array-structure/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-deeply-nested-inline/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-deeply-nested-inline/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-empty-array/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-empty-array/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-inline-object-with-array/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-inline-object-with-array/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-inline-object/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-inline-object/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-mixed-property-types/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-mixed-property-types/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-nested-object-reference/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-nested-object-reference/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-optional-array-of-inline-objects/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-optional-array-of-inline-objects/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-optional-array-of-referenced-types/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-optional-array-of-referenced-types/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-optional-inline-object/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-optional-inline-object/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-optional-nested-object-reference/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-optional-nested-object-reference/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/recursive-json-primitive-array/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/recursive-json-primitive-array/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/request-body-content-types/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/request-body-content-types/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/reserved-word-fields/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/reserved-word-fields/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/response-body-default-and-exact/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/response-body-default-and-exact/runtime/Auth.kt.golden
@@ -30,17 +30,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/response-body-fallback/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/response-body-fallback/runtime/Auth.kt.golden
@@ -30,17 +30,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/response-body-multi-status-responses/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/response-body-multi-status-responses/runtime/Auth.kt.golden
@@ -30,17 +30,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/response-body-no-response-body/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/response-body-no-response-body/runtime/Auth.kt.golden
@@ -30,17 +30,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/server-object/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/server-object/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-complex-union/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-complex-union/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-inline-discriminator-only/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-inline-discriminator-only/runtime/Auth.kt.golden
@@ -40,17 +40,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-internally-tagged/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-internally-tagged/runtime/Auth.kt.golden
@@ -33,17 +33,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/Auth.kt.golden
@@ -36,17 +36,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-multiple/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-multiple/runtime/Auth.kt.golden
@@ -34,17 +34,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-with-refs/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-discriminated-union-with-refs/runtime/Auth.kt.golden
@@ -32,17 +32,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-intersection-allof/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-intersection-allof/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-intersection-with-nullable-reference/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-intersection-with-nullable-reference/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-nested-union/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-nested-union/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-simple-type-alias/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-simple-type-alias/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-mixed/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-mixed/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-with-any/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-with-any/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-with-inline-objects/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-with-inline-objects/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-with-interfaces/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-with-interfaces/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-with-primitives/runtime/Auth.kt.golden
+++ b/tests/golden/kotlin/kotlin-okhttp/type-aliases-union-with-primitives/runtime/Auth.kt.golden
@@ -31,17 +31,33 @@ class BearerAuth : Authenticator {
     }
 }
 
-class ApiKeyAuth(
-    private val key: String,
-    private val name: String,
-    private val location: ApiKeyLocation,
-) : Authenticator {
+class ApiKeyAuth : Authenticator {
+    private val key: String?
+    private val keyProvider: (() -> String)?
+    private val name: String
+    private val location: ApiKeyLocation
+
+    constructor(key: String, name: String, location: ApiKeyLocation) {
+        this.key = key
+        this.keyProvider = null
+        this.name = name
+        this.location = location
+    }
+
+    constructor(keyProvider: () -> String, name: String, location: ApiKeyLocation) {
+        this.key = null
+        this.keyProvider = keyProvider
+        this.name = name
+        this.location = location
+    }
+
     override fun authenticate(builder: Request.Builder) {
+        val k = keyProvider?.invoke() ?: key!!
         when (location) {
-            ApiKeyLocation.HEADER -> builder.header(name, key)
+            ApiKeyLocation.HEADER -> builder.header(name, k)
             ApiKeyLocation.QUERY -> {
                 val url = builder.build().url.newBuilder()
-                    .addQueryParameter(name, key)
+                    .addQueryParameter(name, k)
                     .build()
                 builder.url(url)
             }

--- a/tests/golden/python/python-httpx/additional-properties/additional_properties_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/additional-properties/additional_properties_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/delete-with-response-schema/test_api_with_delete_response_schema/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/delete-with-response-schema/test_api_with_delete_response_schema/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/duplicate-param-names/duplicate_parameter_names_test_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/duplicate-param-names/duplicate_parameter_names_test_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/interface-with-enum-reference/interface_with_enum_reference_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/interface-with-enum-reference/interface_with_enum_reference_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/minimal/minimal_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/minimal/minimal_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/multiple-similar-request-schemas/multiple_similar_request_schemas_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/multiple-similar-request-schemas/multiple_similar_request_schemas_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/naming-conventions/naming_conventions_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/naming-conventions/naming_conventions_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/petstore/petstore_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/petstore/petstore_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/query-param-enum/query_parameter_enum_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/query-param-enum/query_parameter_enum_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-all-optional-properties/all_optional_properties_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-all-optional-properties/all_optional_properties_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-array-of-inline-objects/array_of_inline_objects_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-array-of-inline-objects/array_of_inline_objects_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-array-of-referenced-types/array_of_referenced_types_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-array-of-referenced-types/array_of_referenced_types_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-array-with-reference-property/array_with_reference_property_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-array-with-reference-property/array_with_reference_property_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-complex-array-structure/complex_array_structure_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-complex-array-structure/complex_array_structure_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-deeply-nested-inline/deeply_nested_inline_objects_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-deeply-nested-inline/deeply_nested_inline_objects_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-empty-array/empty_array_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-empty-array/empty_array_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-inline-object-with-array/inline_object_with_array_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-inline-object-with-array/inline_object_with_array_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-inline-object/inline_object_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-inline-object/inline_object_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-mixed-property-types/mixed_property_types_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-mixed-property-types/mixed_property_types_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-nested-object-reference/nested_object_reference_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-nested-object-reference/nested_object_reference_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-optional-array-of-inline-objects/optional_array_of_inline_objects_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-optional-array-of-inline-objects/optional_array_of_inline_objects_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-optional-array-of-referenced-types/optional_array_of_referenced_types_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-optional-array-of-referenced-types/optional_array_of_referenced_types_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-optional-inline-object/optional_inline_object_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-optional-inline-object/optional_inline_object_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-optional-nested-object-reference/optional_nested_object_reference_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-optional-nested-object-reference/optional_nested_object_reference_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/recursive-json-primitive-array/primitive_array_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/recursive-json-primitive-array/primitive_array_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/request-body-content-types/request_body_content_types/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/request-body-content-types/request_body_content_types/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/response-body-default-and-exact/default_and_exact_response_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/response-body-default-and-exact/default_and_exact_response_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/response-body-fallback/response_fallback_test_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/response-body-fallback/response_fallback_test_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/response-body-multi-status-responses/multi_status_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/response-body-multi-status-responses/multi_status_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/response-body-no-response-body/no_response_body_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/response-body-no-response-body/no_response_body_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/server-object/test_api_with_server_objects/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/server-object/test_api_with_server_objects/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-complex-union/complex_union_type_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-complex-union/complex_union_type_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-inline-discriminator-only/discriminated_union_with_inline_discriminator_only_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-inline-discriminator-only/discriminated_union_with_inline_discriminator_only_test/runtime/auth.py.golden
@@ -45,11 +45,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/runtime/auth.py.golden
@@ -38,11 +38,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/runtime/auth.py.golden
@@ -41,11 +41,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/runtime/auth.py.golden
@@ -39,11 +39,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/runtime/auth.py.golden
@@ -37,11 +37,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-intersection-allof/intersection_type_all_of_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-intersection-allof/intersection_type_all_of_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-nested-union/nested_union_type_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-nested-union/nested_union_type_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-simple-type-alias/simple_type_alias_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-simple-type-alias/simple_type_alias_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-union-mixed/union_type_with_mixed_members_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-mixed/union_type_with_mixed_members_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-union-with-any/union_type_with_any_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-with-any/union_type_with_any_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-union-with-inline-objects/union_type_with_inline_objects_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-with-inline-objects/union_type_with_inline_objects_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-union-with-interfaces/union_type_with_interfaces_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-with-interfaces/union_type_with_interfaces_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-httpx/type-aliases-union-with-primitives/union_type_with_primitives_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-with-primitives/union_type_with_primitives_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/additional-properties/additional_properties_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/additional-properties/additional_properties_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/delete-with-response-schema/test_api_with_delete_response_schema/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/delete-with-response-schema/test_api_with_delete_response_schema/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/duplicate-param-names/duplicate_parameter_names_test_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/duplicate-param-names/duplicate_parameter_names_test_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/interface-with-enum-reference/interface_with_enum_reference_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/interface-with-enum-reference/interface_with_enum_reference_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/minimal/minimal_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/minimal/minimal_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/multiple-similar-request-schemas/multiple_similar_request_schemas_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/multiple-similar-request-schemas/multiple_similar_request_schemas_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/naming-conventions/naming_conventions_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/naming-conventions/naming_conventions_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/petstore/petstore_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/petstore/petstore_api/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/query-param-enum/query_parameter_enum_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/query-param-enum/query_parameter_enum_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-all-optional-properties/all_optional_properties_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-all-optional-properties/all_optional_properties_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-array-of-inline-objects/array_of_inline_objects_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-array-of-inline-objects/array_of_inline_objects_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-array-of-referenced-types/array_of_referenced_types_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-array-of-referenced-types/array_of_referenced_types_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-array-with-reference-property/array_with_reference_property_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-array-with-reference-property/array_with_reference_property_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-complex-array-structure/complex_array_structure_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-complex-array-structure/complex_array_structure_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-deeply-nested-inline/deeply_nested_inline_objects_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-deeply-nested-inline/deeply_nested_inline_objects_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-empty-array/empty_array_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-empty-array/empty_array_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-inline-object-with-array/inline_object_with_array_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-inline-object-with-array/inline_object_with_array_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-inline-object/inline_object_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-inline-object/inline_object_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-mixed-property-types/mixed_property_types_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-mixed-property-types/mixed_property_types_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-nested-object-reference/nested_object_reference_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-nested-object-reference/nested_object_reference_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-optional-array-of-inline-objects/optional_array_of_inline_objects_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-optional-array-of-inline-objects/optional_array_of_inline_objects_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-optional-array-of-referenced-types/optional_array_of_referenced_types_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-optional-array-of-referenced-types/optional_array_of_referenced_types_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-optional-inline-object/optional_inline_object_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-optional-inline-object/optional_inline_object_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-optional-nested-object-reference/optional_nested_object_reference_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-optional-nested-object-reference/optional_nested_object_reference_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/recursive-json-primitive-array/primitive_array_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/recursive-json-primitive-array/primitive_array_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/request-body-content-types/request_body_content_types/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/request-body-content-types/request_body_content_types/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/response-body-default-and-exact/default_and_exact_response_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/response-body-default-and-exact/default_and_exact_response_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/response-body-fallback/response_fallback_test_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/response-body-fallback/response_fallback_test_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/response-body-multi-status-responses/multi_status_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/response-body-multi-status-responses/multi_status_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/response-body-no-response-body/no_response_body_api/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/response-body-no-response-body/no_response_body_api/runtime/auth.py.golden
@@ -35,11 +35,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/server-object/test_api_with_server_objects/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/server-object/test_api_with_server_objects/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-complex-union/complex_union_type_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-complex-union/complex_union_type_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-inline-discriminator-only/discriminated_union_with_inline_discriminator_only_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-inline-discriminator-only/discriminated_union_with_inline_discriminator_only_test/runtime/auth.py.golden
@@ -45,11 +45,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/runtime/auth.py.golden
@@ -38,11 +38,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/runtime/auth.py.golden
@@ -41,11 +41,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/runtime/auth.py.golden
@@ -39,11 +39,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/runtime/auth.py.golden
@@ -37,11 +37,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-intersection-allof/intersection_type_all_of_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-intersection-allof/intersection_type_all_of_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-intersection-with-nullable-reference/intersection_type_with_nullable_reference_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-nested-union/nested_union_type_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-nested-union/nested_union_type_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-simple-type-alias/simple_type_alias_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-simple-type-alias/simple_type_alias_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-union-mixed/union_type_with_mixed_members_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-mixed/union_type_with_mixed_members_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-union-with-any/union_type_with_any_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-with-any/union_type_with_any_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-union-with-inline-objects/union_type_with_inline_objects_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-with-inline-objects/union_type_with_inline_objects_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-union-with-interfaces/union_type_with_interfaces_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-with-interfaces/union_type_with_interfaces_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/python/python-requests/type-aliases-union-with-primitives/union_type_with_primitives_test/runtime/auth.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-with-primitives/union_type_with_primitives_test/runtime/auth.py.golden
@@ -36,11 +36,16 @@ class BearerAuth(Authenticator):
 
 
 class ApiKeyAuth(Authenticator):
-    """API key authentication via a custom header."""
+    """API key authentication via a custom header.
 
-    def __init__(self, header_name: str, api_key: str) -> None:
+    Accepts a static key string or a callable that returns the
+    current key (evaluated on every request).
+    """
+
+    def __init__(self, header_name: str, api_key: str | Callable[[], str]) -> None:
         self._header_name = header_name
         self._api_key = api_key
 
     def auth_headers(self) -> dict[str, str]:
-        return {self._header_name: self._api_key}
+        key = self._api_key() if callable(self._api_key) else self._api_key
+        return {self._header_name: key}

--- a/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/minimal/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/src/runtime/auth.rs.golden
@@ -93,17 +93,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -113,6 +170,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/auth.rs.golden
@@ -95,17 +95,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -115,6 +172,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/petstore/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/auth.rs.golden
@@ -93,17 +93,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -113,6 +170,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/auth.rs.golden
@@ -93,17 +93,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -113,6 +170,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/auth.rs.golden
@@ -93,17 +93,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -113,6 +170,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/auth.rs.golden
@@ -93,17 +93,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -113,6 +170,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/server-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/auth.rs.golden
@@ -103,17 +103,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -123,6 +180,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/auth.rs.golden
@@ -96,17 +96,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -116,6 +173,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/auth.rs.golden
@@ -99,17 +99,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -119,6 +176,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/auth.rs.golden
@@ -97,17 +97,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -117,6 +174,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/auth.rs.golden
@@ -95,17 +95,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -115,6 +172,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/auth.rs.golden
@@ -94,17 +94,74 @@ impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
@@ -114,6 +171,10 @@ impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
         &self,
         req: aioduct::RequestBuilder<'a, R>,
     ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
-        Ok(req.header_str(&self.header_name, &self.api_key)?)
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        Ok(req.header_str(&self.header_name, &key)?)
     }
 }

--- a/tests/golden/rust/rust-reqwest/additional-properties/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/additional-properties/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/comprehensive-schemas/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/comprehensive-schemas/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/delete-with-response-schema/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/delete-with-response-schema/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/duplicate-param-names/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/duplicate-param-names/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/enum-repr/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/enum-repr/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/interface-with-enum-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/interface-with-enum-reference/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/minimal/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/minimal/src/runtime/auth.rs.golden
@@ -95,30 +95,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/multiline-docs-and-primitive-alias/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/multiline-docs-and-primitive-alias/src/runtime/auth.rs.golden
@@ -97,30 +97,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/multiple-similar-request-schemas/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/multiple-similar-request-schemas/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/naming-conventions/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/naming-conventions/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/petstore/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/petstore/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/query-param-enum/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/query-param-enum/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-all-optional-properties/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-all-optional-properties/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-array-of-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-array-of-inline-objects/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-array-of-referenced-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-array-of-referenced-types/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-array-with-reference-property/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-array-with-reference-property/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-complex-array-structure/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-complex-array-structure/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-deeply-nested-inline/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-deeply-nested-inline/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-empty-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-empty-array/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-inline-object-with-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-inline-object-with-array/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-inline-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-inline-object/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-mixed-property-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-mixed-property-types/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-nested-object-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-nested-object-reference/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-optional-array-of-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-optional-array-of-inline-objects/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-optional-array-of-referenced-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-optional-array-of-referenced-types/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-optional-inline-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-optional-inline-object/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-optional-nested-object-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-optional-nested-object-reference/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/recursive-json-primitive-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-primitive-array/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/request-body-content-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/request-body-content-types/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/response-body-default-and-exact/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/response-body-default-and-exact/src/runtime/auth.rs.golden
@@ -95,30 +95,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/response-body-fallback/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/response-body-fallback/src/runtime/auth.rs.golden
@@ -95,30 +95,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/response-body-multi-status-responses/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/response-body-multi-status-responses/src/runtime/auth.rs.golden
@@ -95,30 +95,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/response-body-no-response-body/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/response-body-no-response-body/src/runtime/auth.rs.golden
@@ -95,30 +95,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/server-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/server-object/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-complex-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-complex-union/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/auth.rs.golden
@@ -105,30 +105,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-internally-tagged/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-internally-tagged/src/runtime/auth.rs.golden
@@ -98,30 +98,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/auth.rs.golden
@@ -101,30 +101,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-multiple/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-multiple/src/runtime/auth.rs.golden
@@ -99,30 +99,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-with-refs/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-with-refs/src/runtime/auth.rs.golden
@@ -97,30 +97,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-intersection-allof/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-intersection-allof/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-intersection-with-nullable-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-intersection-with-nullable-reference/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-nested-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-nested-union/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-simple-type-alias/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-simple-type-alias/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-mixed/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-mixed/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-with-any/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-with-any/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-with-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-with-inline-objects/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-with-interfaces/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-with-interfaces/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-with-primitives/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-with-primitives/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/utoipa-mixed/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/utoipa-mixed/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/utoipa-untagged-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/utoipa-untagged-union/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-reqwest/utoipa-with-extra-derives/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-reqwest/utoipa-with-extra-derives/src/runtime/auth.rs.golden
@@ -96,30 +96,90 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication via header.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
-    /// Create a new API key authenticator.
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn authenticate(&self, headers: &mut HeaderMap) -> Result<(), Error> {
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
         let name = reqwest::header::HeaderName::from_bytes(self.header_name.as_bytes())
             .map_err(|e| Error::Api {
                 status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
                 body: format!("invalid header name: {e}"),
             })?;
-        let value = HeaderValue::from_str(&self.api_key).map_err(|e| Error::Api {
+        let value = HeaderValue::from_str(&key).map_err(|e| Error::Api {
             status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
             body: format!("invalid header value: {e}"),
         })?;

--- a/tests/golden/rust/rust-ureq/additional-properties/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/additional-properties/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/comprehensive-schemas/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/comprehensive-schemas/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/delete-with-response-schema/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/delete-with-response-schema/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/duplicate-param-names/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/duplicate-param-names/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/enum-repr/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/enum-repr/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/interface-with-enum-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/interface-with-enum-reference/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/minimal/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/minimal/src/runtime/auth.rs.golden
@@ -85,23 +85,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/multiline-docs-and-primitive-alias/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/multiline-docs-and-primitive-alias/src/runtime/auth.rs.golden
@@ -87,23 +87,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/multiple-similar-request-schemas/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/multiple-similar-request-schemas/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/naming-conventions/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/naming-conventions/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/petstore/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/petstore/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/query-param-enum/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/query-param-enum/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-all-optional-properties/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-all-optional-properties/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-array-of-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-array-of-inline-objects/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-array-of-referenced-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-array-of-referenced-types/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-array-with-reference-property/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-array-with-reference-property/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-complex-array-structure/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-complex-array-structure/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-deeply-nested-inline/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-deeply-nested-inline/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-empty-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-empty-array/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-inline-object-with-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-inline-object-with-array/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-inline-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-inline-object/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-mixed-property-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-mixed-property-types/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-nested-object-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-nested-object-reference/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-optional-array-of-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-optional-array-of-inline-objects/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-optional-array-of-referenced-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-optional-array-of-referenced-types/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-optional-inline-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-optional-inline-object/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-optional-nested-object-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-optional-nested-object-reference/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/recursive-json-primitive-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-primitive-array/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/request-body-content-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/request-body-content-types/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/response-body-default-and-exact/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/response-body-default-and-exact/src/runtime/auth.rs.golden
@@ -85,23 +85,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/response-body-fallback/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/response-body-fallback/src/runtime/auth.rs.golden
@@ -85,23 +85,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/response-body-multi-status-responses/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/response-body-multi-status-responses/src/runtime/auth.rs.golden
@@ -85,23 +85,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/response-body-no-response-body/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/response-body-no-response-body/src/runtime/auth.rs.golden
@@ -85,23 +85,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/server-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/server-object/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-complex-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-complex-union/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/auth.rs.golden
@@ -95,23 +95,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-internally-tagged/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-internally-tagged/src/runtime/auth.rs.golden
@@ -88,23 +88,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/auth.rs.golden
@@ -91,23 +91,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-multiple/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-multiple/src/runtime/auth.rs.golden
@@ -89,23 +89,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-with-refs/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-with-refs/src/runtime/auth.rs.golden
@@ -87,23 +87,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-intersection-allof/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-intersection-allof/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-intersection-with-nullable-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-intersection-with-nullable-reference/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-nested-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-nested-union/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-simple-type-alias/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-simple-type-alias/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-union-mixed/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-mixed/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-union-with-any/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-with-any/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-union-with-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-with-inline-objects/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-union-with-interfaces/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-with-interfaces/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/type-aliases-union-with-primitives/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-with-primitives/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/utoipa-mixed/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/utoipa-mixed/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/utoipa-untagged-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/utoipa-untagged-union/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/rust/rust-ureq/utoipa-with-extra-derives/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-ureq/utoipa-with-extra-derives/src/runtime/auth.rs.golden
@@ -86,23 +86,84 @@ impl Authenticator for BearerAuth {
 }
 
 /// API key authentication.
-#[derive(Debug, Clone)]
+///
+/// Use [`ApiKeyAuth::new`] with a static key, or
+/// [`ApiKeyAuth::from_provider`] with a function that returns the
+/// current key (evaluated on every request).
 pub struct ApiKeyAuth {
     header_name: String,
-    api_key: String,
+    api_key: KeySource,
+}
+
+enum KeySource {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl std::fmt::Debug for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Static(k) => f.debug_tuple("Static").field(&k).finish(),
+            Self::Dynamic(_) => f.debug_tuple("Dynamic").field(&"<function>").finish(),
+        }
+    }
+}
+
+impl Clone for KeySource {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Static(k) => Self::Static(k.clone()),
+            Self::Dynamic(f) => Self::Dynamic(Arc::clone(f)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("header_name", &self.header_name)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+impl Clone for ApiKeyAuth {
+    fn clone(&self) -> Self {
+        Self {
+            header_name: self.header_name.clone(),
+            api_key: self.api_key.clone(),
+        }
+    }
 }
 
 impl ApiKeyAuth {
+    /// Create a new API key authenticator with a static key.
     pub fn new(header_name: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             header_name: header_name.into(),
-            api_key: api_key.into(),
+            api_key: KeySource::Static(api_key.into()),
+        }
+    }
+
+    /// Create an API key authenticator that evaluates the given
+    /// function on every request to obtain the current key.
+    pub fn from_provider(
+        header_name: impl Into<String>,
+        f: impl Fn() -> String + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            header_name: header_name.into(),
+            api_key: KeySource::Dynamic(Arc::new(f)),
         }
     }
 }
 
 impl Authenticator for ApiKeyAuth {
     fn auth_headers(&self) -> Vec<(&str, String)> {
-        vec![(&self.header_name, self.api_key.clone())]
+        let key = match &self.api_key {
+            KeySource::Static(k) => k.clone(),
+            KeySource::Dynamic(f) => f(),
+        };
+        vec![(&self.header_name, key)]
     }
 }

--- a/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
@@ -10,8 +10,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -41,12 +41,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -145,6 +153,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
@@ -10,8 +10,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -41,12 +41,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -145,6 +153,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
@@ -10,8 +10,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -41,12 +41,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -145,6 +153,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
@@ -10,8 +10,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -41,12 +41,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -145,6 +153,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
@@ -10,8 +10,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -41,12 +41,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -145,6 +153,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-enum-const/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-enum-const/runtime/runtime.ts.golden
@@ -10,8 +10,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -41,12 +41,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -145,6 +153,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-enum-ref/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-enum-ref/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-externally-tagged/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-externally-tagged/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-intersection-enum-ref/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-intersection-enum-ref/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-intersection/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-intersection/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-response-only-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-response-only-types/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-tagged-union-variant-with-discriminator/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-tagged-union-variant-with-discriminator/runtime/runtime.ts.golden
@@ -14,8 +14,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -45,12 +45,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -149,6 +157,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-tagged-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-tagged-union/runtime/runtime.ts.golden
@@ -12,8 +12,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -43,12 +43,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -147,6 +155,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-union/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-comprehensive/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-comprehensive/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-delete-response/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-delete-response/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-enum-repr/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-enum-repr/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-petstore/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-petstore/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp/runtime/runtime.ts.golden
@@ -12,8 +12,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -43,12 +43,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -147,6 +155,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/ts-type-guards/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-type-guards/runtime/runtime.ts.golden
@@ -10,8 +10,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -41,12 +41,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -145,6 +153,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
@@ -20,8 +20,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -51,12 +51,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -155,6 +163,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
@@ -13,8 +13,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -44,12 +44,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -148,6 +156,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/runtime.ts.golden
@@ -16,8 +16,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -47,12 +47,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -151,6 +159,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
@@ -14,8 +14,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -45,12 +45,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -149,6 +157,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
@@ -12,8 +12,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -43,12 +43,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -147,6 +155,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
@@ -11,8 +11,8 @@ export interface ConfigurationParameters {
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-  username?: string; // parameter for basic security
-  password?: string; // parameter for basic security
+  username?: string | (() => string | Promise<string>); // parameter for basic security
+  password?: string | (() => string | Promise<string>); // parameter for basic security
   apiKey?: string | Promise<string> | ((name: string) => string | Promise<string>); // parameter for apiKey security
   accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
   headers?: HTTPHeaders; //header params we want to use on every request
@@ -42,12 +42,20 @@ export class Configuration {
     return this.configuration.queryParamsStringify || querystring;
   }
 
-  get username(): string | undefined {
-    return this.configuration.username;
+  get username(): (() => string | Promise<string>) | undefined {
+    const username = this.configuration.username;
+    if (username) {
+      return typeof username === 'function' ? username : async () => username;
+    }
+    return undefined;
   }
 
-  get password(): string | undefined {
-    return this.configuration.password;
+  get password(): (() => string | Promise<string>) | undefined {
+    const password = this.configuration.password;
+    if (password) {
+      return typeof password === 'function' ? password : async () => password;
+    }
+    return undefined;
   }
 
   get apiKey(): ((name: string) => string | Promise<string>) | undefined {
@@ -146,6 +154,14 @@ export class BaseAPI {
     const token = await this.configuration.accessToken?.();
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (!headers['Authorization']) {
+      const username = await this.configuration.username?.();
+      const password = await this.configuration.password?.();
+      if (username && password) {
+        headers['Authorization'] = `Basic ${btoa(`${username}:${password}`)}`;
+      }
     }
 
     const initOverrideFn =


### PR DESCRIPTION
## Summary

Extends dynamic/lazy auth provider support to `ApiKeyAuth` and `BasicAuth`, matching the pattern already established for `BearerAuth` in #106. Every auth type now consistently supports both static credentials and per-request evaluation across all generators.

## Changes by auth type

### ApiKeyAuth dynamic key provider

| Generator | Change |
|-----------|--------|
| **Go** | `KeyProvider func() string` field |
| **Java** | `Supplier\<String\>` constructor overload |
| **Kotlin** | `(() -> String)` constructor overload |
| **Python** | `api_key` accepts `str \| Callable[[], str]` |
| **Rust** | `KeySource` enum + `from_provider()` factory |

### BasicAuth dynamic credential provider

| Generator | Change |
|-----------|--------|
| **Go** | `UsernameProvider` / `PasswordProvider` func fields |
| **TypeScript** | `username` / `password` accept `(() => string \| Promise\<string\>)`, auto-wired into `createFetchParams()` |

### TypeScript Configuration

- `username`/`password` getters now normalize to callable (same pattern as `accessToken`)
- Basic auth wired with `!headers['Authorization']` guard (defers to `accessToken` when both are configured)

## Docs

- New `Usage Patterns` section with end-to-end OAuth2 token refresh examples (TS, Go, Python, Rust)
- Dynamic provider examples for all three auth types
- Updated changelog

## Verification

- All 648 tests pass
- Golden files regenerated for all 9 generators