### PR TITLE
feat(typescript): support erasableSyntaxOnly in TypeScript generators

### DIFF
--- a/src/generators/typescript/fetch/project_files/runtime.ts.txt
+++ b/src/generators/typescript/fetch/project_files/runtime.ts.txt
@@ -14,9 +14,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -85,9 +89,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -266,22 +272,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -405,8 +420,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -415,8 +432,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/src/generators/typescript/fetch/sigil_emit_api.rs
+++ b/src/generators/typescript/fetch/sigil_emit_api.rs
@@ -1160,13 +1160,21 @@ fn build_convenience_method(op: &IrOperation) -> Result<FunSpec, String> {
 }
 
 fn is_void_type(ty: &TypeName) -> bool {
+    is_primitive_type(ty, "void")
+}
+
+fn is_unknown_type(ty: &TypeName) -> bool {
+    is_primitive_type(ty, "unknown")
+}
+
+fn is_primitive_type(ty: &TypeName, primitive: &str) -> bool {
     let Ok(val) = serde_json::to_value(ty) else {
         return false;
     };
-    let Ok(void_val) = serde_json::to_value(TypeName::primitive("void")) else {
+    let Ok(primitive_val) = serde_json::to_value(TypeName::primitive(primitive)) else {
         return false;
     };
-    val == void_val
+    val == primitive_val
 }
 
 // ============================================================================
@@ -1312,6 +1320,9 @@ fn dedup_union_members(members: Vec<TypeName>) -> Vec<TypeName> {
 
 fn dedup_union(members: Vec<TypeName>) -> TypeName {
     let mut out = dedup_union_members(members);
+    if out.iter().any(is_unknown_type) {
+        return TypeName::primitive("unknown");
+    }
     if out.len() == 1 {
         out.pop().unwrap()
     } else {
@@ -1775,5 +1786,24 @@ fn collect_convertible_named_refs(
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn type_json(ty: &TypeName) -> serde_json::Value {
+        serde_json::to_value(ty).expect("TypeName serializes")
+    }
+
+    #[test]
+    fn dedup_union_collapses_unknown_members() {
+        let ty = dedup_union(vec![
+            TypeName::primitive("unknown"),
+            TypeName::importable_type("../models/ErrorResponse", "ErrorResponse"),
+        ]);
+
+        assert_eq!(type_json(&ty), type_json(&TypeName::primitive("unknown")));
     }
 }

--- a/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/additional-properties/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/binary-transfer-media-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/binary-transfer-media-types/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -124,9 +128,11 @@ function isFile(value: UploadFileInput): value is File {
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -305,22 +311,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -444,8 +459,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -454,8 +471,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/comprehensive-schemas/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/delete-with-response-schema/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/duplicate-param-names/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/enum-repr/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/interface-with-enum-reference/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/media-type-selection/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/media-type-selection/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -124,9 +128,11 @@ function isFile(value: UploadFileInput): value is File {
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -305,22 +311,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -444,8 +459,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -454,8 +471,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/minimal/runtime/runtime.ts.golden
@@ -19,9 +19,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -90,9 +94,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -271,22 +277,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -410,8 +425,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -420,8 +437,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/multipart-edge-cases/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multipart-edge-cases/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -124,9 +128,11 @@ function isFile(value: UploadFileInput): value is File {
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -305,22 +311,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -444,8 +459,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -454,8 +471,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/multipart-explicit-encoding/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multipart-explicit-encoding/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -124,9 +128,11 @@ function isFile(value: UploadFileInput): value is File {
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -305,22 +311,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -444,8 +459,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -454,8 +471,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/multipart-nested-object-parts/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multipart-nested-object-parts/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -124,9 +128,11 @@ function isFile(value: UploadFileInput): value is File {
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -305,22 +311,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -444,8 +459,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -454,8 +471,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/multipart-unsupported-schema/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multipart-unsupported-schema/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/multiple-similar-request-schemas/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/naming-conventions/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/optional-request-bodies/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/optional-request-bodies/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/petstore/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/query-param-enum/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-all-optional-properties/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-inline-objects/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-of-referenced-types/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-array-with-reference-property/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-complex-array-structure/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-deeply-nested-inline/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-empty-array/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object-with-array/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-inline-object/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-mixed-property-types/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-nested-object-reference/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-inline-objects/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-array-of-referenced-types/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-inline-object/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-optional-nested-object-reference/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/recursive-json-primitive-array/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/request-body-content-types/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-default-and-exact/runtime/runtime.ts.golden
@@ -19,9 +19,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -90,9 +94,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -271,22 +277,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -410,8 +425,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -420,8 +437,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-fallback/runtime/runtime.ts.golden
@@ -19,9 +19,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -90,9 +94,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -271,22 +277,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -410,8 +425,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -420,8 +437,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-multi-status-responses/runtime/runtime.ts.golden
@@ -19,9 +19,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -90,9 +94,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -271,22 +277,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -410,8 +425,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -420,8 +437,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/response-body-no-response-body/runtime/runtime.ts.golden
@@ -19,9 +19,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -90,9 +94,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -271,22 +277,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -410,8 +425,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -420,8 +437,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-object/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/server-path-prefix/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/server-path-prefix/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-enum-const/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-enum-const/runtime/runtime.ts.golden
@@ -19,9 +19,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -90,9 +94,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -271,22 +277,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -410,8 +425,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -420,8 +437,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-enum-ref/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-enum-ref/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-externally-tagged/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-externally-tagged/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-intersection-enum-ref/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-intersection-enum-ref/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-intersection/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-intersection/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-multipart-parts/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-multipart-parts/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -124,9 +128,11 @@ function isFile(value: UploadFileInput): value is File {
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -305,22 +311,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -444,8 +459,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -454,8 +471,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-response-only-types/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-response-only-types/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-tagged-union-variant-with-discriminator/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-tagged-union-variant-with-discriminator/runtime/runtime.ts.golden
@@ -23,9 +23,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -94,9 +98,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -275,22 +281,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -414,8 +429,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -424,8 +441,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-tagged-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-tagged-union/runtime/runtime.ts.golden
@@ -21,9 +21,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -92,9 +96,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -273,22 +279,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -412,8 +427,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -422,8 +439,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case-union/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-property-naming-camel-case/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-camel-case-tagged-nullable-unions/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-camel-case-tagged-nullable-unions/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-comprehensive/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-comprehensive/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-delete-response/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-delete-response/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-enum-repr/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-enum-repr/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-petstore/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp-petstore/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-toolchain-vp/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-toolchain-vp/runtime/runtime.ts.golden
@@ -21,9 +21,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -92,9 +96,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -273,22 +279,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -412,8 +427,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -422,8 +439,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/ts-type-guards/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/ts-type-guards/runtime/runtime.ts.golden
@@ -19,9 +19,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -90,9 +94,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -271,22 +277,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -410,8 +425,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -420,8 +437,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-complex-union/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-inline-discriminator-only/runtime/runtime.ts.golden
@@ -29,9 +29,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -100,9 +104,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -281,22 +287,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -420,8 +435,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -430,8 +447,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-internally-tagged/runtime/runtime.ts.golden
@@ -22,9 +22,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -93,9 +97,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -274,22 +280,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -413,8 +428,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -423,8 +440,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-long-names/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-long-names/runtime/runtime.ts.golden
@@ -22,9 +22,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -93,9 +97,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -274,22 +280,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -413,8 +428,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -423,8 +440,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-mixed-unit-and-allof/runtime/runtime.ts.golden
@@ -25,9 +25,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -96,9 +100,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -277,22 +283,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -416,8 +431,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -426,8 +443,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-multiple/runtime/runtime.ts.golden
@@ -23,9 +23,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -94,9 +98,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -275,22 +281,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -414,8 +429,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -424,8 +441,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-discriminated-union-with-refs/runtime/runtime.ts.golden
@@ -21,9 +21,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -92,9 +96,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -273,22 +279,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -412,8 +427,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -422,8 +439,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-allof/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-intersection-with-nullable-reference/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-nested-union/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-simple-type-alias/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-mixed/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-any/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-inline-objects/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-interfaces/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {

--- a/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
+++ b/tests/golden/typescript/typescript-fetch/type-aliases-union-with-primitives/runtime/runtime.ts.golden
@@ -20,9 +20,13 @@ export interface ConfigurationParameters {
 }
 
 export class Configuration {
-  constructor(private configuration: ConfigurationParameters = {}) {}
+  private configuration: ConfigurationParameters;
 
-  set config(configuration: Configuration) {
+  constructor(configuration: ConfigurationParameters = {}) {
+    this.configuration = configuration;
+  }
+
+  set config(configuration: ConfigurationParameters) {
     this.configuration = configuration;
   }
 
@@ -91,9 +95,11 @@ export const DefaultConfig = new Configuration();
 export class BaseAPI {
 
   private static readonly jsonRegex = new RegExp('^(:?application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+  protected configuration: Configuration;
   private middleware: Middleware[];
 
-  constructor(protected configuration = DefaultConfig) {
+  constructor(configuration: Configuration = DefaultConfig) {
+    this.configuration = configuration;
     this.middleware = configuration.middleware;
   }
 
@@ -272,22 +278,31 @@ function isFormData(value: unknown): value is FormData {
 
 export class ResponseError extends Error {
   override name = "ResponseError" as const;
-  constructor(public response: Response, msg?: string) {
+  public response: Response;
+
+  constructor(response: Response, msg?: string) {
     super(msg);
+    this.response = response;
   }
 }
 
 export class FetchError extends Error {
   override name = "FetchError" as const;
-  constructor(public cause: Error, msg?: string) {
+  public cause: Error;
+
+  constructor(cause: Error, msg?: string) {
     super(msg);
+    this.cause = cause;
   }
 }
 
 export class RequiredError extends Error {
   override name = "RequiredError" as const;
-  constructor(public field: string, msg?: string) {
+  public field: string;
+
+  constructor(field: string, msg?: string) {
     super(msg);
+    this.field = field;
   }
 }
 
@@ -411,8 +426,10 @@ class ApiResponseBase {
   public readonly ok: boolean;
   public readonly statusText: string;
   public readonly headers: Headers;
+  public readonly raw: Response;
 
-  constructor(public readonly raw: Response) {
+  constructor(raw: Response) {
+    this.raw = raw;
     this.status = raw.status;
     this.ok = raw.ok;
     this.statusText = raw.statusText;
@@ -421,8 +438,11 @@ class ApiResponseBase {
 }
 
 export class JSONApiResponse<T> extends ApiResponseBase {
-  constructor(raw: Response, private transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
+  private transformer: ResponseTransformer<T>;
+
+  constructor(raw: Response, transformer: ResponseTransformer<T> = (jsonValue: unknown) => jsonValue as T) {
     super(raw);
+    this.transformer = transformer;
   }
 
   async value(): Promise<T> {


### PR DESCRIPTION
## Summary
- Replace generated TypeScript parameter properties with explicit fields and assignments
- Keep the TypeScript fetch runtime compatible with erasableSyntaxOnly mode
- Collapse generated API unions containing unknown down to plain unknown
- Regenerate TypeScript fetch runtime goldens for the updated output

## Tests
- `cargo fmt --all -- --check`
- `cargo test dedup_union_collapses_unknown_members`
- `cargo test --test golden_tests_typescript_fetch`