### PR TITLE
refactor: quote rust request body emission

### DIFF
--- a/src/generators/rust/aioduct/codegen.rs
+++ b/src/generators/rust/aioduct/codegen.rs
@@ -184,7 +184,7 @@ serde_repr.workspace = true
 aioduct = {{ version = "{aioduct_version}", features = {aioduct_features} }}
 serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 {url_explicit}"#
         ),

--- a/src/generators/rust/aioduct/sigil_emit_api.rs
+++ b/src/generators/rust/aioduct/sigil_emit_api.rs
@@ -1,6 +1,7 @@
 //! Aioduct-specific API method body emission (async, generic runtime).
 
 use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::sigil_quote;
 
 use crate::generators::rust::common::emit_api::{
     BodyEncoding, MultipartPart, OpPlan, RustBackendConfig, binary_field_expr, emit_response_match,
@@ -36,12 +37,7 @@ pub fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
         && matches!(&body.encoding, BodyEncoding::Multipart)
         && !body.multipart_supported
     {
-        b.add("let _ = self.client;\n", ());
-        b.add(&format!("let _ = {};\n", body.var_name), ());
-        b.add(
-            "return Err(Error::Unsupported(\"multipart/form-data request bodies must be object schemas\"));\n",
-            (),
-        );
+        b.add_code(unsupported_multipart_body(&body.var_name));
         return b.build().unwrap();
     }
 
@@ -135,55 +131,25 @@ pub fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
     if let Some(body) = body {
         match &body.encoding {
             BodyEncoding::Json => {
-                b.add(&format!("req = req.json(&{})?;\n", body.var_name), ());
+                b.add_code(json_body(&body.var_name));
             }
             BodyEncoding::FormUrlEncoded => {
-                b.add(&format!("req = req.form_serde(&{})?;\n", body.var_name), ());
+                b.add_code(form_body(&body.var_name));
             }
             BodyEncoding::Xml => {
-                let media_type = rust_string_literal(&body.media_type);
-                b.add(
-                    &format!("req = req.header_str(\"Content-Type\", {media_type})?;\n"),
-                    (),
-                );
-                b.add(
-                    &format!(
-                        "let body_xml = serde_xml_rs::to_string({})?;\n",
-                        body.var_name
-                    ),
-                    (),
-                );
-                b.add("req = req.body(body_xml.into_bytes());\n", ());
+                b.add_code(xml_body(&body.var_name, &body.media_type));
             }
             BodyEncoding::TextPlain => {
-                let media_type = rust_string_literal(&body.media_type);
-                b.add(
-                    &format!("req = req.header_str(\"Content-Type\", {media_type})?;\n"),
-                    (),
-                );
-                b.add(
-                    &format!("req = req.body({}.clone().into_bytes());\n", body.var_name),
-                    (),
-                );
+                b.add_code(text_body(&body.var_name, &body.media_type));
             }
             BodyEncoding::OctetStream => {
-                let media_type = rust_string_literal(&body.media_type);
-                b.add(
-                    &format!("req = req.header_str(\"Content-Type\", {media_type})?;\n"),
-                    (),
-                );
-                b.add(&format!("req = req.body({}.clone());\n", body.var_name), ());
+                b.add_code(octet_stream_body(&body.var_name, &body.media_type));
             }
             BodyEncoding::Multipart => {
                 emit_multipart_body(&mut b, &body.var_name, &body.multipart_parts);
             }
             BodyEncoding::Other(media_type) => {
-                b.add(
-                    &format!(
-                        "return Err(Error::Unsupported(\"unsupported request body media type: {media_type}\"));\n"
-                    ),
-                    (),
-                );
+                b.add_code(unsupported_media_type_body(media_type));
             }
         }
     }
@@ -205,6 +171,62 @@ pub fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
     }
 
     b.build().unwrap()
