### PR TITLE
chore: prepare 0.1.16 release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -181,5 +181,5 @@ jobs:
             --target "$RELEASE_COMMIT" \
             --prerelease \
             --title "Nightly build" \
-            --notes "Nightly build from commit ${RELEASE_COMMIT}. See [CHANGELOG.md](https://github.com/adamcavendish/openapi-nexus/blob/main/CHANGELOG.md) for stable releases." \
+            --notes "Nightly build from commit ${RELEASE_COMMIT}. See [CHANGELOG.md](https://github.com/rust-codegen-group/openapi-nexus/blob/main/CHANGELOG.md) for stable releases." \
             artifacts/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16]
+
+### Added
+
+- README: add a Codecov coverage badge for the `main` branch
+
+### Changed
+
+- Rust aioduct: support aioduct 0.2 runtime APIs with `HttpEngineSend`, `RuntimePoll`, `ConnectorSend`, and `RequestBuilderSend`
+- Rust aioduct: default generated `Cargo.toml` files to the `aioduct = "0.2"` semver requirement so generated clients can pick up compatible 0.2.x releases
+- Update package metadata, release links, and mdBook links to `rust-codegen-group/openapi-nexus` and the `main` branch
+
 ## [0.1.15]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixture-generator-additional-properties"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "axum",
  "axum-extra",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-enum-repr"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "axum",
  "axum-extra",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "fixture-generator-petstore"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1032,7 +1032,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openapi-nexus"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 rust-version = "1.90"
 description = "OpenAPI 3.x multi-language code generator"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ OpenAPI Nexus transforms OpenAPI specifications into type-safe client libraries.
 **Shell installer (no Rust toolchain needed):**
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-codegen-group/openapi-nexus/releases/download/0.1.15/openapi-nexus-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-codegen-group/openapi-nexus/releases/download/0.1.16/openapi-nexus-installer.sh | sh
 ```
 
 **Nightly build (latest main):**

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -5,7 +5,7 @@
 **Shell installer (no Rust toolchain needed):**
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-codegen-group/openapi-nexus/releases/download/0.1.15/openapi-nexus-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-codegen-group/openapi-nexus/releases/download/0.1.16/openapi-nexus-installer.sh | sh
 ```
 
 **Nightly build (latest main):**


### PR DESCRIPTION
- Bump workspace crate versions to 0.1.16
- Update stable installer links in README and mdBook docs
- Add changelog notes for aioduct 0.2 support and repository URL cleanup