### PR TITLE
chore: upgrade aioduct to 0.2

### DIFF
--- a/docs/src/rust_config.md
+++ b/docs/src/rust_config.md
@@ -117,7 +117,7 @@ Configure aioduct-specific dependency features for the generated crate. This sec
 
 ```toml
 [generators.rust-aioduct.aioduct]
-version = "0.1.8"
+version = "0.2.0"
 runtime = "tokio"
 tls = "rustls-ring"
 compression = ["gzip", "brotli", "zstd"]
@@ -128,7 +128,7 @@ All fields are optional. Defaults: `runtime = "tokio"`, `tls = "rustls-ring"`, n
 
 #### `version`
 
-Override the pinned aioduct version. Defaults to `"0.1.8"`.
+Override the pinned aioduct version. Defaults to `"0.2.0"`.
 
 #### `runtime`
 

--- a/docs/src/rust_config.md
+++ b/docs/src/rust_config.md
@@ -117,7 +117,7 @@ Configure aioduct-specific dependency features for the generated crate. This sec
 
 ```toml
 [generators.rust-aioduct.aioduct]
-version = "0.2.0"
+version = "0.2"
 runtime = "tokio"
 tls = "rustls-ring"
 compression = ["gzip", "brotli", "zstd"]
@@ -128,7 +128,7 @@ All fields are optional. Defaults: `runtime = "tokio"`, `tls = "rustls-ring"`, n
 
 #### `version`
 
-Override the pinned aioduct version. Defaults to `"0.2.0"`.
+Override the aioduct version requirement. Defaults to `"0.2"`.
 
 #### `runtime`
 

