### PR TITLE
chore: prepare 0.1.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.14]
+
+### Added
+
+- Multipart request body generation across all generated clients
+  - Supports explicit per-part media types from OpenAPI `encoding.contentType`
+  - Adds multipart fixtures for edge cases, nested object parts, unsupported schemas, and optional bodies
+- Optional request body fixture coverage across all generators
+
+### Fixed
+
+- Rust: preserve `requestBody.required: false` and emit optional request bodies as `Option<&T>`
+  - `reqwest` and `aioduct` omit body setup when optional bodies are absent
+  - `ureq` uses the existing empty-send path for absent optional POST bodies
+- Rust: align JSON, form, multipart, XML, text, and binary request body media-type emission
+- TypeScript and Python: align multipart wire output with current generated clients
+- Go, Java, Kotlin, Python, Rust, and TypeScript: fix SDK generation edge cases around array parameters, tagged unions, type aliases, response matching, path prefixes, and media-type selection
+
+### Changed
+
+- Refactor Rust request body emission around `sigil_quote!`
+- Bump `sigil-stitch` to 0.6.7
+
 ## [0.1.13]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixture-generator-additional-properties"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "axum",
  "axum-extra",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-enum-repr"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "axum",
  "axum-extra",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-petstore"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1032,7 +1032,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openapi-nexus"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 rust-version = "1.90"
 description = "OpenAPI 3.x multi-language code generator"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ OpenAPI Nexus transforms OpenAPI specifications into type-safe client libraries.
 **Shell installer (no Rust toolchain needed):**
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/adamcavendish/openapi-nexus/releases/download/0.1.13/openapi-nexus-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/adamcavendish/openapi-nexus/releases/download/0.1.14/openapi-nexus-installer.sh | sh
 ```
 
 **Nightly build (latest master):**

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -5,7 +5,7 @@
 **Shell installer (no Rust toolchain needed):**
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/adamcavendish/openapi-nexus/releases/download/0.1.13/openapi-nexus-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/adamcavendish/openapi-nexus/releases/download/0.1.14/openapi-nexus-installer.sh | sh
 ```
 
 **Nightly build (latest master):**


### PR DESCRIPTION
## Summary
- bump workspace package versions and lockfile entries to `0.1.14`
- update stable installer links in the README and mdBook getting started docs
- add `0.1.14` changelog notes for multipart, media-type, and optional body fixes

## Validation
- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --check`
- `git diff --check`
- `mdbook build docs`
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
