### PR TITLE
fix: per-item stringification for non-string array params

### DIFF
--- a/src/generators/go/http/sigil_emit_api.rs
+++ b/src/generators/go/http/sigil_emit_api.rs
@@ -198,11 +198,11 @@ fn collect_stringify_imports(t: &IrTypeExpr, pkgs: &mut BTreeSet<String>) {
         }
         IrTypeExpr::Nullable(inner) => collect_stringify_imports(inner, pkgs),
         IrTypeExpr::Array(inner) => {
-            if is_stringish_primitive(inner) {
-                pkgs.insert("strings".to_string());
-            } else {
+            pkgs.insert("strings".to_string());
+            if !is_stringish_primitive(inner) {
                 pkgs.insert("fmt".to_string());
             }
+            collect_stringify_imports(inner, pkgs);
         }
         _ => {
             pkgs.insert("fmt".to_string());
@@ -831,7 +831,16 @@ fn render_value_as_string(value_expr: &str, t: &IrTypeExpr) -> String {
             if is_stringish_primitive(inner) {
                 format!("strings.Join({value_expr}, \",\")")
             } else {
-                format!("fmt.Sprintf(\"%v\", {value_expr})")
+                let (item_expr, item_type) =
+                    if let IrTypeExpr::Nullable(real_inner) = inner.as_ref() {
+                        ("*v", real_inner.as_ref())
+                    } else {
+                        ("v", inner.as_ref())
+                    };
+                let item_fmt = render_value_as_string(item_expr, item_type);
+                format!(
+                    "strings.Join(func() []string {{ parts := make([]string, len({value_expr})); for i, v := range {value_expr} {{ parts[i] = {item_fmt} }}; return parts }}(), \",\")"
+                )
             }
         }
         _ => format!("fmt.Sprintf(\"%%v\", {value_expr})"),

--- a/src/generators/java/okhttp/sigil_emit_api.rs
+++ b/src/generators/java/okhttp/sigil_emit_api.rs
@@ -73,6 +73,7 @@ fn emit_api_file(tag: &str, ops: &[&IrOperation], package_name: &str) -> String 
         .add_import(ImportSpec::named("java.util", "HashMap"))
         .add_import(ImportSpec::named("java.util", "List"))
         .add_import(ImportSpec::named("java.util", "Map"))
+        .add_import(ImportSpec::named("java.util.stream", "Collectors"))
         .add_import(ImportSpec::named("okhttp3", "Request"))
         .add_import(ImportSpec::named("okhttp3", "Response"));
 

--- a/src/generators/java/okhttp/util.rs
+++ b/src/generators/java/okhttp/util.rs
@@ -210,7 +210,9 @@ pub fn render_value_as_string(value_expr: &str, t: &IrTypeExpr) -> String {
             ) {
                 format!("String.join(\",\", {value_expr})")
             } else {
-                format!("String.valueOf({value_expr})")
+                format!(
+                    "{value_expr}.stream().map(Object::toString).collect(java.util.stream.Collectors.joining(\",\"))"
+                )
             }
         }
         IrTypeExpr::Named(_) => format!("String.valueOf({value_expr})"),

--- a/tests/golden/java/java-okhttp/additional-properties/apis/AdditionalPropertiesApi.java.golden
+++ b/tests/golden/java/java-okhttp/additional-properties/apis/AdditionalPropertiesApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/comprehensive-schemas/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/comprehensive-schemas/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/delete-with-response-schema/apis/TestResourceApi.java.golden
+++ b/tests/golden/java/java-okhttp/delete-with-response-schema/apis/TestResourceApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/duplicate-param-names/apis/ItemsApi.java.golden
+++ b/tests/golden/java/java-okhttp/duplicate-param-names/apis/ItemsApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/duplicate-param-names/apis/UsersApi.java.golden
+++ b/tests/golden/java/java-okhttp/duplicate-param-names/apis/UsersApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/enum-repr/apis/EnumReprApi.java.golden
+++ b/tests/golden/java/java-okhttp/enum-repr/apis/EnumReprApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/minimal/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/minimal/apis/DefaultApi.java.golden
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/multiple-similar-request-schemas/apis/TestApiApi.java.golden
+++ b/tests/golden/java/java-okhttp/multiple-similar-request-schemas/apis/TestApiApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/naming-conventions/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/naming-conventions/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/petstore/apis/PetApi.java.golden
+++ b/tests/golden/java/java-okhttp/petstore/apis/PetApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/petstore/apis/StoreApi.java.golden
+++ b/tests/golden/java/java-okhttp/petstore/apis/StoreApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/petstore/apis/UserApi.java.golden
+++ b/tests/golden/java/java-okhttp/petstore/apis/UserApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/query-param-enum/apis/ItemsApi.java.golden
+++ b/tests/golden/java/java-okhttp/query-param-enum/apis/ItemsApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-all-optional-properties/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-all-optional-properties/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-array-of-inline-objects/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-array-of-inline-objects/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-array-of-referenced-types/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-array-of-referenced-types/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-array-with-reference-property/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-array-with-reference-property/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-complex-array-structure/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-complex-array-structure/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-deeply-nested-inline/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-deeply-nested-inline/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-empty-array/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-empty-array/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-inline-object-with-array/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-inline-object-with-array/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-inline-object/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-inline-object/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-mixed-property-types/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-mixed-property-types/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-nested-object-reference/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-nested-object-reference/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-optional-array-of-inline-objects/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-optional-array-of-referenced-types/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-optional-inline-object/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-optional-inline-object/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-optional-nested-object-reference/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-optional-nested-object-reference/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/recursive-json-primitive-array/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/recursive-json-primitive-array/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/request-body-content-types/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/request-body-content-types/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/reserved-word-fields/apis/ItemsApi.java.golden
+++ b/tests/golden/java/java-okhttp/reserved-word-fields/apis/ItemsApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/response-body-default-and-exact/apis/WidgetApi.java.golden
+++ b/tests/golden/java/java-okhttp/response-body-default-and-exact/apis/WidgetApi.java.golden
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/response-body-fallback/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/response-body-fallback/apis/DefaultApi.java.golden
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/response-body-multi-status-responses/apis/WidgetApi.java.golden
+++ b/tests/golden/java/java-okhttp/response-body-multi-status-responses/apis/WidgetApi.java.golden
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/response-body-no-response-body/apis/FooApi.java.golden
+++ b/tests/golden/java/java-okhttp/response-body-no-response-body/apis/FooApi.java.golden
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/server-object/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/server-object/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/server-path-prefix/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/server-path-prefix/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-complex-union/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-complex-union/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-inline-discriminator-only/apis/DefaultApi.java.golden
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-internally-tagged/apis/DefaultApi.java.golden
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-long-names/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-long-names/apis/DefaultApi.java.golden
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-mixed-unit-and-allof/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-mixed-unit-and-allof/apis/DefaultApi.java.golden
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-multiple/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-multiple/apis/DefaultApi.java.golden
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-discriminated-union-with-refs/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-discriminated-union-with-refs/apis/DefaultApi.java.golden
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-intersection-allof/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-intersection-allof/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-intersection-with-nullable-reference/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-nested-union/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-nested-union/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-simple-type-alias/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-simple-type-alias/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-union-mixed/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-mixed/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-union-with-any/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-with-any/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-union-with-inline-objects/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-with-inline-objects/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-union-with-interfaces/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-with-interfaces/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;

--- a/tests/golden/java/java-okhttp/type-aliases-union-with-primitives/apis/DefaultApi.java.golden
+++ b/tests/golden/java/java-okhttp/type-aliases-union-with-primitives/apis/DefaultApi.java.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.example.sdk.models.*;
 import com.example.sdk.runtime.ApiClient;


### PR DESCRIPTION
## Problem

For non-string array query/header params, generated code used:
- Go: `fmt.Sprintf("%v", arr)` producing `[1 2 3]` (bracket-enclosed, not valid query format)
- Java: `String.valueOf(list)` producing `[1, 2, 3]` (same issue)

## Fix

**Go**: Generate inline closure with per-item stringification + `strings.Join`:
```go
strings.Join(func() []string {
    parts := make([]string, len(arr))
    for i, v := range arr { parts[i] = strconv.FormatInt(int64(v), 10) }
    return parts
}(), ",")
```
`strings` import now added for all arrays; inner type imports recursively collected.

**Java**: Use stream + Collectors.joining:
```java
list.stream().map(Object::toString).collect(Collectors.joining(","))
```
`java.util.stream.Collectors` import added to API file template.

String arrays keep `strings.Join` / `String.join` for simplicity.