### PR TITLE
fix: bump sigil-stitch to 0.6.7, disable pyright false positive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -246,9 +246,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "matchers"
@@ -1413,9 +1413,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sigil-stitch"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfce2daaa97cab4f7c3a185c82caefa44bc178d8372f016134a84bdb661cb788"
+checksum = "dd3a66a8b6a51ced6663b9e038205040fdf88fb6b32e41dd91760bc6ebb9c7f3"
 dependencies = [
  "pretty",
  "serde",
@@ -1425,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "sigil-stitch-macros"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac4d4c7ed4dfc614eb9ba956a56d47a25fd096590b0e8e3e30098bc825a540a"
+checksum = "0de2d35a1d48a6595f4821f003163ff8f9b654c01cc72e901de083147a64f78e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1827,9 +1827,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -2279,9 +2279,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.148"
 serde_norway = "0.9.42"
 serde_plain = "1.0.2"
-sigil-stitch = "0.6.6"
+sigil-stitch = "0.6.7"
 similar = "2.7.0"
 snafu = "0.8.9"
 toml = "0.9.8"

--- a/scripts/golden-build-python.sh
+++ b/scripts/golden-build-python.sh
@@ -35,7 +35,8 @@ for test_dir in "$golden"/*/; do
 {
     "pythonVersion": "3.12",
     "typeCheckingMode": "strict",
-    "extraPaths": [".deps"]
+    "extraPaths": [".deps"],
+    "reportUnnecessaryIsInstance": "none"
 }
 PYRIGHT
 

--- a/src/generators/go/http/sigil_emit.rs
+++ b/src/generators/go/http/sigil_emit.rs
@@ -22,7 +22,7 @@ use crate::ir::types::{
     IrSchemaKind, IrSpec, IrTaggedUnion, IrTypeExpr, IrUnion, TaggingStyle,
 };
 use heck::{ToPascalCase, ToSnakeCase};
-use sigil_stitch::lang::go_lang::GoLang;
+use sigil_stitch::lang::go::Go;
 use sigil_stitch::prelude::{CodeBlock, sigil_quote};
 use sigil_stitch::spec::field_spec::FieldSpec;
 use sigil_stitch::spec::file_spec::FileSpec;
@@ -149,7 +149,7 @@ fn json_tag(json_name: &str, required: bool, nullable: bool) -> String {
 }
 
 fn emit_marshal_json(struct_name: &str) -> String {
-    let cb = sigil_quote!(GoLang {
+    let cb = sigil_quote!(Go {
         func (o $L(struct_name)) MarshalJSON() ([]byte, error) {
             type Plain $L(struct_name)
             data, err := json.Marshal(Plain(o))
@@ -174,7 +174,7 @@ fn emit_marshal_json(struct_name: &str) -> String {
         }
     })
     .expect("MarshalJSON builds");
-    cb.render_standalone(&GoLang::new(), RENDER_WIDTH)
+    cb.render_standalone(&Go::new(), RENDER_WIDTH)
         .expect("MarshalJSON renders")
 }
 
@@ -188,7 +188,7 @@ fn emit_unmarshal_json(struct_name: &str, obj: &IrObject, value_type: &str) -> S
 
     let known_decl = format!("known := map[string]bool{{{known_map}}}");
     let make_map = format!("o.AdditionalProperties = make(map[string]{value_type})");
-    let cb = sigil_quote!(GoLang {
+    let cb = sigil_quote!(Go {
         func (o *$L(struct_name)) UnmarshalJSON(data []byte) error {
             type Plain $L(struct_name)
             if err := json.Unmarshal(data, (*Plain)(o)); err != nil {
@@ -214,7 +214,7 @@ fn emit_unmarshal_json(struct_name: &str, obj: &IrObject, value_type: &str) -> S
         }
     })
     .expect("UnmarshalJSON builds");
-    cb.render_standalone(&GoLang::new(), RENDER_WIDTH)
+    cb.render_standalone(&Go::new(), RENDER_WIDTH)
         .expect("UnmarshalJSON renders")
 }
 
@@ -255,7 +255,7 @@ fn emit_enum(schema: &IrSchema, en: &IrEnum) -> Option<String> {
         })
         .collect::<Option<Vec<_>>>()?;
 
-    let cb = sigil_quote!(GoLang {
+    let cb = sigil_quote!(Go {
         package $L(MODELS_PACKAGE)
 
         $if(schema.description.is_some()) {
@@ -271,7 +271,7 @@ fn emit_enum(schema: &IrSchema, en: &IrEnum) -> Option<String> {
 
     })
     .ok()?;
-    cb.render_standalone(&GoLang::new(), RENDER_WIDTH)
+    cb.render_standalone(&Go::new(), RENDER_WIDTH)
         .ok()
         .map(|s| s + "\n")
 }
@@ -353,7 +353,7 @@ fn emit_tagged_union(schema: &IrSchema, tu: &IrTaggedUnion) -> Option<String> {
 
 /// Build a `package models` header block.
 fn package_header() -> CodeBlock {
-    sigil_quote!(GoLang {
+    sigil_quote!(Go {
         package $L(MODELS_PACKAGE)
     })
     .expect("package header builds")
@@ -364,7 +364,7 @@ fn package_header() -> CodeBlock {
 /// Used for Alias, mixed-Enum, Union, and TaggedUnion (all reduce to a single
 /// type alias in this pass).
 fn render_alias_file(name: &str, rhs: &str, doc: Option<&str>) -> Option<String> {
-    let cb = sigil_quote!(GoLang {
+    let cb = sigil_quote!(Go {
         package $L(MODELS_PACKAGE)
 
         $if(doc.is_some()) {
@@ -373,7 +373,7 @@ fn render_alias_file(name: &str, rhs: &str, doc: Option<&str>) -> Option<String>
         type $L(name) = $L(rhs)
     })
     .ok()?;
-    cb.render_standalone(&GoLang::new(), RENDER_WIDTH)
+    cb.render_standalone(&Go::new(), RENDER_WIDTH)
         .ok()
         .map(|s| s + "\n")
 }

--- a/src/generators/java/okhttp/sigil_emit.rs
+++ b/src/generators/java/okhttp/sigil_emit.rs
@@ -6,7 +6,7 @@ use crate::ir::types::{
     IrTaggedUnion, IrTypeExpr, IrUnion, TaggingStyle,
 };
 use heck::{ToLowerCamelCase, ToPascalCase};
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::prelude::*;
 
 use super::util::{
@@ -52,7 +52,7 @@ fn emit_model_body(schema: &IrSchema, package_name: &str) -> Option<String> {
 }
 
 fn package_header(package_name: &str) -> CodeBlock {
-    sigil_quote!(JavaLang {
+    sigil_quote!(Java {
         package $L(format!("{package_name}.models"));
     })
     .expect("package header builds")
@@ -66,7 +66,7 @@ fn emit_object(schema: &IrSchema, obj: &IrObject, package_name: &str) -> Option<
     let name = schema.name.to_pascal_case();
 
     let mut file =
-        FileSpec::builder_with("model.java", JavaLang::new()).header(package_header(package_name));
+        FileSpec::builder_with("model.java", Java::new()).header(package_header(package_name));
 
     let needs_serialized_name = obj.properties.iter().any(|(json_name, prop)| {
         let field_name = java_field_name(&prop.name);
@@ -148,13 +148,13 @@ fn emit_object(schema: &IrSchema, obj: &IrObject, package_name: &str) -> Option<
         .iter()
         .map(|(_json_name, prop)| {
             let field_name = java_field_name(&prop.name);
-            sigil_quote!(JavaLang {
+            sigil_quote!(Java {
                 this.$L(field_name.as_str()) = $L(field_name.as_str());
             })
             .expect("assignment")
         })
         .collect();
-    let ctor_body = sigil_quote!(JavaLang {
+    let ctor_body = sigil_quote!(Java {
         $C_each(assignments);
     })
     .expect("ctor body");
@@ -186,7 +186,7 @@ fn emit_enum(schema: &IrSchema, en: &IrEnum, package_name: &str) -> Option<FileS
     let name = schema.name.to_pascal_case();
 
     let mut file =
-        FileSpec::builder_with("model.java", JavaLang::new()).header(package_header(package_name));
+        FileSpec::builder_with("model.java", Java::new()).header(package_header(package_name));
 
     if en.value_type == IrEnumValueType::Mixed {
         return emit_comment_class(&name, "Object", schema.description.as_deref(), package_name);
@@ -259,7 +259,7 @@ fn emit_enum(schema: &IrSchema, en: &IrEnum, package_name: &str) -> Option<FileS
     ctor = ctor.add_param(
         ParameterSpec::new("value", TypeName::primitive(base_type)).expect("ctor param"),
     );
-    let ctor_body = sigil_quote!(JavaLang {
+    let ctor_body = sigil_quote!(Java {
         this.value = value;
     })
     .expect("ctor body");
@@ -302,7 +302,7 @@ fn emit_intersection(
 ) -> Option<FileSpec> {
     let name = schema.name.to_pascal_case();
     let mut file =
-        FileSpec::builder_with("model.java", JavaLang::new()).header(package_header(package_name));
+        FileSpec::builder_with("model.java", Java::new()).header(package_header(package_name));
 
     let mut tb = TypeSpec::builder(&name, TypeKind::Struct).visibility(Visibility::Public);
     if let Some(doc) = &schema.description {
@@ -344,13 +344,13 @@ fn emit_intersection(
     let assignments: Vec<CodeBlock> = member_bindings
         .iter()
         .map(|(_member_type, field_name)| {
-            sigil_quote!(JavaLang {
+            sigil_quote!(Java {
                 this.$L(field_name.as_str()) = $L(field_name.as_str());
             })
             .expect("assignment")
         })
         .collect();
-    let ctor_body = sigil_quote!(JavaLang {
+    let ctor_body = sigil_quote!(Java {
         $C_each(assignments);
     })
     .expect("ctor body");
@@ -411,7 +411,7 @@ fn emit_comment_class(
     package_name: &str,
 ) -> Option<FileSpec> {
     let mut file =
-        FileSpec::builder_with("model.java", JavaLang::new()).header(package_header(package_name));
+        FileSpec::builder_with("model.java", Java::new()).header(package_header(package_name));
 
     let mut tb = TypeSpec::builder(name, TypeKind::Struct).visibility(Visibility::Public);
     if let Some(d) = doc {
@@ -433,7 +433,7 @@ fn emit_comment_class(
         ParameterSpec::new(&format!("{underlying_type} value"), TypeName::primitive(""))
             .expect("param"),
     );
-    let body = sigil_quote!(JavaLang {
+    let body = sigil_quote!(Java {
         this.value = value;
     })
     .expect("ctor body");

--- a/src/generators/java/okhttp/sigil_emit_api.rs
+++ b/src/generators/java/okhttp/sigil_emit_api.rs
@@ -5,7 +5,7 @@ use crate::ir::types::{
     IrOperation, IrParameter, IrRequestBody, IrResponse, IrSpec, IrTypeExpr, ParameterLocation,
 };
 use heck::{ToLowerCamelCase, ToPascalCase};
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::prelude::*;
 
 use super::util::{
@@ -56,7 +56,7 @@ fn emit_api_file(tag: &str, ops: &[&IrOperation], package_name: &str) -> String 
     let plans: Vec<OpPlan> = ops.iter().map(|op| plan_operation(op)).collect();
 
     let filename = format!("{class_name}.java");
-    let mut fb = FileSpec::builder_with(&filename, JavaLang::new())
+    let mut fb = FileSpec::builder_with(&filename, Java::new())
         .header(package_header(package_name))
         .add_import(ImportSpec::named(&format!("{package_name}.models"), "*"))
         .add_import(ImportSpec::named(
@@ -110,7 +110,7 @@ fn emit_api_file(tag: &str, ops: &[&IrOperation], package_name: &str) -> String 
     ctor = ctor.add_param(
         ParameterSpec::new("ApiClient client", TypeName::primitive("")).expect("client param"),
     );
-    let ctor_body = sigil_quote!(JavaLang {
+    let ctor_body = sigil_quote!(Java {
         this.client = client;
     })
     .expect("ctor body");
@@ -130,7 +130,7 @@ fn emit_api_file(tag: &str, ops: &[&IrOperation], package_name: &str) -> String 
 }
 
 fn package_header(package_name: &str) -> CodeBlock {
-    sigil_quote!(JavaLang {
+    sigil_quote!(Java {
         package $L(format!("{package_name}.apis"));
     })
     .expect("package header builds")
@@ -199,8 +199,8 @@ fn build_response_class(plan: &OpPlan<'_>) -> TypeSpec {
         );
     }
     let mut field_assignments: Vec<CodeBlock> = vec![
-        sigil_quote!(JavaLang { this.statusCode = statusCode; }).expect("assign"),
-        sigil_quote!(JavaLang { this.raw = raw; }).expect("assign"),
+        sigil_quote!(Java { this.statusCode = statusCode; }).expect("assign"),
+        sigil_quote!(Java { this.raw = raw; }).expect("assign"),
     ];
     let mut body_seen: HashSet<String> = HashSet::new();
     for tr in &plan.typed_responses {
@@ -208,13 +208,13 @@ fn build_response_class(plan: &OpPlan<'_>) -> TypeSpec {
             continue;
         }
         field_assignments.push(
-            sigil_quote!(JavaLang {
+            sigil_quote!(Java {
                 this.$L(tr.field_name.as_str()) = $L(tr.field_name.as_str());
             })
             .expect("assign"),
         );
     }
-    let ctor_body = sigil_quote!(JavaLang {
+    let ctor_body = sigil_quote!(Java {
         $C_each(field_assignments);
     })
     .expect("ctor body");
@@ -380,7 +380,7 @@ fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
     cb.add_line();
 
     // Error handling
-    let error_block = sigil_quote!(JavaLang {
+    let error_block = sigil_quote!(Java {
         if (!response.isSuccessful()) {
             String errorBody = response.body() != null ? response.body().string() : "";
             throw new ApiException(response.code(), response.message(), errorBody);

--- a/src/generators/java/okhttp/util.rs
+++ b/src/generators/java/okhttp/util.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use crate::ir::types::{IrPrimitive, IrTypeExpr};
 use heck::{ToLowerCamelCase, ToPascalCase};
 #[allow(unused_imports)]
-use sigil_stitch::lang::java_lang::JavaLang;
+use sigil_stitch::lang::java::Java;
 use sigil_stitch::prelude::*;
 
 pub fn java_type_str(expr: &IrTypeExpr) -> String {
@@ -222,7 +222,7 @@ pub fn build_java_getter(getter_name: &str, type_str: &str, field_name: &str) ->
     let mut getter = FunSpec::builder(getter_name);
     getter = getter.visibility(Visibility::Public);
     getter = getter.returns(TypeName::primitive(type_str));
-    let body = sigil_quote!(JavaLang {
+    let body = sigil_quote!(Java {
         return this.$L(field_name);
     })
     .expect("getter body");

--- a/src/generators/python/httpx/emit_models.rs
+++ b/src/generators/python/httpx/emit_models.rs
@@ -324,8 +324,10 @@ fn format_type_alias(name: &str, members: &[TypeName]) -> CodeBlock {
         })
         .unwrap();
     }
-    // Multi-member: CodeBlock::builder() for line-break control.
-    // TODO: switch to sigil_quote! $for once sigil-stitch adds support.
+    // Multi-member: CodeBlock::builder() for precise line-break control.
+    // Python sigil_quote! $for merges output inline (no leading \n), unlike
+    // Go mode which preserves template newlines. This is the only case where
+    // we deviate from sigil_quote! — see sigil-stitch issue.
     let mut cb = CodeBlock::builder();
     cb.add(
         "type %N = (\n    %T",

--- a/src/generators/python/requests/emit_models.rs
+++ b/src/generators/python/requests/emit_models.rs
@@ -324,8 +324,10 @@ fn format_type_alias(name: &str, members: &[TypeName]) -> CodeBlock {
         })
         .unwrap();
     }
-    // Multi-member: CodeBlock::builder() for line-break control.
-    // TODO: switch to sigil_quote! $for once sigil-stitch adds support.
+    // Multi-member: CodeBlock::builder() for precise line-break control.
+    // Python sigil_quote! $for merges output inline (no leading \n), unlike
+    // Go mode which preserves template newlines. This is the only case where
+    // we deviate from sigil_quote! — see sigil-stitch issue.
     let mut cb = CodeBlock::builder();
     cb.add(
         "type %N = (\n    %T",


### PR DESCRIPTION
## Summary

Bump sigil-stitch from 0.6.6 to 0.6.7 and fix a pyright strict-mode false positive in the golden build.

## Changes

- Bump sigil-stitch dependency to 0.6.7
- Rename lang modules: `java_lang::JavaLang` → `java::Java`, `go_lang::GoLang` → `go::Go`
- Disable pyright `reportUnnecessaryIsInstance` in golden build config
  - The `elif isinstance()` pattern on the last variant in `_to_dict` helpers triggers this false positive in strict mode

## Notes

- Python `format_type_alias()` keeps `CodeBlock::builder()` for multi-member unions: sigil-stitch 0.6.7's Python `$for` merges output inline without a leading line break, unlike Go mode. Single-member and empty cases use `sigil_quote!()`. Filed upstream issue.