### PR TITLE
chore: prepare 0.1.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15]
+
+### Fixed
+
+- TypeScript Fetch: handle adjacent tagged-union payload keys correctly under camelCase property naming
+- TypeScript Fetch: emit tag-only discriminated union variants without synthetic payload fields
+- TypeScript Fetch: preserve nullable array and reference conversions with explicit null guards
+- TypeScript Fetch: simplify redundant generated union type members
+
 ### Changed
 
 - Bump `sigil-stitch` to 0.6.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixture-generator-additional-properties"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "axum",
  "axum-extra",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-enum-repr"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "axum",
  "axum-extra",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-petstore"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1032,7 +1032,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openapi-nexus"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 rust-version = "1.90"
 description = "OpenAPI 3.x multi-language code generator"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ OpenAPI Nexus transforms OpenAPI specifications into type-safe client libraries.
 **Shell installer (no Rust toolchain needed):**
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/adamcavendish/openapi-nexus/releases/download/0.1.14/openapi-nexus-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/adamcavendish/openapi-nexus/releases/download/0.1.15/openapi-nexus-installer.sh | sh
 ```
 
 **Nightly build (latest master):**

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -5,7 +5,7 @@
 **Shell installer (no Rust toolchain needed):**
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/adamcavendish/openapi-nexus/releases/download/0.1.14/openapi-nexus-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/adamcavendish/openapi-nexus/releases/download/0.1.15/openapi-nexus-installer.sh | sh
 ```
 
 **Nightly build (latest master):**


### PR DESCRIPTION
## Summary
- Bump the workspace package version to 0.1.15
- Update stable installer links in README and mdBook getting-started docs
- Add changelog notes for the TypeScript Fetch generator fixes included in this release

## Validation
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- `mdbook build docs`
- `cargo test --workspace --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
