### PR TITLE
fix: wrap Python type aliases in parentheses for PEP 695 multi-line support

### DIFF
--- a/src/generators/python/httpx/emit_models.rs
+++ b/src/generators/python/httpx/emit_models.rs
@@ -264,7 +264,7 @@ fn emit_alias(schema: &IrSchema, expr: &IrTypeExpr) -> Option<FileSpec> {
     let rhs_type = python_type_name(expr);
 
     let type_alias = sigil_quote!(Python {
-        type $N(name.as_str()) = $T(rhs_type);
+        type $N(name.as_str()) = ($T(rhs_type));
     })
     .ok()?;
 
@@ -298,6 +298,38 @@ fn emit_type_alias_raw(schema: &IrSchema, rhs: &str) -> Option<FileSpec> {
 }
 
 // ---------------------------------------------------------------------------
+// Type alias builder with proper multi-line formatting
+// ---------------------------------------------------------------------------
+
+fn format_type_alias(name: &str, members: &[TypeName]) -> CodeBlock {
+    let mut cb = CodeBlock::builder();
+    if members.is_empty() {
+        cb.add(
+            "type %N = (%T)",
+            (
+                NameArg(name.to_string()),
+                TypeName::importable("typing", "Any"),
+            ),
+        );
+    } else if members.len() == 1 {
+        cb.add(
+            "type %N = (%T)",
+            (NameArg(name.to_string()), members[0].clone()),
+        );
+    } else {
+        cb.add(
+            "type %N = (\n    %T",
+            (NameArg(name.to_string()), members[0].clone()),
+        );
+        for member in &members[1..] {
+            cb.add("\n    | %T", (member.clone(),));
+        }
+        cb.add("\n)", ());
+    }
+    cb.build_unwrap()
+}
+
+// ---------------------------------------------------------------------------
 // Union -> type X = A | B | C
 // ---------------------------------------------------------------------------
 
@@ -308,16 +340,8 @@ fn emit_union(schema: &IrSchema, u: &IrUnion) -> Option<FileSpec> {
     if u.nullable {
         members.push(TypeName::primitive("None"));
     }
-    let union_ty = if members.is_empty() {
-        TypeName::importable("typing", "Any")
-    } else {
-        TypeName::union(members)
-    };
 
-    let type_alias = sigil_quote!(Python {
-        type $N(name.as_str()) = $T(union_ty);
-    })
-    .ok()?;
+    let type_alias = format_type_alias(&name, &members);
 
     let mut file =
         FileSpec::builder_with("model.py", Python::new()).header(future_annotations_header());
@@ -358,16 +382,8 @@ fn emit_intersection(schema: &IrSchema, inter: &IrIntersection, ir: &IrSpec) -> 
 fn emit_intersection_as_alias(schema: &IrSchema, inter: &IrIntersection) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
     let members: Vec<TypeName> = inter.members.iter().map(python_type_name).collect();
-    let union_ty = if members.is_empty() {
-        TypeName::importable("typing", "Any")
-    } else {
-        TypeName::union(members)
-    };
 
-    let type_alias = sigil_quote!(Python {
-        type $N(name.as_str()) = $T(union_ty);
-    })
-    .ok()?;
+    let type_alias = format_type_alias(&name, &members);
 
     let mut file =
         FileSpec::builder_with("model.py", Python::new()).header(future_annotations_header());
@@ -457,16 +473,7 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion, ir: &IrSpec) -> Opti
         .map(|v| python_type_name(&v.content_type))
         .collect();
 
-    let union_ty = if members.is_empty() {
-        TypeName::importable("typing", "Any")
-    } else {
-        TypeName::union(members)
-    };
-
-    let type_alias = sigil_quote!(Python {
-        type $N(name.as_str()) = $T(union_ty);
-    })
-    .ok()?;
+    let type_alias = format_type_alias(&name, &members);
 
     let hint = match &tu.tagging {
         TaggingStyle::Internal => {

--- a/src/generators/python/requests/emit_models.rs
+++ b/src/generators/python/requests/emit_models.rs
@@ -264,7 +264,7 @@ fn emit_alias(schema: &IrSchema, expr: &IrTypeExpr) -> Option<FileSpec> {
     let rhs_type = python_type_name(expr);
 
     let type_alias = sigil_quote!(Python {
-        type $N(name.as_str()) = $T(rhs_type);
+        type $N(name.as_str()) = ($T(rhs_type));
     })
     .ok()?;
 
@@ -298,6 +298,38 @@ fn emit_type_alias_raw(schema: &IrSchema, rhs: &str) -> Option<FileSpec> {
 }
 
 // ---------------------------------------------------------------------------
+// Type alias builder with proper multi-line formatting
+// ---------------------------------------------------------------------------
+
+fn format_type_alias(name: &str, members: &[TypeName]) -> CodeBlock {
+    let mut cb = CodeBlock::builder();
+    if members.is_empty() {
+        cb.add(
+            "type %N = (%T)",
+            (
+                NameArg(name.to_string()),
+                TypeName::importable("typing", "Any"),
+            ),
+        );
+    } else if members.len() == 1 {
+        cb.add(
+            "type %N = (%T)",
+            (NameArg(name.to_string()), members[0].clone()),
+        );
+    } else {
+        cb.add(
+            "type %N = (\n    %T",
+            (NameArg(name.to_string()), members[0].clone()),
+        );
+        for member in &members[1..] {
+            cb.add("\n    | %T", (member.clone(),));
+        }
+        cb.add("\n)", ());
+    }
+    cb.build_unwrap()
+}
+
+// ---------------------------------------------------------------------------
 // Union -> type X = A | B | C
 // ---------------------------------------------------------------------------
 
@@ -308,16 +340,8 @@ fn emit_union(schema: &IrSchema, u: &IrUnion) -> Option<FileSpec> {
     if u.nullable {
         members.push(TypeName::primitive("None"));
     }
-    let union_ty = if members.is_empty() {
-        TypeName::importable("typing", "Any")
-    } else {
-        TypeName::union(members)
-    };
 
-    let type_alias = sigil_quote!(Python {
-        type $N(name.as_str()) = $T(union_ty);
-    })
-    .ok()?;
+    let type_alias = format_type_alias(&name, &members);
 
     let mut file =
         FileSpec::builder_with("model.py", Python::new()).header(future_annotations_header());
@@ -358,16 +382,8 @@ fn emit_intersection(schema: &IrSchema, inter: &IrIntersection, ir: &IrSpec) -> 
 fn emit_intersection_as_alias(schema: &IrSchema, inter: &IrIntersection) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
     let members: Vec<TypeName> = inter.members.iter().map(python_type_name).collect();
-    let union_ty = if members.is_empty() {
-        TypeName::importable("typing", "Any")
-    } else {
-        TypeName::union(members)
-    };
 
-    let type_alias = sigil_quote!(Python {
-        type $N(name.as_str()) = $T(union_ty);
-    })
-    .ok()?;
+    let type_alias = format_type_alias(&name, &members);
 
     let mut file =
         FileSpec::builder_with("model.py", Python::new()).header(future_annotations_header());
@@ -457,16 +473,7 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion, ir: &IrSpec) -> Opti
         .map(|v| python_type_name(&v.content_type))
         .collect();
 
-    let union_ty = if members.is_empty() {
-        TypeName::importable("typing", "Any")
-    } else {
-        TypeName::union(members)
-    };
-
-    let type_alias = sigil_quote!(Python {
-        type $N(name.as_str()) = $T(union_ty);
-    })
-    .ok()?;
+    let type_alias = format_type_alias(&name, &members);
 
     let hint = match &tu.tagging {
         TaggingStyle::Internal => {

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/any_of_types.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/any_of_types.py.golden
@@ -7,4 +7,7 @@ from __future__ import annotations
 
 # Any of multiple types
 
-type AnyOfTypes = str | float
+type AnyOfTypes = (
+    str
+    | float
+)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/array_with_max_items.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/array_with_max_items.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array with maximum items constraint
 
-type ArrayWithMaxItems = list[str]
+type ArrayWithMaxItems = (list[str])

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/array_with_min_items.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/array_with_min_items.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array with minimum items constraint
 
-type ArrayWithMinItems = list[str]
+type ArrayWithMinItems = (list[str])

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/binary_string.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/binary_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with binary format
 
-type BinaryString = bytes
+type BinaryString = (bytes)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/boolean_array.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/boolean_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array of booleans
 
-type BooleanArray = list[bool]
+type BooleanArray = (list[bool])

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/boolean_type.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/boolean_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Boolean type
 
-type BooleanType = bool
+type BooleanType = (bool)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/byte_string.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/byte_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with byte format (base64)
 
-type ByteString = str
+type ByteString = (str)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/date_time_string.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/date_time_string.py.golden
@@ -9,4 +9,4 @@ from datetime import datetime
 
 # String with date-time format
 
-type DateTimeString = datetime
+type DateTimeString = (datetime)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/double_type.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/double_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Double precision floating point
 
-type DoubleType = float
+type DoubleType = (float)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/email_string.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/email_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with email format
 
-type EmailString = str
+type EmailString = (str)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/empty_object.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/empty_object.py.golden
@@ -9,4 +9,4 @@ from typing import Any
 
 # Object without properties
 
-type EmptyObject = Any
+type EmptyObject = (Any)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/float_type.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/float_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Floating point number
 
-type FloatType = float
+type FloatType = (float)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/integer32.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/integer32.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # 32-bit integer
 
-type Integer32 = int
+type Integer32 = (int)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/integer64.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/integer64.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # 64-bit integer
 
-type Integer64 = int
+type Integer64 = (int)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/integer_type.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/integer_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Basic integer type
 
-type IntegerType = int
+type IntegerType = (int)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/nested_array.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/nested_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array of arrays (nested)
 
-type NestedArray = list[list[str]]
+type NestedArray = (list[list[str]])

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/nullable_string.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/nullable_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Nullable string type (OpenAPI 3.1.2 style)
 
-type NullableString = str | None
+type NullableString = (str | None)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_array.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array of numbers
 
-type NumberArray = list[float]
+type NumberArray = (list[float])

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_type.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Basic number type
 
-type NumberType = float
+type NumberType = (float)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_maximum.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_maximum.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Number with maximum value
 
-type NumberWithMaximum = float
+type NumberWithMaximum = (float)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_minimum.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_minimum.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Number with minimum value
 
-type NumberWithMinimum = float
+type NumberWithMinimum = (float)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_multiple_of.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_multiple_of.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Number divisible by multipleOf
 
-type NumberWithMultipleOf = float
+type NumberWithMultipleOf = (float)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/object_array.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/object_array.py.golden
@@ -9,4 +9,4 @@ from .object_array_items import ObjectArrayItems
 
 # Array of objects
 
-type ObjectArray = list[ObjectArrayItems]
+type ObjectArray = (list[ObjectArrayItems])

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_objects.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_objects.py.golden
@@ -10,4 +10,7 @@ from .nested_object import NestedObject
 
 # Union of object types
 
-type OneOfObjects = BasicObject | NestedObject
+type OneOfObjects = (
+    BasicObject
+    | NestedObject
+)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_types.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_types.py.golden
@@ -7,4 +7,8 @@ from __future__ import annotations
 
 # Union of multiple primitive types
 
-type OneOfTypes = str | float | bool
+type OneOfTypes = (
+    str
+    | float
+    | bool
+)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_with_null.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_with_null.py.golden
@@ -9,4 +9,8 @@ from .basic_object import BasicObject
 
 # Union of string, null, and schema reference
 
-type OneOfWithNull = str | BasicObject | None
+type OneOfWithNull = (
+    str
+    | BasicObject
+    | None
+)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/password_string.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/password_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with password format
 
-type PasswordString = str
+type PasswordString = (str)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/reference_array.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/reference_array.py.golden
@@ -9,4 +9,4 @@ from .string_type import StringType
 
 # Array of references
 
-type ReferenceArray = list[StringType]
+type ReferenceArray = (list[StringType])

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_array.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array of strings
 
-type StringArray = list[str]
+type StringArray = (list[str])

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_type.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Basic string type
 
-type StringType = str
+type StringType = (str)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_max_length.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_max_length.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with maximum length
 
-type StringWithMaxLength = str
+type StringWithMaxLength = (str)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_min_length.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_min_length.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with minimum length
 
-type StringWithMinLength = str
+type StringWithMinLength = (str)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_pattern.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_pattern.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with regex pattern
 
-type StringWithPattern = str
+type StringWithPattern = (str)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/unique_items_array.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/unique_items_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array with unique items constraint
 
-type UniqueItemsArray = list[str]
+type UniqueItemsArray = (list[str])

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/uri_string.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/uri_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with URI format
 
-type UriString = str
+type UriString = (str)

--- a/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/uuid_string.py.golden
+++ b/tests/golden/python/python-httpx/comprehensive-schemas/comprehensive_schema_types_example/models/uuid_string.py.golden
@@ -9,4 +9,4 @@ from uuid import UUID
 
 # String with UUID format
 
-type UuidString = UUID
+type UuidString = (UUID)

--- a/tests/golden/python/python-httpx/delete-with-response-schema/test_api_with_delete_response_schema/models/create_test_resource_request.py.golden
+++ b/tests/golden/python/python-httpx/delete-with-response-schema/test_api_with_delete_response_schema/models/create_test_resource_request.py.golden
@@ -9,4 +9,4 @@ from typing import Any
 
 # Request to create a new test resource (type alias - no properties)
 
-type CreateTestResourceRequest = Any
+type CreateTestResourceRequest = (Any)

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
@@ -15,7 +15,10 @@ from .variant_b import VariantB
 # 
 # Discriminator: ty / content: data (adjacent).
 
-type AdjacentlyTaggedEnum = VariantA | VariantB
+type AdjacentlyTaggedEnum = (
+    VariantA
+    | VariantB
+)
 
 
 def adjacently_tagged_enum_from_dict(data: dict[str, object]) -> AdjacentlyTaggedEnum:

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
@@ -15,7 +15,10 @@ from .variant_b import VariantB
 # 
 # Discriminator: variant key (external).
 
-type ExternallyTaggedEnum = VariantA | VariantB
+type ExternallyTaggedEnum = (
+    VariantA
+    | VariantB
+)
 
 
 def externally_tagged_enum_from_dict(data: dict[str, object]) -> ExternallyTaggedEnum:

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
@@ -15,7 +15,10 @@ from .variant_b import VariantB
 # 
 # Discriminator: ty (internal).
 
-type InternallyTaggedEnum = VariantA | VariantB
+type InternallyTaggedEnum = (
+    VariantA
+    | VariantB
+)
 
 
 def internally_tagged_enum_from_dict(data: dict[str, object]) -> InternallyTaggedEnum:

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/mixed_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/mixed_enum.py.golden
@@ -12,4 +12,9 @@ from .mixed_enum_member4 import MixedEnumMember4
 
 # Mixed enum with unit variants (SimpleA, SimpleB) and tuple variants (VariantA(VariantA), VariantB(VariantB))
 
-type MixedEnum = Literal["SimpleA"] | MixedEnumMember2 | Literal["SimpleB"] | MixedEnumMember4
+type MixedEnum = (
+    Literal["SimpleA"]
+    | MixedEnumMember2
+    | Literal["SimpleB"]
+    | MixedEnumMember4
+)

--- a/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/untagged_enum.py.golden
+++ b/tests/golden/python/python-httpx/enum-repr/enum_representation_api/models/untagged_enum.py.golden
@@ -10,4 +10,7 @@ from .variant_b import VariantB
 
 # Untagged enum
 
-type UntaggedEnum = VariantA | VariantB
+type UntaggedEnum = (
+    VariantA
+    | VariantB
+)

--- a/tests/golden/python/python-httpx/type-aliases-complex-union/complex_union_type_test/models/foo.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-complex-union/complex_union_type_test/models/foo.py.golden
@@ -9,4 +9,8 @@ from .bar import Bar
 from .baz import Baz
 from .qux import Qux
 
-type Foo = Bar | Baz | Qux
+type Foo = (
+    Bar
+    | Baz
+    | Qux
+)

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-inline-discriminator-only/discriminated_union_with_inline_discriminator_only_test/models/event.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-inline-discriminator-only/discriminated_union_with_inline_discriminator_only_test/models/event.py.golden
@@ -18,4 +18,8 @@ from .event_member1 import EventMember1
 from .event_member2 import EventMember2
 from .event_member3 import EventMember3
 
-type Event = EventMember1 | EventMember2 | EventMember3
+type Event = (
+    EventMember1
+    | EventMember2
+    | EventMember3
+)

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
@@ -13,7 +13,11 @@ from .resource_unspecified import ResourceUnspecified
 
 # Discriminator: kind (internal).
 
-type Resource = ResourceUnspecified | ResourceQuick | ResourceCustom
+type Resource = (
+    ResourceUnspecified
+    | ResourceQuick
+    | ResourceCustom
+)
 
 
 def resource_from_dict(data: dict[str, object]) -> Resource:

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/models/setup.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/models/setup.py.golden
@@ -18,7 +18,11 @@ from .setup_setup_unspecified import SetupSetupUnspecified
 # 
 # Discriminator: kind (internal).
 
-type Setup = SetupSetupUnspecified | SetupQuick | SetupCustom
+type Setup = (
+    SetupSetupUnspecified
+    | SetupQuick
+    | SetupCustom
+)
 
 
 def setup_from_dict(data: dict[str, object]) -> Setup:

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
@@ -13,7 +13,10 @@ from .container_kind_managed import ContainerKindManaged
 
 # Discriminator: kind (internal).
 
-type ContainerKind = ContainerKindManaged | ContainerKindCustom
+type ContainerKind = (
+    ContainerKindManaged
+    | ContainerKindCustom
+)
 
 
 def container_kind_from_dict(data: dict[str, object]) -> ContainerKind:

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
@@ -13,7 +13,10 @@ from .volume_kind_remote import VolumeKindRemote
 
 # Discriminator: kind (internal).
 
-type VolumeKind = VolumeKindLocal | VolumeKindRemote
+type VolumeKind = (
+    VolumeKindLocal
+    | VolumeKindRemote
+)
 
 
 def volume_kind_from_dict(data: dict[str, object]) -> VolumeKind:

--- a/tests/golden/python/python-httpx/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
@@ -11,7 +11,10 @@ from .container_image_managed import ContainerImageManaged
 
 # Discriminator: kind (internal).
 
-type ContainerImage = ContainerImageManaged | ContainerImageCustom
+type ContainerImage = (
+    ContainerImageManaged
+    | ContainerImageCustom
+)
 
 
 def container_image_from_dict(data: dict[str, object]) -> ContainerImage:

--- a/tests/golden/python/python-httpx/type-aliases-nested-union/nested_union_type_test/models/foo.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-nested-union/nested_union_type_test/models/foo.py.golden
@@ -7,4 +7,8 @@ from __future__ import annotations
 
 from .qux import Qux
 
-type Foo = Qux | str | float
+type Foo = (
+    Qux
+    | str
+    | float
+)

--- a/tests/golden/python/python-httpx/type-aliases-nested-union/nested_union_type_test/models/qux.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-nested-union/nested_union_type_test/models/qux.py.golden
@@ -8,4 +8,7 @@ from __future__ import annotations
 from .bar import Bar
 from .baz import Baz
 
-type Qux = Bar | Baz
+type Qux = (
+    Bar
+    | Baz
+)

--- a/tests/golden/python/python-httpx/type-aliases-simple-type-alias/simple_type_alias_test/models/bar.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-simple-type-alias/simple_type_alias_test/models/bar.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # A simple number type alias
 
-type Bar = float
+type Bar = (float)

--- a/tests/golden/python/python-httpx/type-aliases-simple-type-alias/simple_type_alias_test/models/baz.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-simple-type-alias/simple_type_alias_test/models/baz.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # A simple array type alias
 
-type Baz = list[str]
+type Baz = (list[str])

--- a/tests/golden/python/python-httpx/type-aliases-simple-type-alias/simple_type_alias_test/models/foo.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-simple-type-alias/simple_type_alias_test/models/foo.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # A simple string type alias
 
-type Foo = str
+type Foo = (str)

--- a/tests/golden/python/python-httpx/type-aliases-union-mixed/union_type_with_mixed_members_test/models/foo.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-mixed/union_type_with_mixed_members_test/models/foo.py.golden
@@ -7,4 +7,8 @@ from __future__ import annotations
 
 from .bar import Bar
 
-type Foo = Bar | str | float
+type Foo = (
+    Bar
+    | str
+    | float
+)

--- a/tests/golden/python/python-httpx/type-aliases-union-with-any/union_type_with_any_test/models/config.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-with-any/union_type_with_any_test/models/config.py.golden
@@ -7,4 +7,8 @@ from __future__ import annotations
 
 from typing import Any
 
-type Config = str | float | Any
+type Config = (
+    str
+    | float
+    | Any
+)

--- a/tests/golden/python/python-httpx/type-aliases-union-with-inline-objects/union_type_with_inline_objects_test/models/foo.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-with-inline-objects/union_type_with_inline_objects_test/models/foo.py.golden
@@ -11,4 +11,8 @@ from .foo_member3 import FooMember3
 
 # Union type with inline object schemas
 
-type Foo = FooMember1 | FooMember2 | FooMember3
+type Foo = (
+    FooMember1
+    | FooMember2
+    | FooMember3
+)

--- a/tests/golden/python/python-httpx/type-aliases-union-with-interfaces/union_type_with_interfaces_test/models/foo.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-with-interfaces/union_type_with_interfaces_test/models/foo.py.golden
@@ -9,4 +9,8 @@ from .bar import Bar
 from .baz import Baz
 from .qux import Qux
 
-type Foo = Bar | Baz | Qux
+type Foo = (
+    Bar
+    | Baz
+    | Qux
+)

--- a/tests/golden/python/python-httpx/type-aliases-union-with-primitives/union_type_with_primitives_test/models/foo.py.golden
+++ b/tests/golden/python/python-httpx/type-aliases-union-with-primitives/union_type_with_primitives_test/models/foo.py.golden
@@ -5,4 +5,9 @@
 
 from __future__ import annotations
 
-type Foo = str | float | bool | None
+type Foo = (
+    str
+    | float
+    | bool
+    | None
+)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/any_of_types.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/any_of_types.py.golden
@@ -7,4 +7,7 @@ from __future__ import annotations
 
 # Any of multiple types
 
-type AnyOfTypes = str | float
+type AnyOfTypes = (
+    str
+    | float
+)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/array_with_max_items.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/array_with_max_items.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array with maximum items constraint
 
-type ArrayWithMaxItems = list[str]
+type ArrayWithMaxItems = (list[str])

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/array_with_min_items.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/array_with_min_items.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array with minimum items constraint
 
-type ArrayWithMinItems = list[str]
+type ArrayWithMinItems = (list[str])

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/binary_string.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/binary_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with binary format
 
-type BinaryString = bytes
+type BinaryString = (bytes)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/boolean_array.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/boolean_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array of booleans
 
-type BooleanArray = list[bool]
+type BooleanArray = (list[bool])

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/boolean_type.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/boolean_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Boolean type
 
-type BooleanType = bool
+type BooleanType = (bool)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/byte_string.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/byte_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with byte format (base64)
 
-type ByteString = str
+type ByteString = (str)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/date_time_string.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/date_time_string.py.golden
@@ -9,4 +9,4 @@ from datetime import datetime
 
 # String with date-time format
 
-type DateTimeString = datetime
+type DateTimeString = (datetime)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/double_type.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/double_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Double precision floating point
 
-type DoubleType = float
+type DoubleType = (float)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/email_string.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/email_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with email format
 
-type EmailString = str
+type EmailString = (str)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/empty_object.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/empty_object.py.golden
@@ -9,4 +9,4 @@ from typing import Any
 
 # Object without properties
 
-type EmptyObject = Any
+type EmptyObject = (Any)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/float_type.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/float_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Floating point number
 
-type FloatType = float
+type FloatType = (float)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/integer32.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/integer32.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # 32-bit integer
 
-type Integer32 = int
+type Integer32 = (int)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/integer64.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/integer64.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # 64-bit integer
 
-type Integer64 = int
+type Integer64 = (int)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/integer_type.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/integer_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Basic integer type
 
-type IntegerType = int
+type IntegerType = (int)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/nested_array.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/nested_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array of arrays (nested)
 
-type NestedArray = list[list[str]]
+type NestedArray = (list[list[str]])

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/nullable_string.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/nullable_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Nullable string type (OpenAPI 3.1.2 style)
 
-type NullableString = str | None
+type NullableString = (str | None)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_array.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array of numbers
 
-type NumberArray = list[float]
+type NumberArray = (list[float])

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_type.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Basic number type
 
-type NumberType = float
+type NumberType = (float)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_maximum.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_maximum.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Number with maximum value
 
-type NumberWithMaximum = float
+type NumberWithMaximum = (float)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_minimum.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_minimum.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Number with minimum value
 
-type NumberWithMinimum = float
+type NumberWithMinimum = (float)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_multiple_of.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/number_with_multiple_of.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Number divisible by multipleOf
 
-type NumberWithMultipleOf = float
+type NumberWithMultipleOf = (float)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/object_array.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/object_array.py.golden
@@ -9,4 +9,4 @@ from .object_array_items import ObjectArrayItems
 
 # Array of objects
 
-type ObjectArray = list[ObjectArrayItems]
+type ObjectArray = (list[ObjectArrayItems])

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_objects.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_objects.py.golden
@@ -10,4 +10,7 @@ from .nested_object import NestedObject
 
 # Union of object types
 
-type OneOfObjects = BasicObject | NestedObject
+type OneOfObjects = (
+    BasicObject
+    | NestedObject
+)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_types.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_types.py.golden
@@ -7,4 +7,8 @@ from __future__ import annotations
 
 # Union of multiple primitive types
 
-type OneOfTypes = str | float | bool
+type OneOfTypes = (
+    str
+    | float
+    | bool
+)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_with_null.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/one_of_with_null.py.golden
@@ -9,4 +9,8 @@ from .basic_object import BasicObject
 
 # Union of string, null, and schema reference
 
-type OneOfWithNull = str | BasicObject | None
+type OneOfWithNull = (
+    str
+    | BasicObject
+    | None
+)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/password_string.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/password_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with password format
 
-type PasswordString = str
+type PasswordString = (str)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/reference_array.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/reference_array.py.golden
@@ -9,4 +9,4 @@ from .string_type import StringType
 
 # Array of references
 
-type ReferenceArray = list[StringType]
+type ReferenceArray = (list[StringType])

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_array.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array of strings
 
-type StringArray = list[str]
+type StringArray = (list[str])

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_type.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_type.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Basic string type
 
-type StringType = str
+type StringType = (str)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_max_length.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_max_length.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with maximum length
 
-type StringWithMaxLength = str
+type StringWithMaxLength = (str)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_min_length.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_min_length.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with minimum length
 
-type StringWithMinLength = str
+type StringWithMinLength = (str)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_pattern.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/string_with_pattern.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with regex pattern
 
-type StringWithPattern = str
+type StringWithPattern = (str)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/unique_items_array.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/unique_items_array.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # Array with unique items constraint
 
-type UniqueItemsArray = list[str]
+type UniqueItemsArray = (list[str])

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/uri_string.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/uri_string.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # String with URI format
 
-type UriString = str
+type UriString = (str)

--- a/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/uuid_string.py.golden
+++ b/tests/golden/python/python-requests/comprehensive-schemas/comprehensive_schema_types_example/models/uuid_string.py.golden
@@ -9,4 +9,4 @@ from uuid import UUID
 
 # String with UUID format
 
-type UuidString = UUID
+type UuidString = (UUID)

--- a/tests/golden/python/python-requests/delete-with-response-schema/test_api_with_delete_response_schema/models/create_test_resource_request.py.golden
+++ b/tests/golden/python/python-requests/delete-with-response-schema/test_api_with_delete_response_schema/models/create_test_resource_request.py.golden
@@ -9,4 +9,4 @@ from typing import Any
 
 # Request to create a new test resource (type alias - no properties)
 
-type CreateTestResourceRequest = Any
+type CreateTestResourceRequest = (Any)

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/adjacently_tagged_enum.py.golden
@@ -15,7 +15,10 @@ from .variant_b import VariantB
 # 
 # Discriminator: ty / content: data (adjacent).
 
-type AdjacentlyTaggedEnum = VariantA | VariantB
+type AdjacentlyTaggedEnum = (
+    VariantA
+    | VariantB
+)
 
 
 def adjacently_tagged_enum_from_dict(data: dict[str, object]) -> AdjacentlyTaggedEnum:

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/externally_tagged_enum.py.golden
@@ -15,7 +15,10 @@ from .variant_b import VariantB
 # 
 # Discriminator: variant key (external).
 
-type ExternallyTaggedEnum = VariantA | VariantB
+type ExternallyTaggedEnum = (
+    VariantA
+    | VariantB
+)
 
 
 def externally_tagged_enum_from_dict(data: dict[str, object]) -> ExternallyTaggedEnum:

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/internally_tagged_enum.py.golden
@@ -15,7 +15,10 @@ from .variant_b import VariantB
 # 
 # Discriminator: ty (internal).
 
-type InternallyTaggedEnum = VariantA | VariantB
+type InternallyTaggedEnum = (
+    VariantA
+    | VariantB
+)
 
 
 def internally_tagged_enum_from_dict(data: dict[str, object]) -> InternallyTaggedEnum:

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/mixed_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/mixed_enum.py.golden
@@ -12,4 +12,9 @@ from .mixed_enum_member4 import MixedEnumMember4
 
 # Mixed enum with unit variants (SimpleA, SimpleB) and tuple variants (VariantA(VariantA), VariantB(VariantB))
 
-type MixedEnum = Literal["SimpleA"] | MixedEnumMember2 | Literal["SimpleB"] | MixedEnumMember4
+type MixedEnum = (
+    Literal["SimpleA"]
+    | MixedEnumMember2
+    | Literal["SimpleB"]
+    | MixedEnumMember4
+)

--- a/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/untagged_enum.py.golden
+++ b/tests/golden/python/python-requests/enum-repr/enum_representation_api/models/untagged_enum.py.golden
@@ -10,4 +10,7 @@ from .variant_b import VariantB
 
 # Untagged enum
 
-type UntaggedEnum = VariantA | VariantB
+type UntaggedEnum = (
+    VariantA
+    | VariantB
+)

--- a/tests/golden/python/python-requests/type-aliases-complex-union/complex_union_type_test/models/foo.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-complex-union/complex_union_type_test/models/foo.py.golden
@@ -9,4 +9,8 @@ from .bar import Bar
 from .baz import Baz
 from .qux import Qux
 
-type Foo = Bar | Baz | Qux
+type Foo = (
+    Bar
+    | Baz
+    | Qux
+)

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-inline-discriminator-only/discriminated_union_with_inline_discriminator_only_test/models/event.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-inline-discriminator-only/discriminated_union_with_inline_discriminator_only_test/models/event.py.golden
@@ -18,4 +18,8 @@ from .event_member1 import EventMember1
 from .event_member2 import EventMember2
 from .event_member3 import EventMember3
 
-type Event = EventMember1 | EventMember2 | EventMember3
+type Event = (
+    EventMember1
+    | EventMember2
+    | EventMember3
+)

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-internally-tagged/discriminated_union_internally_tagged_test/models/resource.py.golden
@@ -13,7 +13,11 @@ from .resource_unspecified import ResourceUnspecified
 
 # Discriminator: kind (internal).
 
-type Resource = ResourceUnspecified | ResourceQuick | ResourceCustom
+type Resource = (
+    ResourceUnspecified
+    | ResourceQuick
+    | ResourceCustom
+)
 
 
 def resource_from_dict(data: dict[str, object]) -> Resource:

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/models/setup.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-mixed-unit-and-allof/discriminated_union_mixed_unit_and_all_of_test/models/setup.py.golden
@@ -18,7 +18,11 @@ from .setup_setup_unspecified import SetupSetupUnspecified
 # 
 # Discriminator: kind (internal).
 
-type Setup = SetupSetupUnspecified | SetupQuick | SetupCustom
+type Setup = (
+    SetupSetupUnspecified
+    | SetupQuick
+    | SetupCustom
+)
 
 
 def setup_from_dict(data: dict[str, object]) -> Setup:

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/container_kind.py.golden
@@ -13,7 +13,10 @@ from .container_kind_managed import ContainerKindManaged
 
 # Discriminator: kind (internal).
 
-type ContainerKind = ContainerKindManaged | ContainerKindCustom
+type ContainerKind = (
+    ContainerKindManaged
+    | ContainerKindCustom
+)
 
 
 def container_kind_from_dict(data: dict[str, object]) -> ContainerKind:

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-multiple/multiple_discriminated_unions_test/models/volume_kind.py.golden
@@ -13,7 +13,10 @@ from .volume_kind_remote import VolumeKindRemote
 
 # Discriminator: kind (internal).
 
-type VolumeKind = VolumeKindLocal | VolumeKindRemote
+type VolumeKind = (
+    VolumeKindLocal
+    | VolumeKindRemote
+)
 
 
 def volume_kind_from_dict(data: dict[str, object]) -> VolumeKind:

--- a/tests/golden/python/python-requests/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-discriminated-union-with-refs/discriminated_union_with_references_test/models/container_image.py.golden
@@ -11,7 +11,10 @@ from .container_image_managed import ContainerImageManaged
 
 # Discriminator: kind (internal).
 
-type ContainerImage = ContainerImageManaged | ContainerImageCustom
+type ContainerImage = (
+    ContainerImageManaged
+    | ContainerImageCustom
+)
 
 
 def container_image_from_dict(data: dict[str, object]) -> ContainerImage:

--- a/tests/golden/python/python-requests/type-aliases-nested-union/nested_union_type_test/models/foo.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-nested-union/nested_union_type_test/models/foo.py.golden
@@ -7,4 +7,8 @@ from __future__ import annotations
 
 from .qux import Qux
 
-type Foo = Qux | str | float
+type Foo = (
+    Qux
+    | str
+    | float
+)

--- a/tests/golden/python/python-requests/type-aliases-nested-union/nested_union_type_test/models/qux.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-nested-union/nested_union_type_test/models/qux.py.golden
@@ -8,4 +8,7 @@ from __future__ import annotations
 from .bar import Bar
 from .baz import Baz
 
-type Qux = Bar | Baz
+type Qux = (
+    Bar
+    | Baz
+)

--- a/tests/golden/python/python-requests/type-aliases-simple-type-alias/simple_type_alias_test/models/bar.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-simple-type-alias/simple_type_alias_test/models/bar.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # A simple number type alias
 
-type Bar = float
+type Bar = (float)

--- a/tests/golden/python/python-requests/type-aliases-simple-type-alias/simple_type_alias_test/models/baz.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-simple-type-alias/simple_type_alias_test/models/baz.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # A simple array type alias
 
-type Baz = list[str]
+type Baz = (list[str])

--- a/tests/golden/python/python-requests/type-aliases-simple-type-alias/simple_type_alias_test/models/foo.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-simple-type-alias/simple_type_alias_test/models/foo.py.golden
@@ -7,4 +7,4 @@ from __future__ import annotations
 
 # A simple string type alias
 
-type Foo = str
+type Foo = (str)

--- a/tests/golden/python/python-requests/type-aliases-union-mixed/union_type_with_mixed_members_test/models/foo.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-mixed/union_type_with_mixed_members_test/models/foo.py.golden
@@ -7,4 +7,8 @@ from __future__ import annotations
 
 from .bar import Bar
 
-type Foo = Bar | str | float
+type Foo = (
+    Bar
+    | str
+    | float
+)

--- a/tests/golden/python/python-requests/type-aliases-union-with-any/union_type_with_any_test/models/config.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-with-any/union_type_with_any_test/models/config.py.golden
@@ -7,4 +7,8 @@ from __future__ import annotations
 
 from typing import Any
 
-type Config = str | float | Any
+type Config = (
+    str
+    | float
+    | Any
+)

--- a/tests/golden/python/python-requests/type-aliases-union-with-inline-objects/union_type_with_inline_objects_test/models/foo.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-with-inline-objects/union_type_with_inline_objects_test/models/foo.py.golden
@@ -11,4 +11,8 @@ from .foo_member3 import FooMember3
 
 # Union type with inline object schemas
 
-type Foo = FooMember1 | FooMember2 | FooMember3
+type Foo = (
+    FooMember1
+    | FooMember2
+    | FooMember3
+)

--- a/tests/golden/python/python-requests/type-aliases-union-with-interfaces/union_type_with_interfaces_test/models/foo.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-with-interfaces/union_type_with_interfaces_test/models/foo.py.golden
@@ -9,4 +9,8 @@ from .bar import Bar
 from .baz import Baz
 from .qux import Qux
 
-type Foo = Bar | Baz | Qux
+type Foo = (
+    Bar
+    | Baz
+    | Qux
+)

--- a/tests/golden/python/python-requests/type-aliases-union-with-primitives/union_type_with_primitives_test/models/foo.py.golden
+++ b/tests/golden/python/python-requests/type-aliases-union-with-primitives/union_type_with_primitives_test/models/foo.py.golden
@@ -5,4 +5,9 @@
 
 from __future__ import annotations
 
-type Foo = str | float | bool | None
+type Foo = (
+    str
+    | float
+    | bool
+    | None
+)


### PR DESCRIPTION
## Problem

Multi-line `type` aliases generated without parentheses were invalid Python 3.12+ syntax. PEP 695 requires the RHS of a type statement to be parenthesized when spanning multiple lines.

**Before (SyntaxError on Python 3.12+):**
```python
type AsmContainerState20260630 = AsmContainerState20260630Member1
| AsmContainerState20260630Member2
| AsmContainerState20260630Member3
```

**After (valid):**
```python
type AsmContainerState20260630 = (
    AsmContainerState20260630Member1
    | AsmContainerState20260630Member2
    | AsmContainerState20260630Member3
    | AsmContainerState20260630Member4
)
```

## Changes

- Added `format_type_alias()` helper using `CodeBlock::builder()` for manual multi-line formatting with proper indentation and hard `\n` breaks
- Updated `emit_union`, `emit_tagged_union`, `emit_intersection_as_alias` to use the new helper
- `emit_alias` keeps `sigil_quote!` with parens (always single-type)
- Empty-member fallback uses `%T` with `TypeName::importable` to preserve import tracking

## Files

- `src/generators/python/httpx/emit_models.rs`
- `src/generators/python/requests/emit_models.rs`
- Golden test fixtures updated for both generators