+}
+
+fn unsupported_multipart_body(body_var: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        let _ = self.client;
+        let _ = $L(body_var);
+        return Err(Error::Unsupported($S("multipart/form-data request bodies must be object schemas")));
+    })
+    .expect("unsupported multipart body builds")
+}
+
+fn unsupported_media_type_body(media_type: &str) -> CodeBlock {
+    let message = format!("unsupported request body media type: {media_type}");
+    sigil_quote!(RustLang {
+        return Err(Error::Unsupported($S(&message)));
+    })
+    .expect("unsupported media type body builds")
+}
+
+fn json_body(body_var: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.json(&$L(body_var))?;
+    })
+    .expect("json body builds")
+}
+
+fn form_body(body_var: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.form_serde(&$L(body_var))?;
+    })
+    .expect("form body builds")
+}
+
+fn xml_body(body_var: &str, media_type: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.header_str("Content-Type", $L(rust_string_literal(media_type)))?;
+        let body_xml = serde_xml_rs::to_string($L(body_var))?;
+        req = req.body(body_xml.into_bytes());
+    })
+    .expect("xml body builds")
+}
+
+fn text_body(body_var: &str, media_type: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.header_str("Content-Type", $L(rust_string_literal(media_type)))?;
+        req = req.body($L(body_var).clone().into_bytes());
+    })
+    .expect("text body builds")
+}
+
+fn octet_stream_body(body_var: &str, media_type: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.header_str("Content-Type", $L(rust_string_literal(media_type)))?;
+        req = req.body($L(body_var).clone());
+    })
+    .expect("octet-stream body builds")
 }
 
 fn emit_multipart_body(

--- a/src/generators/rust/reqwest/codegen.rs
+++ b/src/generators/rust/reqwest/codegen.rs
@@ -184,7 +184,7 @@ serde_repr.workspace = true
 reqwest = {{ version = "0.12", features = ["json", "multipart"] }}
 serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 {url_explicit}"#
         ),

--- a/src/generators/rust/reqwest/sigil_emit_api.rs
+++ b/src/generators/rust/reqwest/sigil_emit_api.rs
@@ -1,6 +1,7 @@
 //! Reqwest-specific API method body emission.
 
 use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::sigil_quote;
 
 use crate::generators::rust::common::emit_api::{
     BodyEncoding, MultipartPart, OpPlan, RustBackendConfig, binary_field_expr, emit_response_match,
@@ -36,12 +37,7 @@ pub fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
         && matches!(&body.encoding, BodyEncoding::Multipart)
         && !body.multipart_supported
     {
-        b.add("let _ = self.client;\n", ());
-        b.add(&format!("let _ = {};\n", body.var_name), ());
-        b.add(
-            "return Err(Error::Unsupported(\"multipart/form-data request bodies must be object schemas\"));\n",
-            (),
-        );
+        b.add_code(unsupported_multipart_body(&body.var_name));
         return b.build().unwrap();
     }
 
@@ -132,51 +128,25 @@ pub fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
     if let Some(body) = body {
         match &body.encoding {
             BodyEncoding::Json => {
-                b.add(&format!("req = req.json(&{});\n", body.var_name), ());
+                b.add_code(json_body(&body.var_name));
             }
             BodyEncoding::FormUrlEncoded => {
-                b.add(&format!("req = req.form(&{});\n", body.var_name), ());
+                b.add_code(form_body(&body.var_name));
             }
             BodyEncoding::Xml => {
-                let media_type = rust_string_literal(&body.media_type);
-                b.add(
-                    &format!(
-                        "let body_xml = serde_xml_rs::to_string({})?;\n",
-                        body.var_name
-                    ),
-                    (),
-                );
-                b.add(
-                    &format!("req = req.header(\"Content-Type\", {media_type}).body(body_xml);\n"),
-                    (),
-                );
+                b.add_code(xml_body(&body.var_name, &body.media_type));
             }
             BodyEncoding::TextPlain => {
-                let media_type = rust_string_literal(&body.media_type);
-                b.add(
-                    &format!("req = req.header(\"Content-Type\", {media_type});\n"),
-                    (),
-                );
-                b.add(&format!("req = req.body({}.clone());\n", body.var_name), ());
+                b.add_code(text_body(&body.var_name, &body.media_type));
             }
             BodyEncoding::OctetStream => {
-                let media_type = rust_string_literal(&body.media_type);
-                b.add(
-                    &format!("req = req.header(\"Content-Type\", {media_type});\n"),
-                    (),
-                );
-                b.add(&format!("req = req.body({}.clone());\n", body.var_name), ());
+                b.add_code(octet_stream_body(&body.var_name, &body.media_type));
             }
             BodyEncoding::Multipart => {
                 emit_multipart_body(&mut b, &body.var_name, &body.multipart_parts);
             }
             BodyEncoding::Other(media_type) => {
-                b.add(
-                    &format!(
-                        "return Err(Error::Unsupported(\"unsupported request body media type: {media_type}\"));\n"
-                    ),
-                    (),
-                );
+                b.add_code(unsupported_media_type_body(media_type));
             }
         }
     }
@@ -201,6 +171,61 @@ pub fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
     }
 
     b.build().unwrap()