--- a/src/generators/rust/aioduct/config.rs
+++ b/src/generators/rust/aioduct/config.rs
@@ -4,7 +4,7 @@ pub use crate::generators::rust::common::config::RustGeneratorConfig as RustAiod
 
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_AIODUCT_VERSION: &str = "0.2.0";
+const DEFAULT_AIODUCT_VERSION: &str = "0.2";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -119,16 +119,16 @@ mod tests {
     #[test]
     fn default_version_is_current() {
         let config = AioductFeatureConfig::default();
-        assert_eq!(config.version(), "0.2.0");
+        assert_eq!(config.version(), "0.2");
     }
 
     #[test]
     fn custom_version_override() {
         let config = AioductFeatureConfig {
-            version: Some("0.2.0".to_string()),
+            version: Some("0.2".to_string()),
             ..Default::default()
         };
-        assert_eq!(config.version(), "0.2.0");
+        assert_eq!(config.version(), "0.2");
     }
 
     #[test]
@@ -221,14 +221,14 @@ mod tests {
     #[test]
     fn deserialize_from_toml() {
         let toml_str = r#"
-            version = "0.2.0"
+            version = "0.2"
             runtime = "smol"
             tls = "rustls-aws-lc-rs"
             compression = ["gzip", "zstd"]
             features = ["tracing"]
         "#;
         let config: AioductFeatureConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.version(), "0.2.0");
+        assert_eq!(config.version(), "0.2");
         assert_eq!(config.runtime, Some(AioductRuntime::Smol));
         assert_eq!(config.tls, Some(AioductTls::RustlsAwsLcRs));
         assert_eq!(

--- a/src/generators/rust/aioduct/config.rs
+++ b/src/generators/rust/aioduct/config.rs
@@ -4,7 +4,7 @@ pub use crate::generators::rust::common::config::RustGeneratorConfig as RustAiod
 
 use serde::{Deserialize, Serialize};
 
-const DEFAULT_AIODUCT_VERSION: &str = "0.1.8";
+const DEFAULT_AIODUCT_VERSION: &str = "0.2.0";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn default_version_is_current() {
         let config = AioductFeatureConfig::default();
-        assert_eq!(config.version(), "0.1.8");
+        assert_eq!(config.version(), "0.2.0");
     }
 
     #[test]

--- a/src/generators/rust/aioduct/runtime.rs
+++ b/src/generators/rust/aioduct/runtime.rs
@@ -48,12 +48,12 @@ fn render_client_rs(cfg: &AioductFeatureConfig) -> String {
 
     let constructor = match (tls, has_http3) {
         (AioductTls::RustlsRing | AioductTls::RustlsAwsLcRs, true) => {
-            "aioduct::Client::<R>::with_http3()"
+            "aioduct::HttpEngineSend::<R, C>::with_http3().expect(\"aioduct HTTP/3 client build\")"
         }
         (AioductTls::RustlsRing | AioductTls::RustlsAwsLcRs, false) => {
-            "aioduct::Client::<R>::with_rustls()"
+            "aioduct::HttpEngineSend::<R, C>::with_rustls()"
         }
-        (AioductTls::Disabled, _) => "aioduct::Client::<R>::new()",
+        (AioductTls::Disabled, _) => "aioduct::HttpEngineSend::<R, C>::new()",
     };
 
     CLIENT_RS_TEMPLATE.replace("{{CLIENT_CONSTRUCTOR}}", constructor)

--- a/src/generators/rust/aioduct/runtime/auth.rs.txt
+++ b/src/generators/rust/aioduct/runtime/auth.rs.txt
@@ -3,12 +3,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -74,11 +76,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -160,11 +162,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/src/generators/rust/aioduct/runtime/client.rs.txt
+++ b/src/generators/rust/aioduct/runtime/client.rs.txt
@@ -1,19 +1,17 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
@@ -22,9 +20,11 @@ impl<R: Runtime> Client<R> {
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -33,7 +33,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -43,7 +43,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -52,7 +52,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -61,7 +61,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -70,7 +70,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -79,7 +79,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -88,7 +88,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -97,7 +97,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/src/generators/rust/aioduct/runtime/error.rs.txt
+++ b/src/generators/rust/aioduct/runtime/error.rs.txt
@@ -41,6 +41,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/src/generators/rust/aioduct/sigil_emit_api.rs
+++ b/src/generators/rust/aioduct/sigil_emit_api.rs
@@ -14,8 +14,8 @@ use crate::generators::rust::common::emit_api::{
 pub fn aioduct_backend_config() -> RustBackendConfig {
     RustBackendConfig {
         is_async: true,
-        struct_generics: Some("R: aioduct::Runtime".to_string()),
-        client_type_args: Some("<R>".to_string()),
+        struct_generics: Some("R: aioduct::RuntimePoll, C: aioduct::ConnectorSend".to_string()),
+        client_type_args: Some("<R, C>".to_string()),
     }
 }
 

--- a/src/generators/rust/common/emit_api.rs
+++ b/src/generators/rust/common/emit_api.rs
@@ -38,7 +38,7 @@ use super::emit_models::rust_type_str_qualified;
 pub struct RustBackendConfig {
     /// Whether methods are async (reqwest, aioduct) or sync (ureq).
     pub is_async: bool,
-    /// Extra generic parameters on the Api struct, e.g., `"R: aioduct::Runtime"`.
+    /// Extra generic parameters on the Api struct, e.g., `"R: aioduct::RuntimePoll"`.
     /// `None` for reqwest and ureq.
     pub struct_generics: Option<String>,
     /// Extra generic args for the client field type, e.g., `"<R>"`.
@@ -135,15 +135,19 @@ fn emit_api_file(
     fsb = fsb.add_import(ImportSpec::named("crate::runtime::client", "Client"));
     fsb = fsb.add_import(ImportSpec::named("crate::runtime::error", "Error"));
 
-    // Struct generics (e.g., `<'a, R: aioduct::Runtime>`)
+    // Struct generics (e.g., `<'a, R: aioduct::RuntimePoll>`)
     let (struct_gen, impl_gen, type_args, client_field_args) = match &config.struct_generics {
         Some(g) => {
             let client_args = config.client_type_args.as_deref().unwrap_or("");
-            let param_name = g.split(':').next().unwrap_or(g).trim();
+            let param_names = g
+                .split(',')
+                .map(|param| param.split(':').next().unwrap_or(param).trim())
+                .collect::<Vec<_>>()
+                .join(", ");
             (
                 format!("<'a, {g}>"),
                 format!("<'a, {g}>"),
-                format!("<'a, {param_name}>"),
+                format!("<'a, {param_names}>"),
                 client_args.to_string(),
             )
         }

--- a/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "API demonstrating OpenAPI additionalProperties with multiple levels of structs (RootLevel -> MiddleLevel -> LeafValue), each with HashMap fields."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "API demonstrating OpenAPI additionalProperties with multiple levels of structs (RootLevel -> MiddleLevel -> LeafValue), each with HashMap fields."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/additional-properties/src/apis/additional_properties.rs.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/src/apis/additional_properties.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "additional-properties" tag.
-pub struct AdditionalPropertiesApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct AdditionalPropertiesApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> AdditionalPropertiesApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> AdditionalPropertiesApi<'a, R, C> {
     /// Create a new `AdditionalPropertiesApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/additional-properties/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/binary-transfer-media-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/binary-transfer-media-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers multipart upload and octet-stream download."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/binary-transfer-media-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/binary-transfer-media-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers multipart upload and octet-stream download."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/binary-transfer-media-types/src/apis/transfer.rs.golden
+++ b/tests/golden/rust/rust-aioduct/binary-transfer-media-types/src/apis/transfer.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "transfer" tag.
-pub struct TransferApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct TransferApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> TransferApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> TransferApi<'a, R, C> {
     /// Create a new `TransferApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/binary-transfer-media-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/binary-transfer-media-types/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/binary-transfer-media-types/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/binary-transfer-media-types/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/binary-transfer-media-types/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/binary-transfer-media-types/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Comprehensive test for all OpenAPI v3.1.2 schema types"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Comprehensive test for all OpenAPI v3.1.2 schema types"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/comprehensive-schemas/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for DELETE operations with JSON response schemas and type alias request bodies"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for DELETE operations with JSON response schemas and type alias request bodies"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/apis/test_resource.rs.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/apis/test_resource.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "test-resource" tag.
-pub struct TestResourceApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct TestResourceApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> TestResourceApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> TestResourceApi<'a, R, C> {
     /// Create a new `TestResourceApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/delete-with-response-schema/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test API with duplicate parameter names across different locations"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test API with duplicate parameter names across different locations"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/src/apis/items.rs.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/src/apis/items.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "items" tag.
-pub struct ItemsApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct ItemsApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> ItemsApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> ItemsApi<'a, R, C> {
     /// Create a new `ItemsApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/src/apis/users.rs.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/src/apis/users.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "users" tag.
-pub struct UsersApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct UsersApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> UsersApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> UsersApi<'a, R, C> {
     /// Create a new `UsersApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/duplicate-param-names/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This API demonstrates all 4 kinds of enum representation types: Externally Tagged, Internally Tagged, Adjacently Tagged, and Untagged"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This API demonstrates all 4 kinds of enum representation types: Externally Tagged, Internally Tagged, Adjacently Tagged, and Untagged"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/apis/enum_repr.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/apis/enum_repr.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "enum-repr" tag.
-pub struct EnumReprApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct EnumReprApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> EnumReprApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> EnumReprApi<'a, R, C> {
     /// Create a new `EnumReprApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/enum-repr/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for interfaces that reference enum types"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for interfaces that reference enum types"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/interface-with-enum-reference/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/media-type-selection/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/media-type-selection/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers normalized media-type selection for requests and responses."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/media-type-selection/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/media-type-selection/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers normalized media-type selection for requests and responses."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/media-type-selection/src/apis/media.rs.golden
+++ b/tests/golden/rust/rust-aioduct/media-type-selection/src/apis/media.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "media" tag.
-pub struct MediaApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct MediaApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> MediaApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> MediaApi<'a, R, C> {
     /// Create a new `MediaApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/media-type-selection/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/media-type-selection/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/media-type-selection/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/media-type-selection/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/media-type-selection/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/media-type-selection/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/minimal/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/src/apis/default.rs.golden
@@ -7,13 +7,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/minimal/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/src/runtime/auth.rs.golden
@@ -8,12 +8,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -79,11 +81,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -165,11 +167,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/minimal/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/src/runtime/client.rs.golden
@@ -6,30 +6,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -38,7 +38,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -48,7 +48,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -57,7 +57,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -66,7 +66,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -75,7 +75,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -84,7 +84,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -93,7 +93,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -102,7 +102,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/minimal/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/minimal/src/runtime/error.rs.golden
@@ -46,6 +46,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "A test fixture for multi-line doc comments"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "A test fixture for multi-line doc comments"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/apis/default.rs.golden
@@ -9,13 +9,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/auth.rs.golden
@@ -10,12 +10,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -81,11 +83,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -167,11 +169,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/client.rs.golden
@@ -8,30 +8,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -40,7 +40,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -50,7 +50,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -59,7 +59,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -68,7 +68,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -77,7 +77,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -86,7 +86,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -95,7 +95,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -104,7 +104,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiline-docs-and-primitive-alias/src/runtime/error.rs.golden
@@ -48,6 +48,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/multipart-edge-cases/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-edge-cases/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers optional multipart bodies, optional parts, and text-only multipart fields."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multipart-edge-cases/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-edge-cases/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers optional multipart bodies, optional parts, and text-only multipart fields."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multipart-edge-cases/src/apis/multipart.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-edge-cases/src/apis/multipart.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "multipart" tag.
-pub struct MultipartApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct MultipartApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> MultipartApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> MultipartApi<'a, R, C> {
     /// Create a new `MultipartApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/multipart-edge-cases/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-edge-cases/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/multipart-edge-cases/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-edge-cases/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/multipart-edge-cases/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-edge-cases/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers explicit multipart part content types."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers explicit multipart part content types."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/src/apis/transfer.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/src/apis/transfer.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "transfer" tag.
-pub struct TransferApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct TransferApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> TransferApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> TransferApi<'a, R, C> {
     /// Create a new `TransferApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-explicit-encoding/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers multipart object parts whose wire names differ from ergonomic names."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers multipart object parts whose wire names differ from ergonomic names."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/src/apis/multipart.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/src/apis/multipart.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "multipart" tag.
-pub struct MultipartApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct MultipartApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> MultipartApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> MultipartApi<'a, R, C> {
     /// Create a new `MultipartApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-nested-object-parts/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers multipart request bodies that are not object-shaped."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers multipart request bodies that are not object-shaped."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/src/apis/transfer.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/src/apis/transfer.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "transfer" tag.
-pub struct TransferApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct TransferApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> TransferApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> TransferApi<'a, R, C> {
     /// Create a new `TransferApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multipart-unsupported-schema/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test API with multiple operations having similar request body schema names"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test API with multiple operations having similar request body schema names"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/apis/test_api.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/apis/test_api.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "test-api" tag.
-pub struct TestApiApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct TestApiApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> TestApiApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> TestApiApi<'a, R, C> {
     /// Create a new `TestApiApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/multiple-similar-request-schemas/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture to verify language property naming conventions"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture to verify language property naming conventions"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/naming-conventions/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/naming-conventions/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/optional-request-bodies/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/optional-request-bodies/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers optional non-multipart request bodies."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/optional-request-bodies/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/optional-request-bodies/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers optional non-multipart request bodies."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/optional-request-bodies/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/optional-request-bodies/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/optional-request-bodies/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/optional-request-bodies/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/optional-request-bodies/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/optional-request-bodies/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/optional-request-bodies/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/optional-request-bodies/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This is a sample Pet Store Server based on the OpenAPI 3.1 specification"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This is a sample Pet Store Server based on the OpenAPI 3.1 specification"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/petstore/src/apis/pet.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/apis/pet.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "pet" tag.
-pub struct PetApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct PetApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> PetApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> PetApi<'a, R, C> {
     /// Create a new `PetApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/petstore/src/apis/store.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/apis/store.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "store" tag.
-pub struct StoreApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct StoreApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> StoreApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> StoreApi<'a, R, C> {
     /// Create a new `StoreApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/petstore/src/apis/user.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/apis/user.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "user" tag.
-pub struct UserApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct UserApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> UserApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> UserApi<'a, R, C> {
     /// Create a new `UserApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/petstore/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/petstore/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/petstore/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/petstore/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for query parameters that reference enum schemas"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for query parameters that reference enum schemas"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/query-param-enum/src/apis/items.rs.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/src/apis/items.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "items" tag.
-pub struct ItemsApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct ItemsApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> ItemsApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> ItemsApi<'a, R, C> {
     /// Create a new `ItemsApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/query-param-enum/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for object with all optional properties including arrays, references, and inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for object with all optional properties including arrays, references, and inline objects"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-all-optional-properties/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects with snake_case to camelCase conversion (main case from user issue)"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects with snake_case to camelCase conversion (main case from user issue)"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-inline-objects/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of referenced model types with recursive FromJSON calls"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of referenced model types with recursive FromJSON calls"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-of-referenced-types/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects that contain a reference property"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects that contain a reference property"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-array-with-reference-property/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects where each object has nested inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for array of inline objects where each object has nested inline objects"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-complex-array-structure/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for three levels of nested inline objects"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for three levels of nested inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-deeply-nested-inline/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for empty array handling"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for empty array handling"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-empty-array/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for inline object containing an array of inline objects"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for inline object containing an array of inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object-with-array/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for inline objects (not arrays) with snake_case to camelCase conversion"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for inline objects (not arrays) with snake_case to camelCase conversion"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-inline-object/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for object with mix of simple types, arrays, references, and inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for object with mix of simple types, arrays, references, and inline objects"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-mixed-property-types/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for nested object reference with recursive FromJSON calls"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for nested object reference with recursive FromJSON calls"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-nested-object-reference/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional array of inline objects with snake_case to camelCase conversion"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional array of inline objects with snake_case to camelCase conversion"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-inline-objects/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional array of referenced model types"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional array of referenced model types"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-array-of-referenced-types/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional inline objects"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-inline-object/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional nested object reference"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for optional nested object reference"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-optional-nested-object-reference/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for arrays with primitive items (should not be affected by recursive parsing)"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test case for arrays with primitive items (should not be affected by recursive parsing)"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/recursive-json-primitive-array/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers non-JSON request body media types to pin Content-Type emission."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Covers non-JSON request body media types to pin Content-Type emission."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/request-body-content-types/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/apis/widget.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/apis/widget.rs.golden
@@ -7,13 +7,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "Widget" tag.
-pub struct WidgetApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct WidgetApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> WidgetApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> WidgetApi<'a, R, C> {
     /// Create a new `WidgetApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/auth.rs.golden
@@ -8,12 +8,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -79,11 +81,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -165,11 +167,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/client.rs.golden
@@ -6,30 +6,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -38,7 +38,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -48,7 +48,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -57,7 +57,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -66,7 +66,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -75,7 +75,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -84,7 +84,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -93,7 +93,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -102,7 +102,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-default-and-exact/src/runtime/error.rs.golden
@@ -46,6 +46,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/src/apis/default.rs.golden
@@ -7,13 +7,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/auth.rs.golden
@@ -8,12 +8,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -79,11 +81,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -165,11 +167,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/client.rs.golden
@@ -6,30 +6,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -38,7 +38,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -48,7 +48,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -57,7 +57,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -66,7 +66,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -75,7 +75,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -84,7 +84,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -93,7 +93,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -102,7 +102,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-fallback/src/runtime/error.rs.golden
@@ -46,6 +46,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/apis/widget.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/apis/widget.rs.golden
@@ -7,13 +7,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "Widget" tag.
-pub struct WidgetApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct WidgetApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> WidgetApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> WidgetApi<'a, R, C> {
     /// Create a new `WidgetApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/auth.rs.golden
@@ -8,12 +8,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -79,11 +81,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -165,11 +167,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/client.rs.golden
@@ -6,30 +6,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -38,7 +38,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -48,7 +48,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -57,7 +57,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -66,7 +66,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -75,7 +75,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -84,7 +84,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -93,7 +93,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -102,7 +102,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-multi-status-responses/src/runtime/error.rs.golden
@@ -46,6 +46,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Generated Rust SDK."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/apis/foo.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/apis/foo.rs.golden
@@ -7,13 +7,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "Foo" tag.
-pub struct FooApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct FooApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> FooApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> FooApi<'a, R, C> {
     /// Create a new `FooApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/auth.rs.golden
@@ -8,12 +8,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -79,11 +81,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -165,11 +167,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/client.rs.golden
@@ -6,30 +6,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -38,7 +38,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -48,7 +48,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -57,7 +57,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -66,7 +66,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -75,7 +75,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -84,7 +84,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -93,7 +93,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -102,7 +102,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/response-body-no-response-body/src/runtime/error.rs.golden
@@ -46,6 +46,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This is a test API specification that includes various server configurations"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "This is a test API specification that includes various server configurations"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/server-object/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/server-object/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/server-object/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/server-object/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-object/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/server-path-prefix/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/server-path-prefix/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for server URL path prefix stripping in operation paths."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/server-path-prefix/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/server-path-prefix/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for server URL path prefix stripping in operation paths."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/server-path-prefix/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-path-prefix/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/server-path-prefix/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-path-prefix/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/server-path-prefix/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-path-prefix/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/server-path-prefix/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/server-path-prefix/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for complex union types"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for complex union types"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-complex-union/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variants are inline objects"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variants are inline objects"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/apis/default.rs.golden
@@ -17,13 +17,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/auth.rs.golden
@@ -18,12 +18,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -89,11 +91,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -175,11 +177,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/client.rs.golden
@@ -16,30 +16,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -48,7 +48,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -112,7 +112,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-inline-discriminator-only/src/runtime/error.rs.golden
@@ -56,6 +56,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for internally tagged (adjacently tagged) discriminator unions."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for internally tagged (adjacently tagged) discriminator unions."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/apis/default.rs.golden
@@ -10,13 +10,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/auth.rs.golden
@@ -11,12 +11,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -82,11 +84,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -168,11 +170,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/client.rs.golden
@@ -9,30 +9,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -41,7 +41,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -51,7 +51,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -60,7 +60,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -69,7 +69,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -78,7 +78,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -87,7 +87,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -96,7 +96,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -105,7 +105,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-internally-tagged/src/runtime/error.rs.golden
@@ -49,6 +49,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variant type names are"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variant type names are"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/src/apis/default.rs.golden
@@ -10,13 +10,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/src/runtime/auth.rs.golden
@@ -11,12 +11,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -82,11 +84,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -168,11 +170,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/src/runtime/client.rs.golden
@@ -9,30 +9,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -41,7 +41,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -51,7 +51,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -60,7 +60,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -69,7 +69,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -78,7 +78,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -87,7 +87,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -96,7 +96,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -105,7 +105,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-long-names/src/runtime/error.rs.golden
@@ -49,6 +49,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for internally tagged discriminated union where the \"unspecified\""
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for internally tagged discriminated union where the \"unspecified\""
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/apis/default.rs.golden
@@ -13,13 +13,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/auth.rs.golden
@@ -14,12 +14,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -85,11 +87,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -171,11 +173,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/client.rs.golden
@@ -12,30 +12,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -44,7 +44,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -54,7 +54,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -63,7 +63,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -72,7 +72,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -81,7 +81,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -90,7 +90,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -99,7 +99,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -108,7 +108,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-mixed-unit-and-allof/src/runtime/error.rs.golden
@@ -52,6 +52,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture with multiple discriminated unions to verify Kind types"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture with multiple discriminated unions to verify Kind types"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/apis/default.rs.golden
@@ -11,13 +11,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/auth.rs.golden
@@ -12,12 +12,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -83,11 +85,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -169,11 +171,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/client.rs.golden
@@ -10,30 +10,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -42,7 +42,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -52,7 +52,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -61,7 +61,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -70,7 +70,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -79,7 +79,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -88,7 +88,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -97,7 +97,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -106,7 +106,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-multiple/src/runtime/error.rs.golden
@@ -50,6 +50,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variants are references to component schemas."
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for discriminated union where variants are references to component schemas."
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/apis/default.rs.golden
@@ -9,13 +9,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/auth.rs.golden
@@ -10,12 +10,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -81,11 +83,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -167,11 +169,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/client.rs.golden
@@ -8,30 +8,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -40,7 +40,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -50,7 +50,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -59,7 +59,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -68,7 +68,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -77,7 +77,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -86,7 +86,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -95,7 +95,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -104,7 +104,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-discriminated-union-with-refs/src/runtime/error.rs.golden
@@ -48,6 +48,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for allOf intersection types"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for allOf intersection types"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-allof/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for allOf intersection types with nullable reference properties"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for allOf intersection types with nullable reference properties"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-intersection-with-nullable-reference/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types that reference other union types"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types that reference other union types"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-nested-union/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for simple type aliases (not unions or intersections)"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for simple type aliases (not unions or intersections)"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-simple-type-alias/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types with both interfaces and primitives"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types with both interfaces and primitives"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-mixed/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types that include the any type"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types that include the any type"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-any/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types (oneOf) with inline object schemas that should generate named interfaces"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types (oneOf) with inline object schemas that should generate named interfaces"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-inline-objects/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for oneOf/anyOf union types with interface members"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for oneOf/anyOf union types with interface members"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-interfaces/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types with primitive members"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for union types with primitive members"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/type-aliases-union-with-primitives/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture covering all schema kinds with utoipa enabled"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture covering all schema kinds with utoipa enabled"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-mixed/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for untagged union manual utoipa impl generation"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test fixture for untagged union manual utoipa impl generation"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-untagged-union/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test that utoipa::ToSchema is additive alongside user extra_derives"
 
 [dependencies]
-aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/Cargo.toml.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/Cargo.toml.golden
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Test that utoipa::ToSchema is additive alongside user extra_derives"
 
 [dependencies]
-aioduct = { version = "0.1.8", features = ["tokio", "rustls", "rustls-ring", "json"] }
+aioduct = { version = "0.2.0", features = ["tokio", "rustls", "rustls-ring", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-xml-rs = "0.8.2"

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/apis/default.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/apis/default.rs.golden
@@ -8,13 +8,13 @@ use crate::runtime::client::Client;
 use crate::runtime::error::Error;
 
 /// API operations under the "default" tag.
-pub struct DefaultApi<'a, R: aioduct::Runtime> {
-    client: &'a Client<R>,
+pub struct DefaultApi<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    client: &'a Client<R, C>,
 }
 
-impl<'a, R: aioduct::Runtime> DefaultApi<'a, R> {
+impl<'a, R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> DefaultApi<'a, R, C> {
     /// Create a new `DefaultApi` bound to the given client.
-    pub fn new(client: &'a Client<R>) -> Self {
+    pub fn new(client: &'a Client<R, C>) -> Self {
         Self {
             client,
         }

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/auth.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/auth.rs.golden
@@ -9,12 +9,14 @@ use std::sync::Arc;
 use crate::runtime::error::Error;
 
 /// Trait for authenticating requests.
-pub trait Authenticator<R: aioduct::Runtime>: Send + Sync + std::fmt::Debug {
+pub trait Authenticator<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend>:
+    Send + Sync + std::fmt::Debug
+{
     /// Apply authentication to the request builder.
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error>;
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error>;
 }
 
 /// Bearer token authentication.
@@ -80,11 +82,11 @@ impl BearerAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for BearerAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for BearerAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let token = match &self.token {
             TokenSource::Static(t) => t.clone(),
             TokenSource::Dynamic(f) => f(),
@@ -166,11 +168,11 @@ impl ApiKeyAuth {
     }
 }
 
-impl<R: aioduct::Runtime> Authenticator<R> for ApiKeyAuth {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Authenticator<R, C> for ApiKeyAuth {
     fn authenticate<'a>(
         &self,
-        req: aioduct::RequestBuilder<'a, R>,
-    ) -> Result<aioduct::RequestBuilder<'a, R>, Error> {
+        req: aioduct::RequestBuilderSend<'a, R, C>,
+    ) -> Result<aioduct::RequestBuilderSend<'a, R, C>, Error> {
         let key = match &self.api_key {
             KeySource::Static(k) => k.clone(),
             KeySource::Dynamic(f) => f(),

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/client.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/client.rs.golden
@@ -7,30 +7,30 @@
 use std::fmt;
 use std::sync::Arc;
 
-use aioduct::Runtime;
-
 use crate::runtime::auth::Authenticator;
 use crate::runtime::error::Error;
 
-/// Async HTTP client wrapping `aioduct::Client<R>`.
-pub struct Client<R: Runtime> {
-    inner: aioduct::Client<R>,
+/// Async HTTP client wrapping `aioduct::HttpEngineSend<R, C>`.
+pub struct Client<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> {
+    inner: aioduct::HttpEngineSend<R, C>,
     base_url: String,
-    authenticator: Option<Arc<dyn Authenticator<R>>>,
+    authenticator: Option<Arc<dyn Authenticator<R, C>>>,
 }
 
-impl<R: Runtime> Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend + Default> Client<R, C> {
     /// Create a new client with the given base URL.
     pub fn new(base_url: &str) -> Self {
         Self {
-            inner: aioduct::Client::<R>::with_rustls(),
+            inner: aioduct::HttpEngineSend::<R, C>::with_rustls(),
             base_url: base_url.trim_end_matches('/').to_string(),
             authenticator: None,
         }
     }
+}
 
-    /// Create a client with a custom `aioduct::Client`.
-    pub fn with_client(inner: aioduct::Client<R>, base_url: &str) -> Self {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> Client<R, C> {
+    /// Create a client with a custom `aioduct::HttpEngineSend`.
+    pub fn with_client(inner: aioduct::HttpEngineSend<R, C>, base_url: &str) -> Self {
         Self {
             inner,
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -39,7 +39,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Attach an authenticator to the client.
-    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R>>) -> Self {
+    pub fn with_auth(mut self, auth: Arc<dyn Authenticator<R, C>>) -> Self {
         self.authenticator = Some(auth);
         self
     }
@@ -49,7 +49,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a GET request.
-    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn get(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.get(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -58,7 +58,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a POST request.
-    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn post(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.post(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -67,7 +67,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PUT request.
-    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn put(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.put(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -76,7 +76,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a DELETE request.
-    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn delete(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.delete(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -85,7 +85,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a PATCH request.
-    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn patch(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.patch(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -94,7 +94,7 @@ impl<R: Runtime> Client<R> {
     }
 
     /// Build a HEAD request.
-    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilder<'_, R>, Error> {
+    pub fn head(&self, path: &str) -> Result<aioduct::RequestBuilderSend<'_, R, C>, Error> {
         let mut req = self.inner.head(&self.full_url(path))?;
         if let Some(auth) = &self.authenticator {
             req = auth.authenticate(req)?;
@@ -103,7 +103,7 @@ impl<R: Runtime> Client<R> {
     }
 }
 
-impl<R: Runtime> fmt::Debug for Client<R> {
+impl<R: aioduct::RuntimePoll, C: aioduct::ConnectorSend> fmt::Debug for Client<R, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)

--- a/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/error.rs.golden
+++ b/tests/golden/rust/rust-aioduct/utoipa-with-extra-derives/src/runtime/error.rs.golden
@@ -47,6 +47,12 @@ impl From<aioduct::Error> for Error {
     }
 }
 
+impl From<aioduct::SendError> for Error {
+    fn from(e: aioduct::SendError) -> Self {
+        Error::Http(e.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::Deserialize(e)


### PR DESCRIPTION
## Summary

- Upgrade the Rust aioduct generator default to the `aioduct` 0.2 series
- Use `version = "0.2"` so generated clients can receive future 0.2.x updates
- Update generated runtime bindings for the 0.2 API surface
- Regenerate Rust aioduct golden outputs and sync docs

## Verification

- `UPDATE_GOLDEN=1 cargo test --test golden_tests_rust_aioduct -- --nocapture`
- `cargo fmt --all`
- `cargo test --test golden_tests_rust_aioduct`
- `./scripts/golden-build-rust.sh aioduct`
- `cargo test --lib`
