### PR TITLE
ci: switch workflows to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 permissions:
@@ -189,7 +189,7 @@ jobs:
     name: Release ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     needs: [basics]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   plan:
@@ -181,5 +181,5 @@ jobs:
             --target "$RELEASE_COMMIT" \
             --prerelease \
             --title "Nightly build" \
-            --notes "Nightly build from commit ${RELEASE_COMMIT}. See [CHANGELOG.md](https://github.com/adamcavendish/openapi-nexus/blob/master/CHANGELOG.md) for stable releases." \
+            --notes "Nightly build from commit ${RELEASE_COMMIT}. See [CHANGELOG.md](https://github.com/adamcavendish/openapi-nexus/blob/main/CHANGELOG.md) for stable releases." \
             artifacts/*

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Deploy mdbook to GitHub Pages
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Update CI workflow branch filters from master to main in .github/workflows/ci.yml
- Update nightly workflow branch filter from master to main and fix changelog link to main
- Update pages workflow branch filter from master to main

## Notes
- This addresses missing CI runs after repository default branch moved to main.