+}
+
+fn unsupported_multipart_body(body_var: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        let _ = self.client;
+        let _ = $L(body_var);
+        return Err(Error::Unsupported($S("multipart/form-data request bodies must be object schemas")));
+    })
+    .expect("unsupported multipart body builds")
+}
+
+fn unsupported_media_type_body(media_type: &str) -> CodeBlock {
+    let message = format!("unsupported request body media type: {media_type}");
+    sigil_quote!(RustLang {
+        return Err(Error::Unsupported($S(&message)));
+    })
+    .expect("unsupported media type body builds")
+}
+
+fn json_body(body_var: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.json(&$L(body_var));
+    })
+    .expect("json body builds")
+}
+
+fn form_body(body_var: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.form(&$L(body_var));
+    })
+    .expect("form body builds")
+}
+
+fn xml_body(body_var: &str, media_type: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        let body_xml = serde_xml_rs::to_string($L(body_var))?;
+        req = req.header("Content-Type", $L(rust_string_literal(media_type))).body(body_xml);
+    })
+    .expect("xml body builds")
+}
+
+fn text_body(body_var: &str, media_type: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.header("Content-Type", $L(rust_string_literal(media_type)));
+        req = req.body($L(body_var).clone());
+    })
+    .expect("text body builds")
+}
+
+fn octet_stream_body(body_var: &str, media_type: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.header("Content-Type", $L(rust_string_literal(media_type)));
+        req = req.body($L(body_var).clone());
+    })
+    .expect("octet-stream body builds")
 }
 
 fn emit_multipart_body(

--- a/src/generators/rust/ureq/codegen.rs
+++ b/src/generators/rust/ureq/codegen.rs
@@ -151,7 +151,7 @@ serde_repr.workspace = true
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 "#
         .to_string(),

--- a/src/generators/rust/ureq/sigil_emit_api.rs
+++ b/src/generators/rust/ureq/sigil_emit_api.rs
@@ -1,6 +1,7 @@
 //! Ureq-specific API method body emission (synchronous, ureq 3.x).
 
 use sigil_stitch::code_block::CodeBlock;
+use sigil_stitch::prelude::sigil_quote;
 
 use crate::generators::rust::common::emit_api::{
     BodyEncoding, MultipartPart, OpPlan, RustBackendConfig, binary_field_expr, emit_response_match,
@@ -40,12 +41,7 @@ pub fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
         && matches!(&body.encoding, BodyEncoding::Multipart)
         && !body.multipart_supported
     {
-        b.add("let _ = self.client;\n", ());
-        b.add(&format!("let _ = {};\n", body.var_name), ());
-        b.add(
-            "return Err(Error::Unsupported(\"multipart/form-data request bodies must be object schemas\"));\n",
-            (),
-        );
+        b.add_code(unsupported_multipart_body(&body.var_name));
         return b.build().unwrap();
     }
 
@@ -148,63 +144,27 @@ pub fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
         if let Some(body) = body {
             match &body.encoding {
                 BodyEncoding::Json => {
-                    b.add(
-                        &format!("let resp = req.send_json(&{})?;\n", body.var_name),
-                        (),
-                    );
+                    b.add_code(json_send(&body.var_name));
                 }
                 BodyEncoding::FormUrlEncoded => {
                     emit_form_body(&mut b, &body.var_name);
-                    b.add("let resp = req.send_form(form_pairs.iter().map(|(key, value)| (key.as_str(), value.as_str())))?;\n", ());
+                    b.add_code(form_send());
                 }
                 BodyEncoding::Xml => {
-                    let media_type = rust_string_literal(&body.media_type);
-                    b.add(
-                        &format!(
-                            "let body_xml = serde_xml_rs::to_string({})?;\n",
-                            body.var_name
-                        ),
-                        (),
-                    );
-                    b.add(
-                        &format!("req = req.header(\"Content-Type\", {media_type});\n"),
-                        (),
-                    );
-                    b.add("let resp = req.send(body_xml)?;\n", ());
+                    b.add_code(xml_send(&body.var_name, &body.media_type));
                 }
                 BodyEncoding::TextPlain => {
-                    let media_type = rust_string_literal(&body.media_type);
-                    b.add(
-                        &format!("req = req.header(\"Content-Type\", {media_type});\n"),
-                        (),
-                    );
-                    b.add(
-                        &format!("let resp = req.send({}.as_str())?;\n", body.var_name),
-                        (),
-                    );
+                    b.add_code(text_send(&body.var_name, &body.media_type));
                 }
                 BodyEncoding::OctetStream => {
-                    let media_type = rust_string_literal(&body.media_type);
-                    b.add(
-                        &format!("req = req.header(\"Content-Type\", {media_type});\n"),
-                        (),
-                    );
-                    b.add(
-                        &format!("let resp = req.send({}.clone())?;\n", body.var_name),
-                        (),
-                    );
+                    b.add_code(octet_stream_send(&body.var_name, &body.media_type));
                 }
                 BodyEncoding::Multipart => {
                     emit_multipart_body(&mut b, &body.var_name, &body.multipart_parts);
-                    b.add("let resp = req.send(multipart_body)?;\n", ());
+                    b.add_code(multipart_send());
                 }
                 BodyEncoding::Other(media_type) => {
-                    b.add(
-                        &format!(
-                            "return Err(Error::Unsupported(\"unsupported request body media type: {media_type}\"));\n"
-                        ),
-                        (),
-                    );
+                    b.add_code(unsupported_media_type_body(media_type));
                 }
             }
         } else {
@@ -230,6 +190,70 @@ pub fn emit_method_body(plan: &OpPlan<'_>) -> CodeBlock {
     b.build().unwrap()
 }
 
+fn unsupported_multipart_body(body_var: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        let _ = self.client;
+        let _ = $L(body_var);
+        return Err(Error::Unsupported($S("multipart/form-data request bodies must be object schemas")));
+    })
+    .expect("unsupported multipart body builds")
+}
+
+fn unsupported_media_type_body(media_type: &str) -> CodeBlock {
+    let message = format!("unsupported request body media type: {media_type}");
+    sigil_quote!(RustLang {
+        return Err(Error::Unsupported($S(&message)));
+    })
+    .expect("unsupported media type body builds")
+}
+
+fn json_send(body_var: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        let resp = req.send_json(&$L(body_var))?;
+    })
+    .expect("json send builds")
+}
+
+fn form_send() -> CodeBlock {
+    let pairs_iter = "form_pairs.iter().map(|(key, value)| (key.as_str(), value.as_str()))";
+    sigil_quote!(RustLang {
+        let resp = req.send_form($L(pairs_iter))?;
+    })
+    .expect("form send builds")
+}
+
+fn xml_send(body_var: &str, media_type: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        let body_xml = serde_xml_rs::to_string($L(body_var))?;
+        req = req.header("Content-Type", $L(rust_string_literal(media_type)));
+        let resp = req.send(body_xml)?;
+    })
+    .expect("xml send builds")
+}
+
+fn text_send(body_var: &str, media_type: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.header("Content-Type", $L(rust_string_literal(media_type)));
+        let resp = req.send($L(body_var).as_str())?;
+    })
+    .expect("text send builds")
+}
+
+fn octet_stream_send(body_var: &str, media_type: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        req = req.header("Content-Type", $L(rust_string_literal(media_type)));
+        let resp = req.send($L(body_var).clone())?;
+    })
+    .expect("octet-stream send builds")
+}
+
+fn multipart_send() -> CodeBlock {
+    sigil_quote!(RustLang {
+        let resp = req.send(multipart_body)?;
+    })
+    .expect("multipart send builds")
+}
+
 fn emit_multipart_body(
     b: &mut sigil_stitch::code_block::CodeBlockBuilder,
     body_var: &str,
@@ -239,29 +263,15 @@ fn emit_multipart_body(
         "let boundary = format!(\"openapi-nexus-{}\", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|duration| duration.as_nanos()).unwrap_or(0));\n",
         (),
     );
-    b.add("let mut multipart_body: Vec<u8> = Vec::new();\n", ());
+    b.add_code(multipart_body_init());
     for part in parts {
         emit_multipart_part(b, body_var, part);
     }
-    b.add(
-        "multipart_body.extend_from_slice(format!(\"--{}--\\r\\n\", boundary).as_bytes());\n",
-        (),
-    );
-    b.add(
-        "req = req.header(\"Content-Type\", &format!(\"multipart/form-data; boundary={}\", boundary));\n",
-        (),
-    );
+    b.add_code(multipart_epilogue());
 }
 
 fn emit_form_body(b: &mut sigil_stitch::code_block::CodeBlockBuilder, body_var: &str) {
-    b.add(
-        &format!("let form_value = serde_json::to_value({body_var})?;\n"),
-        (),
-    );
-    b.add(
-        "let mut form_pairs: Vec<(String, String)> = Vec::new();\n",
-        (),
-    );
+    b.add_code(form_pairs_init(body_var));
     b.begin_control_flow("if let serde_json::Value::Object(fields) = form_value", ());
     b.begin_control_flow("for (key, value) in fields", ());
     b.begin_control_flow("if !value.is_null()", ());
@@ -273,6 +283,29 @@ fn emit_form_body(b: &mut sigil_stitch::code_block::CodeBlockBuilder, body_var: 
     b.end_control_flow();
     b.end_control_flow();
     b.end_control_flow();
+}
+
+fn multipart_body_init() -> CodeBlock {
+    sigil_quote!(RustLang {
+        let mut multipart_body: Vec<u8> = Vec::new();
+    })
+    .expect("multipart body init builds")
+}
+
+fn multipart_epilogue() -> CodeBlock {
+    sigil_quote!(RustLang {
+        multipart_body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+        req = req.header("Content-Type", &format!("multipart/form-data; boundary={}", boundary));
+    })
+    .expect("multipart epilogue builds")
+}
+
+fn form_pairs_init(body_var: &str) -> CodeBlock {
+    sigil_quote!(RustLang {
+        let form_value = serde_json::to_value($L(body_var))?;
+        let mut form_pairs: Vec<(String, String)> = Vec::new();
+    })
+    .expect("form pairs init builds")
 }
 
 fn emit_multipart_part(

--- a/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "API demonstrating OpenAPI additionalProperties with multiple leve
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/binary-transfer-media-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/binary-transfer-media-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Covers multipart upload and octet-stream download."
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Comprehensive test for all OpenAPI v3.1.2 schema types"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for DELETE operations with JSON response schemas and
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test API with duplicate parameter names across different location
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"

--- a/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "This API demonstrates all 4 kinds of enum representation types: E
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for interfaces that reference enum types"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "A test fixture for multi-line doc comments"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Covers multipart request bodies that are not object-shaped."
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test API with multiple operations having similar request body sch
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test fixture to verify language property naming conventions"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"

--- a/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "This is a sample Pet Store Server based on the OpenAPI 3.1 specif
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"

--- a/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test case for query parameters that reference enum schemas"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for object with all optional properties including array
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of inline objects with snake_case to camelCas
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of referenced model types with recursive From
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of inline objects that contain a reference pr
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of inline objects where each object has neste
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for three levels of nested inline objects"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for empty array handling"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for inline object containing an array of inline objects
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for inline objects (not arrays) with snake_case to came
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for object with mix of simple types, arrays, references
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for nested object reference with recursive FromJSON cal
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional array of inline objects with snake_case to
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional array of referenced model types"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional inline objects"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional nested object reference"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for arrays with primitive items (should not be affected
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Covers non-JSON request body media types to pin Content-Type emis
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "This is a test API specification that includes various server con
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/server-path-prefix/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/server-path-prefix/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for server URL path prefix stripping in operation pa
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for complex union types"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for discriminated union where variants are inline ob
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for internally tagged (adjacently tagged) discrimina
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for discriminated union where variant type names are
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for internally tagged discriminated union where the 
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture with multiple discriminated unions to verify Kind ty
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for discriminated union where variants are reference
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for allOf intersection types"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for allOf intersection types with nullable reference
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types that reference other union types"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for simple type aliases (not unions or intersections
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types with both interfaces and primitives"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types that include the any type"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types (oneOf) with inline object schemas t
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for oneOf/anyOf union types with interface members"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types with primitive members"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/Cargo.toml.golden
@@ -8,7 +8,7 @@ description = "Test fixture covering all schema kinds with utoipa enabled"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"
 utoipa = { version = "5" }

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test fixture for untagged union manual utoipa impl generation"
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 utoipa = { version = "5" }

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test that utoipa::ToSchema is additive alongside user extra_deriv
 aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 utoipa = { version = "5" }

--- a/tests/golden/rust/rust-reqwest/additional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/additional-properties/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "API demonstrating OpenAPI additionalProperties with multiple leve
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/binary-transfer-media-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/binary-transfer-media-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Covers multipart upload and octet-stream download."
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/comprehensive-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/comprehensive-schemas/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Comprehensive test for all OpenAPI v3.1.2 schema types"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/delete-with-response-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/delete-with-response-schema/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for DELETE operations with JSON response schemas and
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/duplicate-param-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/duplicate-param-names/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test API with duplicate parameter names across different location
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"

--- a/tests/golden/rust/rust-reqwest/enum-repr/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/enum-repr/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "This API demonstrates all 4 kinds of enum representation types: E
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/interface-with-enum-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/interface-with-enum-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for interfaces that reference enum types"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/minimal/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/minimal/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/multiline-docs-and-primitive-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/multiline-docs-and-primitive-alias/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "A test fixture for multi-line doc comments"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/multipart-unsupported-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/multipart-unsupported-schema/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Covers multipart request bodies that are not object-shaped."
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/multiple-similar-request-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/multiple-similar-request-schemas/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test API with multiple operations having similar request body sch
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/naming-conventions/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/naming-conventions/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test fixture to verify language property naming conventions"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"

--- a/tests/golden/rust/rust-reqwest/petstore/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/petstore/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "This is a sample Pet Store Server based on the OpenAPI 3.1 specif
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"

--- a/tests/golden/rust/rust-reqwest/query-param-enum/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/query-param-enum/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test case for query parameters that reference enum schemas"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"

--- a/tests/golden/rust/rust-reqwest/recursive-json-all-optional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-all-optional-properties/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for object with all optional properties including array
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-array-of-inline-objects/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of inline objects with snake_case to camelCas
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-array-of-referenced-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of referenced model types with recursive From
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-array-with-reference-property/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-array-with-reference-property/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of inline objects that contain a reference pr
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-complex-array-structure/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-complex-array-structure/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of inline objects where each object has neste
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-deeply-nested-inline/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-deeply-nested-inline/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for three levels of nested inline objects"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-empty-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-empty-array/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for empty array handling"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-inline-object-with-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-inline-object-with-array/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for inline object containing an array of inline objects
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-inline-object/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for inline objects (not arrays) with snake_case to came
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-mixed-property-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-mixed-property-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for object with mix of simple types, arrays, references
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-nested-object-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for nested object reference with recursive FromJSON cal
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional array of inline objects with snake_case to
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional array of referenced model types"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-optional-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-optional-inline-object/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional inline objects"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-optional-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-optional-nested-object-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional nested object reference"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/recursive-json-primitive-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/recursive-json-primitive-array/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for arrays with primitive items (should not be affected
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/request-body-content-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/request-body-content-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Covers non-JSON request body media types to pin Content-Type emis
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/response-body-default-and-exact/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/response-body-default-and-exact/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/response-body-fallback/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/response-body-fallback/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/response-body-multi-status-responses/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/response-body-multi-status-responses/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/response-body-no-response-body/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/response-body-no-response-body/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/server-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/server-object/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "This is a test API specification that includes various server con
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/server-path-prefix/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/server-path-prefix/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for server URL path prefix stripping in operation pa
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-complex-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-complex-union/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for complex union types"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for discriminated union where variants are inline ob
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for internally tagged (adjacently tagged) discrimina
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-long-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-long-names/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for discriminated union where variant type names are
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for internally tagged discriminated union where the 
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-multiple/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-multiple/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture with multiple discriminated unions to verify Kind ty
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for discriminated union where variants are reference
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-intersection-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-intersection-allof/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for allOf intersection types"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for allOf intersection types with nullable reference
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-nested-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-nested-union/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types that reference other union types"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-simple-type-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-simple-type-alias/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for simple type aliases (not unions or intersections
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-mixed/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types with both interfaces and primitives"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-with-any/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-with-any/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types that include the any type"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-with-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-with-inline-objects/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types (oneOf) with inline object schemas t
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-with-interfaces/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-with-interfaces/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for oneOf/anyOf union types with interface members"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/type-aliases-union-with-primitives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/type-aliases-union-with-primitives/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types with primitive members"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-reqwest/utoipa-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/utoipa-mixed/Cargo.toml.golden
@@ -8,7 +8,7 @@ description = "Test fixture covering all schema kinds with utoipa enabled"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 url = "2"
 utoipa = { version = "5" }

--- a/tests/golden/rust/rust-reqwest/utoipa-untagged-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/utoipa-untagged-union/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test fixture for untagged union manual utoipa impl generation"
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 utoipa = { version = "5" }

--- a/tests/golden/rust/rust-reqwest/utoipa-with-extra-derives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-reqwest/utoipa-with-extra-derives/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test that utoipa::ToSchema is additive alongside user extra_deriv
 reqwest = { version = "0.12", features = ["json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 utoipa = { version = "5" }

--- a/tests/golden/rust/rust-ureq/additional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/additional-properties/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "API demonstrating OpenAPI additionalProperties with multiple leve
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/binary-transfer-media-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/binary-transfer-media-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Covers multipart upload and octet-stream download."
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/comprehensive-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/comprehensive-schemas/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Comprehensive test for all OpenAPI v3.1.2 schema types"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/delete-with-response-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/delete-with-response-schema/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for DELETE operations with JSON response schemas and
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/duplicate-param-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/duplicate-param-names/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test API with duplicate parameter names across different location
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/enum-repr/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/enum-repr/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "This API demonstrates all 4 kinds of enum representation types: E
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/interface-with-enum-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/interface-with-enum-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for interfaces that reference enum types"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/minimal/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/minimal/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/multiline-docs-and-primitive-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/multiline-docs-and-primitive-alias/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "A test fixture for multi-line doc comments"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/multipart-unsupported-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/multipart-unsupported-schema/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Covers multipart request bodies that are not object-shaped."
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/multiple-similar-request-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/multiple-similar-request-schemas/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test API with multiple operations having similar request body sch
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/naming-conventions/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/naming-conventions/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture to verify language property naming conventions"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/petstore/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/petstore/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "This is a sample Pet Store Server based on the OpenAPI 3.1 specif
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/query-param-enum/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/query-param-enum/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for query parameters that reference enum schemas"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-all-optional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-all-optional-properties/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for object with all optional properties including array
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-array-of-inline-objects/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of inline objects with snake_case to camelCas
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-array-of-referenced-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of referenced model types with recursive From
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-array-with-reference-property/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-array-with-reference-property/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of inline objects that contain a reference pr
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-complex-array-structure/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-complex-array-structure/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for array of inline objects where each object has neste
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-deeply-nested-inline/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-deeply-nested-inline/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for three levels of nested inline objects"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-empty-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-empty-array/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for empty array handling"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-inline-object-with-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-inline-object-with-array/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for inline object containing an array of inline objects
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-inline-object/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for inline objects (not arrays) with snake_case to came
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-mixed-property-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-mixed-property-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for object with mix of simple types, arrays, references
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-nested-object-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for nested object reference with recursive FromJSON cal
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional array of inline objects with snake_case to
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional array of referenced model types"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-optional-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-optional-inline-object/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional inline objects"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-optional-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-optional-nested-object-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for optional nested object reference"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/recursive-json-primitive-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/recursive-json-primitive-array/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test case for arrays with primitive items (should not be affected
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/request-body-content-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/request-body-content-types/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Covers non-JSON request body media types to pin Content-Type emis
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/response-body-default-and-exact/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/response-body-default-and-exact/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/response-body-fallback/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/response-body-fallback/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/response-body-multi-status-responses/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/response-body-multi-status-responses/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/response-body-no-response-body/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/response-body-no-response-body/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Generated Rust SDK."
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/server-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/server-object/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "This is a test API specification that includes various server con
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/server-path-prefix/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/server-path-prefix/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for server URL path prefix stripping in operation pa
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-complex-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-complex-union/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for complex union types"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for discriminated union where variants are inline ob
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for internally tagged (adjacently tagged) discrimina
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-long-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-long-names/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for discriminated union where variant type names are
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for internally tagged discriminated union where the 
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-multiple/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-multiple/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture with multiple discriminated unions to verify Kind ty
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for discriminated union where variants are reference
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-intersection-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-intersection-allof/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for allOf intersection types"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for allOf intersection types with nullable reference
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-nested-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-nested-union/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types that reference other union types"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-simple-type-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-simple-type-alias/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for simple type aliases (not unions or intersections
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-union-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-mixed/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types with both interfaces and primitives"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-union-with-any/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-with-any/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types that include the any type"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-union-with-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-with-inline-objects/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types (oneOf) with inline object schemas t
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-union-with-interfaces/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-with-interfaces/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for oneOf/anyOf union types with interface members"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/type-aliases-union-with-primitives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/type-aliases-union-with-primitives/Cargo.toml.golden
@@ -8,5 +8,5 @@ description = "Test fixture for union types with primitive members"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"

--- a/tests/golden/rust/rust-ureq/utoipa-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/utoipa-mixed/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test fixture covering all schema kinds with utoipa enabled"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 utoipa = { version = "5" }

--- a/tests/golden/rust/rust-ureq/utoipa-untagged-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/utoipa-untagged-union/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test fixture for untagged union manual utoipa impl generation"
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 utoipa = { version = "5" }

--- a/tests/golden/rust/rust-ureq/utoipa-with-extra-derives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-ureq/utoipa-with-extra-derives/Cargo.toml.golden
@@ -8,6 +8,6 @@ description = "Test that utoipa::ToSchema is additive alongside user extra_deriv
 ureq = { version = "3", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-xml-rs = "0.6"
+serde-xml-rs = "0.8.2"
 serde_repr = "0.1"
 utoipa = { version = "5" }


### PR DESCRIPTION
## Summary
- Refactor rust-aioduct, rust-reqwest, and rust-ureq request-body emission to use sigil_quote! helper blocks for static snippets.
- Keep token-sensitive dynamic loops on CodeBlock builders where sigil_quote! would change generated formatting.
- Bump generated Rust clients to serde-xml-rs 0.8.2 in explicit dependency mode and regenerate Rust Cargo.toml goldens.

## Validation
- cargo test
